### PR TITLE
removing resending email functionality

### DIFF
--- a/frontstage/templates/register/register.link-expired.html
+++ b/frontstage/templates/register/register.link-expired.html
@@ -8,7 +8,10 @@
 <h1 class="saturn">Your link has expired</h1>
 
 <div>
-    <a id="new-email-link" href="/register/create-account/email-resent?user_id={{ user_id }}">Request another email with a new link</a>.
+    <p>
+        Please call <a href="tel:03001234931">03001234931</a> or send an email to <a href="mailto:surveys@ons.gov.uk">surveys@ons.gov.uk</a>
+        to request another link.
+    </p>
 </div>
 
 {% endblock main %}

--- a/frontstage/views/register.py
+++ b/frontstage/views/register.py
@@ -319,20 +319,32 @@ def register_activate_account(token):
 
     if result.status_code == 409:
         # Token is expired
-        json_response = json.loads(result.text)
-        party_id = json_response.get('id')
-        if party_id:
-            logger.warning('Expired token', token=token, party_id=party_id)
-            return render_template('register/register.link-expired.html', _theme='default', party_id=party_id)
-        else:
-            logger.error('No party_id found', token=token)
-            return redirect(url_for('error_bp.default_error_page'))
+        logger.warning('Expired token', token=token)
+        return render_template('register/register.link-expired.html', _theme='default')
     elif result.status_code == 404:
         # Token not recognised
         logger.warning("Unrecognised email verification token", token=token)
         return redirect(url_for('error_bp.not_found_error_page'))
     elif result.status_code != 200:
         raise ExternalServiceError(result)
+
+    # THE BELOW CODE WILL REDIRECT TO A RESEND EMAIL PAGE IF TOKEN IS EXPIRED (REQUIRES CHANGES IN PARTY SERVICE
+    # if result.status_code == 409:
+    #     # Token is expired
+    #     json_response = json.loads(result.text)
+    #     party_id = json_response.get('id')
+    #     if party_id:
+    #         logger.warning('Expired token', token=token, party_id=party_id)
+    #         return render_template('register/register.link-expired.html', _theme='default', party_id=party_id)
+    #     else:
+    #         logger.error('No party_id found', token=token)
+    #         return redirect(url_for('error_bp.default_error_page'))
+    # elif result.status_code == 404:
+    #     # Token not recognised
+    #     logger.warning("Unrecognised email verification token", token=token)
+    #     return redirect(url_for('error_bp.not_found_error_page'))
+    # elif result.status_code != 200:
+    #     raise ExternalServiceError(result)
 
     json_response = json.loads(result.text)
 
@@ -348,18 +360,19 @@ def register_activate_account(token):
         return redirect(url_for('error_bp.default_error_page'))
 
 
-@register_bp.route('/create-account/email-resent', methods=['GET'])
-def register_email_resent():
-    # Resend email verification link
-    party_id = request.args.get('party_id')
-    logger.debug('Attempting to re-send email verification link', party_id=party_id)
-    url = app.config['RAS_PARTY_RESEND_VERIFICATION'].format(app.config['RAS_PARTY_SERVICE'], party_id)
-    response = requests.get(url, auth=app.config['BASIC_AUTH'])
-    if response.status_code == 200:
-        logger.info("Successfully re-sent email verification link", party_id=party_id)
-        return render_template('register/register.email-resent.html', _theme='default', party_id=party_id)
-    elif response.status_code == 404:
-        logger.warning("Party not found to resend email verification link to", party_id=party_id)
-        return redirect(url_for('error_bp.default_error_page'))
-    else:
-        raise ExternalServiceError(response)
+# WAITING FOR PARTY SERVICE CHANGES TO IMPLEMENT
+# @register_bp.route('/create-account/email-resent', methods=['GET'])
+# def register_email_resent():
+#     # Resend email verification link
+#     party_id = request.args.get('party_id')
+#     logger.debug('Attempting to re-send email verification link', party_id=party_id)
+#     url = app.config['RAS_PARTY_RESEND_VERIFICATION'].format(app.config['RAS_PARTY_SERVICE'], party_id)
+#     response = requests.get(url, auth=app.config['BASIC_AUTH'])
+#     if response.status_code == 200:
+#         logger.info("Successfully re-sent email verification link", party_id=party_id)
+#         return render_template('register/register.email-resent.html', _theme='default', party_id=party_id)
+#     elif response.status_code == 404:
+#         logger.warning("Party not found to resend email verification link to", party_id=party_id)
+#         return redirect(url_for('error_bp.default_error_page'))
+#     else:
+#         raise ExternalServiceError(response)

