### PR TITLE
added content-type to secure messaging post requests

### DIFF
--- a/frontstage/views/secure_messaging.py
+++ b/frontstage/views/secure_messaging.py
@@ -12,7 +12,7 @@ from frontstage.exceptions.exceptions import ExternalServiceError
 
 logger = wrap_logger(logging.getLogger(__name__))
 
-headers = {}
+headers = {"Content-Type": "application/json"}
 
 modify_data = {'action': '',
                'label': ''}
@@ -193,7 +193,9 @@ def reply_message(session):
 
             if "msg_id" in request.form:
                 data['msg_id'] = request.form['msg_id']
-                response = requests.put(DRAFT_PUT_API_URL.format(request.form['msg_id']), data=json.dumps(data), headers=headers)
+                response = requests.put(DRAFT_PUT_API_URL.format(request.form['msg_id']),
+                                        data=json.dumps(data),
+                                        headers=headers)
                 if response.status_code == 400:
                     get_json = json.loads(response.content)
                     return render_template('secure-messages/secure-messages-draft.html',

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,4 +44,4 @@ Flask-Cors==3.0.3
 python-jose==1.3.2
 Flask-Twisted==0.1.2
 treq==17.3.1
-git+https://github.com/ONSdigital/ras-common.git@integration_baseline_1
+git+https://github.com/ONSdigital/ras-common.git


### PR DESCRIPTION
Adding `"Content-Type": "application/json"` to the headers for requests to secure-messaging