### PR TITLE
Added hidden input field thread id

### DIFF
--- a/frontstage/templates/secure-messages/secure-messages-create.html
+++ b/frontstage/templates/secure-messages/secure-messages-create.html
@@ -14,7 +14,7 @@
             <h1 class="saturn">Create message</h1>
 
             <div class="secure-message-form">
-                <form  action="{{ url_for('secure_message_bp.reply_message') }}" method="post">
+                <form method="post">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
                     <input name="secure-message-thread-id" type="hidden" id="secure-message-thread-id" value="{{ draft['thread_id'] }}">
 

--- a/frontstage/templates/secure-messages/secure-messages-create.html
+++ b/frontstage/templates/secure-messages/secure-messages-create.html
@@ -14,8 +14,10 @@
             <h1 class="saturn">Create message</h1>
 
             <div class="secure-message-form">
-                <form method="post">
+                <form  action="{{ url_for('secure_message_bp.reply_message') }}" method="post">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                    <input name="secure-message-thread-id" type="hidden" id="secure-message-thread-id" value="{{ draft['thread_id'] }}">
+
                     <p>To: ONS Business Surveys team</p>
 
                     {% if "subject" in errors %}


### PR DESCRIPTION
Replying to a message in external generates Bad_request failure

https://trello.com/c/xGExW55k/660-defect-62-story-found-in-release10-replying-to-a-message-in-external-generates-badrequest-failure

Thread id hidden field was missing from secure-messages-create.html