### PR TITLE
Removed 'already got account?' content

### DIFF
--- a/frontstage/templates/register/register.confirm-organisation-survey.html
+++ b/frontstage/templates/register/register.confirm-organisation-survey.html
@@ -28,7 +28,7 @@
 
     <button class="btn btn--primary venus" type="submit" id="CONFIRM_AND_CONTINUE_BUTTON">Confirm</button>
 
-    <p>If the organisation or survey details aren't what you were expecting,please contact us on <a href="tel:+4403001234931">0300 1234 931</a></p>
+    <p>If the organisation or survey details aren't what you were expecting, please contact us on <a href="tel:+4403001234931">0300 1234 931</a></p>
 
 </form>
 {% endblock main %}

--- a/frontstage/templates/register/register.confirm-organisation-survey.html
+++ b/frontstage/templates/register/register.confirm-organisation-survey.html
@@ -28,13 +28,7 @@
 
     <button class="btn btn--primary venus" type="submit" id="CONFIRM_AND_CONTINUE_BUTTON">Confirm</button>
 
-    <p>If the organisation or survey details aren't what you were expecting.<br />
-        Please contact us on <a href="tel:+4403001234931">0300 1234 931</a></p>
-
-    <br />
-
-    <h2 class="neptune">Already have an account?</h2>
-    <p>You can still use this enrolment code after you <a href="/sign-in">sign in</a>.</p>
+    <p>If the organisation or survey details aren't what you were expecting,please contact us on <a href="tel:+4403001234931">0300 1234 931</a></p>
 
 </form>
 {% endblock main %}

--- a/frontstage/templates/register/register.enter-enrolment-code.html
+++ b/frontstage/templates/register/register.enter-enrolment-code.html
@@ -52,7 +52,6 @@
 
     </form>
 
-    <p>Already have an account? <a href="/sign-in">sign in here</a></p>
 </section>
 
 


### PR DESCRIPTION
BRES respondents won't already have an account, so have removed this from the "Create account - Enrolment code" and "Confirm organisation and survey" pages.

Due to the current P1, you won't be able to view "Confirm organisation and survey" page in the browser, but can test that I've removed the content in the html.