### PR TITLE
Adding code to recover party_id from party service by email address

### DIFF
--- a/app/views/sign_in.py
+++ b/app/views/sign_in.py
@@ -9,6 +9,7 @@ from structlog import wrap_logger
 from app.jwt import encode
 from app.models import LoginForm
 from config import Config
+import requests
 
 app = Flask(__name__)
 app.debug = True
@@ -92,6 +93,21 @@ def login():
  #           logger.error("Error logging in: {}", str(e))
  #           return redirect(url_for('error_page'))
 
+
+        logger.debug('Email Address: {}'.format(username))
+        url = Config.RAS_PARTY_GET_BY_EMAIL.format(Config.RAS_PARTY_SERVICE, username)
+        req = requests.get(url, verify=False)
+        if req.status_code != 200:
+            logger.error('unable to lookup email for "{}"'.format(username))
+            return render_template("error.html", _theme='default', data={"error": {"type": "failed"}})
+
+        try:
+            party_id = req.json().get('id')
+        except Exception as e:
+            logger.error(str(e))
+            logger.error('error trying to get username from party service')
+            return render_template("error.html", _theme='default', data={"error": {"type": "failed"}})
+
         data_dict_for_jwt_token = {
             "refresh_token": token['refresh_token'],
             "access_token": token['access_token'],
@@ -100,7 +116,7 @@ def login():
             "username": username,
             "user_uuid": "ce12b958-2a5f-44f4-a6da-861e59070a32",
             "role": "respondent",
-            "party_id": "db036fd7-ce17-40c2-a8fc-932e7c228397"
+            "party_id": party_id    #"db036fd7-ce17-40c2-a8fc-932e7c228397"
         }
 
         encoded_jwt_token = encode(data_dict_for_jwt_token)

--- a/app/views/sign_in.py
+++ b/app/views/sign_in.py
@@ -116,7 +116,7 @@ def login():
             "username": username,
             "user_uuid": "ce12b958-2a5f-44f4-a6da-861e59070a32",
             "role": "respondent",
-            "party_id": party_id    #"db036fd7-ce17-40c2-a8fc-932e7c228397"
+            "party_id": party_id
         }
 
         encoded_jwt_token = encode(data_dict_for_jwt_token)

--- a/config.py
+++ b/config.py
@@ -136,8 +136,7 @@ class Config(object):
     RAS_PARTY_VERIFY_EMAIL = '{}party-api/v1/emailverification/{}'
     RM_IAC_GET = '{}iacs/{}'
     RM_CASE_GET_BY_PARTY = '{}cases/partyid/{}'
-
-# url = Config.API_GATEWAY_COLLECTION_INSTRUMENT_URL + 'download/' + collection_instrument_id
+    RAS_PARTY_GET_BY_EMAIL = '{}party-api/v1/respondents/email/{}'
 
 
 class ProductionConfig(Config):

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -4,7 +4,7 @@ if ! [ -a .build ] ; then
 	virtualenv .build -p python3
 fi
 source .build/bin/activate
-#pip3 install -r requirements.txt --upgrade
+pip3 install -r requirements.txt --upgrade
 LOG_LEVEL=debug \
 DEBUG=true \
 APP_SETTINGS=config.DevelopmentConfig \

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -10,6 +10,10 @@ from config import Config
 with open('tests/test_data/my_surveys.json') as json_data:
     my_surveys_data = json.load(json_data)
 
