### PR TITLE
Accessibility - Changes to html in footer

### DIFF
--- a/frontstage/templates/partials/footer.html
+++ b/frontstage/templates/partials/footer.html
@@ -2,7 +2,7 @@
     <div class="container">
         <div class="grid">
             <div class="grid__col col-4@m">
-                <h3 class="venus footer__heading">Legal information</h3>
+                <p class="venus footer__heading"><strong>Legal information</strong></p>
                 <ul class="list footer__list">
                     <li>
                         <a href="/cookies-privacy"
@@ -12,7 +12,7 @@
             </div>
 
             <div class="grid__col col-4@m">
-                <h3 class="venus footer__heading">About ONS</h3>
+                <p class="venus footer__heading"><strong>About ONS</strong></p>
                 <ul class="list footer__list">
                     <li>
                         <a href="https://www.ons.gov.uk/aboutus/whatwedo"
@@ -30,7 +30,7 @@
             </div>
 
             <div class="grid__col col-4@m">
-                <h3 class="venus footer__heading">Statistics</h3>
+                <p class="venus footer__heading"><strong>Statistics</strong></p>
                 <ul class="list footer__list">
                     <li>
                         <a href="https://www.statisticsauthority.gov.uk/about-the-authority/"

--- a/frontstage/templates/partials/footer.html
+++ b/frontstage/templates/partials/footer.html
@@ -48,7 +48,7 @@
             </div>
 
             <div class="grid__col col-12@m footer__license">
-                <img class="ogl-icon" src="/static/images/ogl.svg"> All content is available under the <a
+                <img alt="OGL" class="ogl-icon" src="/static/images/ogl.svg"> All content is available under the <a
                     href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government
                     Licence v3.0</a>, except where otherwise stated
             </div>


### PR DESCRIPTION
Without alt text, the image in the footer failed accessibility compliance.

Added "OGL" as alt text.