### PR TITLE
Add ons email and remove help with email

### DIFF
--- a/frontstage/templates/sign-in/sign-in.account-not-verified.html
+++ b/frontstage/templates/sign-in/sign-in.account-not-verified.html
@@ -7,8 +7,6 @@
     <h1 class="saturn">Trouble signing in?</h1>
 
     <p>Please follow the link in the verification email we sent you.</p>
-    <p>If you haven't received an email please call us on 0300 1234 932</p>
-
-    {% include "register/register.help-with-email.html" %}
+    <p>If you haven't received an email please call us on 0300 1234 932 or email <a href="mailto:surveys@ons.gov.uk">surveys@ons.gov.uk</a></p>
 
 {% endblock main %}


### PR DESCRIPTION
Incorrect message when the trying to login without verifying the account.

- Added ons email
- Remove 'help with email' section

https://trello.com/c/kERbocRp/675-defect-47-us007-found-in-release-80-sit-incorrect-message-when-the-trying-to-login-without-verifying-the-account