+with open('tests/test_data/my_party.json') as json_data:
+    my_party_data = json.load(json_data)
+
+
 returned_token = {
     "id": 6,
     "access_token": "a712f0f9-d00d-447a-b143-49984ca3db68",
@@ -152,7 +156,7 @@ class TestApplication(unittest.TestCase):
         # Build URL's which is used to talk to the OAuth2 server
         url_get_token = Config.ONS_OAUTH_PROTOCOL + Config.ONS_OAUTH_SERVER + Config.ONS_TOKEN_ENDPOINT
         url_get_survey_data = Config.API_GATEWAY_AGGREGATED_SURVEYS_URL + 'todo/' + party_id
-
+        url_get_party_by_email = Config.RAS_PARTY_GET_BY_EMAIL.format(Config.RAS_PARTY_SERVICE, 'testuser@email.com')
         # Here we place a listener on the URL's The flow of events are:
         # 1) The ras_frontstage signs in OAuth2 user.
         # 2) The OAuth2 replies with a HTTP 200 OK and token data.
@@ -166,6 +170,7 @@ class TestApplication(unittest.TestCase):
 
         mock_object.post(url_get_token, status_code=200, json=returned_token)
         mock_object.get(url_get_survey_data, status_code=200, json=my_surveys_data)
+        mock_object.get(url_get_party_by_email, status_code=200, json=my_party_data)
 
         # 1) Send a POST message to sign in as a test user
         #   User                        FS                      OAuth2                  PS

--- a/tests/test_data/my_party.json
+++ b/tests/test_data/my_party.json
@@ -1,0 +1,8 @@
+{
+  "emailAddress": "testuser@email.com",
+  "firstName": "Test",
+  "id": "db036fd7-ce17-40c2-a8fc-932e7c228397",
+  "lastName": "User",
+  "sampleUnitType": "BI",
+  "telephone": "1234"
+}

--- a/tests/test_surveys.py
+++ b/tests/test_surveys.py
@@ -15,6 +15,9 @@ with open('tests/test_data/collection_instrument.json') as json_data:
 with open('tests/test_data/cases.json') as json_data:
     cases_data = json.load(json_data)
 
+with open('tests/test_data/my_party.json') as json_data:
+    my_party_data = json.load(json_data)
+
 
 # print("Test data JSON values are:{}".format(collection_instrument_data))
 
@@ -25,7 +28,7 @@ returned_token = {
     "token_type": "Bearer",
     "scope": "",
     "refresh_token": "37ca04d2-6b6c-4854-8e85-f59c2cc7d3de",
-    "party_id": "3b136c4b-7a14-4904-9e01-13364dd7b972"
+    "party_id": "db036fd7-ce17-40c2-a8fc-932e7c228397"
 
 }
 
@@ -57,6 +60,8 @@ class TestSurveys(unittest.TestCase):
         #url_get_survey_data = Config.API_GATEWAY_AGGREGATED_SURVEYS_URL + 'todo/' + party_id
         url_get_survey_data = Config.RAS_AGGREGATOR_TODO.format(Config.RAS_API_GATEWAY_SERVICE, party_id)
 
+        url_get_party_by_email = Config.RAS_PARTY_GET_BY_EMAIL.format(Config.RAS_PARTY_SERVICE, 'testuser@email.com')
+        mock_object.get(url_get_party_by_email, status_code=200, json=my_party_data)
         mock_object.post(url_get_token, status_code=200, json=returned_token)
         mock_object.get(url_get_survey_data, status_code=200, json=my_surveys_data)
 
@@ -109,12 +114,13 @@ class TestSurveys(unittest.TestCase):
         url_get_collection_instrument_data = Config.RAS_CI_GET.format(Config.RAS_COLLECTION_INSTRUMENT_SERVICE, collection_instrument_id)
 
         url_get_cases = Config.RM_CASE_GET_BY_PARTY.format(Config.RM_CASE_SERVICE, party_id)
+        url_get_party_by_email = Config.RAS_PARTY_GET_BY_EMAIL.format(Config.RAS_PARTY_SERVICE, 'testuser@email.com')
+        mock_object.get(url_get_party_by_email, status_code=200, json=my_party_data)
 
         mock_object.post(url_get_token, status_code=200, json=returned_token)
         mock_object.get(url_get_survey_data, status_code=200, json=my_surveys_data)
         mock_object.get(url_get_collection_instrument_data, status_code=200, json=collection_instrument_data)
         mock_object.get(url_get_cases, status_code=200, json=cases_data)
-        print("Cases>", url_get_cases)
 
         self.app.post('/sign-in/', data={'username': 'testuser@email.com', 'password': 'password'}, headers=self.headers)
 
@@ -122,9 +128,10 @@ class TestSurveys(unittest.TestCase):
             'case_id': case_id,
             'collection_instrument_id': collection_instrument_id
         }
-
         response = self.app.post('/surveys/access_survey', headers=self.headers, data=survey_params)
         self.assertEqual(response.status_code, 200)
+
+        print("Response>", response)
 
         # There should be a Download button
         self.assertTrue(bytes('download-survey-button', encoding='UTF-8') in response.data)

--- a/tests/test_surveys.py
+++ b/tests/test_surveys.py
@@ -131,8 +131,6 @@ class TestSurveys(unittest.TestCase):
         response = self.app.post('/surveys/access_survey', headers=self.headers, data=survey_params)
         self.assertEqual(response.status_code, 200)
 
-        print("Response>", response)
-
         # There should be a Download button
         self.assertTrue(bytes('download-survey-button', encoding='UTF-8') in response.data)
 


### PR DESCRIPTION
Adds a simple lookup to recover a party_id from the party service based on the requested login id (email address) and inserts that party_id into the JWT in place of the previously hard-coded id.