### PR TITLE
adding choice of indented or one line json logs

### DIFF
--- a/frontstage/logger_config.py
+++ b/frontstage/logger_config.py
@@ -33,7 +33,7 @@ def logger_initial_config(service_name=None,
               filter_by_level,
               add_service,
               TimeStamper(fmt=logger_date_format, utc=True, key="created_at"),
-              JSONRenderer(indent=1)])
+              JSONRenderer(indent=os.getenv('JSON_INDENT_LOGGING', None))])
     oauth_log = logging.getLogger("requests_oauthlib")
     oauth_log.addHandler(logging.NullHandler())
     oauth_log.propagate = False


### PR DESCRIPTION
Setting default logging to be json formatted across one line.

You can set the environment variable `JSON_LOGGING_INDENT=1` to enable indented json logs locally