### PR TITLE
fixed added whitespace

### DIFF
--- a/app/templates/secure-messages-draft.html
+++ b/app/templates/secure-messages-draft.html
@@ -47,9 +47,7 @@ Send secure message
                             class="secure-message-form__body input"
                             rows="10"
                             name="secure-message-body"
-                            required>{{ draft['body']}}
-                        </textarea>
-
+                            required>{{draft['body']}}</textarea>
                     </fieldset>
 
                     <br />


### PR DESCRIPTION
What is the context of this PR:

Fixed a bug that caused additional whitespace to be added when editing a previously saved draft.
Trello Card - [https://trello.com/c/i9HKtkQq](https://trello.com/c/i9HKtkQq)

How to review:

Create a draft then click in the text area when editing and see if the cursor goes half way down the second line. 