--- a/tests/app/test_account_activation.py
+++ b/tests/app/test_account_activation.py
@@ -51,14 +51,14 @@ class TestAccountActivation(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue('Expired'.encode() in response.data)
 
-    def test_activate_account_expired_token_no_party_id(self, mock_object):
-        del self.emailverification_response['id']
-        mock_object.put(url_email_verification, status_code=409, json=self.emailverification_response)
-
-        response = self.app.get('/register/activate-account/' + token, headers=self.headers, follow_redirects=True)
-
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue('Oops!'.encode() in response.data)
+    # def test_activate_account_expired_token_no_party_id(self, mock_object):
+    #     del self.emailverification_response['id']
+    #     mock_object.put(url_email_verification, status_code=409, json=self.emailverification_response)
+    #
+    #     response = self.app.get('/register/activate-account/' + token, headers=self.headers, follow_redirects=True)
+    #
+    #     self.assertEqual(response.status_code, 200)
+    #     self.assertTrue('Oops!'.encode() in response.data)
 
     # Test that the user ends up on the 'You've activated your account' login page if they try to access the
     # account activation page with a valid, non-expired token
@@ -89,36 +89,36 @@ class TestAccountActivation(unittest.TestCase):
 
     # ==============EMAIL RE-SENT PAGE ===============
 
-    # Check the content of the 'We've re-sent your email' page
-    def test_email_resent(self, mock_object):
-        mock_object.get(url_resend_verification, status_code=200)
+    # # Check the content of the 'We've re-sent your email' page
+    # def test_email_resent(self, mock_object):
+    #     mock_object.get(url_resend_verification, status_code=200)
+    #
+    #     response = self.app.get('/register/create-account/email-resent?party_id=' + party_id,
+    #                             headers=self.headers,
+    #                             follow_redirects=True)
+    #
+    #     self.assertEqual(response.status_code, 200)
+    #     self.assertTrue('re-sent'.encode() in response.data)
 
-        response = self.app.get('/register/create-account/email-resent?party_id=' + party_id,
-                                headers=self.headers,
-                                follow_redirects=True)
+    # def test_email_resent_404(self, mock_object):
+    #     mock_object.get(url_resend_verification, status_code=404)
+    #
+    #     response = self.app.get('/register/create-account/email-resent?party_id=' + party_id,
+    #                             headers=self.headers,
+    #                             follow_redirects=True)
+    #
+    #     self.assertEqual(response.status_code, 200)
+    #     self.assertTrue('Oops!'.encode() in response.data)
 
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue('re-sent'.encode() in response.data)
-
-    def test_email_resent_404(self, mock_object):
-        mock_object.get(url_resend_verification, status_code=404)
-
-        response = self.app.get('/register/create-account/email-resent?party_id=' + party_id,
-                                headers=self.headers,
-                                follow_redirects=True)
-
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue('Oops!'.encode() in response.data)
-
-    def test_email_resent_500(self, mock_object):
-        mock_object.get(url_resend_verification, status_code=500)
-
-        response = self.app.get('/register/create-account/email-resent?party_id=' + party_id,
-                                headers=self.headers,
-                                follow_redirects=True)
-
-        self.assertEqual(response.status_code, 500)
-        self.assertTrue('Server error'.encode() in response.data)
+    # def test_email_resent_500(self, mock_object):
+    #     mock_object.get(url_resend_verification, status_code=500)
+    #
+    #     response = self.app.get('/register/create-account/email-resent?party_id=' + party_id,
+    #                             headers=self.headers,
+    #                             follow_redirects=True)
+    #
+    #     self.assertEqual(response.status_code, 500)
+    #     self.assertTrue('Server error'.encode() in response.data)
 
     # ============== SIGN IN PAGE WITH 'ACCOUNT ACTIVATED' MESSAGE ===============
 


### PR DESCRIPTION
Removed the code around resending a verification email for an expired token.

I've left the removed code commented as it should work once ras-party changes have been made.

Along with this I've updated the templates to match what is in defect 30 https://trello.com/c/lPXVBZmZ/595-defect-30-story-us008-verify-new-account-8-a-500-error-is-displayed-not-the-message-to-contact-the-ons-to-request-a-new-link-fou

