### PR TITLE
Adding error handling for duplicate email

### DIFF
--- a/frontstage/logger_config.py
+++ b/frontstage/logger_config.py
@@ -14,7 +14,7 @@ def logger_initial_config(service_name=None,
     if not logger_date_format:
         logger_date_format = os.getenv('LOGGING_DATE_FORMAT', "%Y-%m-%dT%H:%M%s")
     if not log_level:
-        log_level = os.getenv('SMS_LOG_LEVEL', 'DEBUG')
+        log_level = os.getenv('SMS_LOG_LEVEL', 'INFO')
     if not logger_format:
         logger_format = "%(message)s , 'file'='%(name)s', 'line_number'=%(lineno)s"
     if not service_name:

--- a/frontstage/logger_config.py
+++ b/frontstage/logger_config.py
@@ -14,7 +14,7 @@ def logger_initial_config(service_name=None,
     if not logger_date_format:
         logger_date_format = os.getenv('LOGGING_DATE_FORMAT', "%Y-%m-%dT%H:%M%s")
     if not log_level:
-        log_level = os.getenv('SMS_LOG_LEVEL', 'INFO')
+        log_level = os.getenv('SMS_LOG_LEVEL', 'DEBUG')
     if not logger_format:
         logger_format = "%(message)s , 'file'='%(name)s', 'line_number'=%(lineno)s"
     if not service_name:

--- a/frontstage/views/register.py
+++ b/frontstage/views/register.py
@@ -286,11 +286,16 @@ def register_enter_your_details():
         result = requests.post(party_service_url, headers=headers, data=json.dumps(registration_data))
         logger.debug('Party service response', status_code=result.status_code, reason=result.reason, text=result.text)
 
-        if result.status_code == 200:
-            return render_template('register/register.almost-done.html', _theme='default', email=email_address)
+        if result.status_code == 400:
+            duplicate_error = {"email_address": ["This email has already been used to register an account"]}
+            return render_template('register/register.enter-your-details.html',
+                                   _theme='default',
+                                   form=form,
+                                   errors=duplicate_error)
         elif result.status_code != 200:
             raise ExternalServiceError(result)
-
+        else:
+            return render_template('register/register.almost-done.html', _theme='default', email=email_address)
         # TODO We need to add an exception timeout catch and handle this type of error
     else:
         if form.errors:


### PR DESCRIPTION
When a user tries to register an account with an email address that has already been used we no longer throw a 500 error. It is handled in the same way as the rest of the form validation