### PR TITLE
Adding show password toggle to password-reset form

### DIFF
--- a/frontstage/templates/passwords/reset-password.html
+++ b/frontstage/templates/passwords/reset-password.html
@@ -55,20 +55,24 @@
         <li>at least one number</li>
     </ul>
 
-    <fieldset class="js-new-password-group" id="reset-details">
+    <fieldset class="js-new-password-group js-password-obfuscation-group" id="reset-details">
         {% if errorType.password %}
 
         <div class="panel panel--simple panel--error">
             <p class="error-message">{{ errorType['password'][0] }}</p>
         {% endif %}
+            <span>
+                <input class="js-password-obfuscation-toggle" type="checkbox" id="password-toggle" />
+                <label for="password-toggle">Show password</label>
+            </span>
             <div class="field" id="password_field">
                 {{ form.password.label(class_='label') }}
-                {{ form.password(class_='input input--text input-type__input js-new-password') }}
+                {{ form.password(class_='input input--text input-type__input js-new-password js-password-obfuscation-field') }}
             </div>
             <br/>
             <div class="field">
                 {{ form.password_confirm.label(class_='label') }}
-                {{ form.password_confirm(class_='input input--text input-type__input js-confirm-new-password') }}
+                {{ form.password_confirm(class_='input input--text input-type__input js-confirm-new-password js-password-obfuscation-field') }}
             </div>
         {% if errorType.password %}
         </div>


### PR DESCRIPTION
Show password toggle added to form in same way as sign-in page.

To test you can comment out lines 56-66 in `passwords.py` and got to the 
`/passwords/reset-password/aaa` endpoint