### PR TITLE
Added email address and corrected international number

### DIFF
--- a/frontstage/templates/register/register.confirm-organisation-survey.html
+++ b/frontstage/templates/register/register.confirm-organisation-survey.html
@@ -29,7 +29,7 @@
 
     <button class="btn btn--primary venus" type="submit" id="CONFIRM_AND_CONTINUE_BUTTON">Confirm</button>
 
-    <p>If the organisation or survey details aren't what you were expecting, please contact us on <a href="tel:+4403001234931">0300 1234 931</a></p>
+    <p>If the organisation or survey details aren't what you were expecting, please contact us on <a class="nowrap" href="tel:+44-300-1234-931">0300 1234 931</a> or send an email to <a href="mailto:surveys@ons.gov.uk">surveys@ons.gov.uk</a></p>
 
 </form>
 {% endblock main %}


### PR DESCRIPTION
Added surveys.ons.gov.uk as an option if details not as expected, for people who prefer to email rather than use the phone.

Also, the international number had been put in with the leading 0 after the country code, which may have cause a problem for anyone using the link.

Added the nowrap class so phone number remains on one line.