### PR TITLE
allowing sign-in form to fail more gracefully

### DIFF
--- a/tests/test_sign_in.py
+++ b/tests/test_sign_in.py
@@ -148,6 +148,16 @@ class TestSignIn(unittest.TestCase):
 
         response = self.app.post('/sign-in/', data=self.sign_in_form, follow_redirects=True)
 
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('Incorrect email or password'.encode() in response.data)
+
+    @requests_mock.mock()
+    def test_sign_in_party_fail(self, mock_object):
+        mock_object.post(url_oauth_token, status_code=201, json=oauth_token)
+        mock_object.get(url_party_by_email, status_code=500, json=my_party_data)
+
+        response = self.app.post('/sign-in/', data=self.sign_in_form, follow_redirects=True)
+
         self.assertEqual(response.status_code, 500)
         self.assertTrue('Server error'.encode() in response.data)
 


### PR DESCRIPTION
Handle 404 response from party service on sign-in so it doesnt just throw a 500 error