### PR TITLE
Change api url endpoints to use namespaces

### DIFF
--- a/config.py
+++ b/config.py
@@ -33,25 +33,25 @@ class Config(object):
     RAS_FRONTSTAGE_API_SERVICE = '{}://{}:{}/'.format(RAS_FRONTSTAGE_API_PROTOCOL,
                                                       RAS_FRONTSTAGE_API_HOST,
                                                       RAS_FRONTSTAGE_API_PORT)
-    GET_MESSAGES_URL = 'messages-list'
-    GET_MESSAGE_URL = 'message'
-    SEND_MESSAGE_URL = 'send-message'
+    GET_MESSAGES_URL = 'secure-messaging/messages-list'
+    GET_MESSAGE_URL = 'secure-messaging/message'
+    SEND_MESSAGE_URL = 'secure-messaging/send-message'
 
     SIGN_IN_URL = 'sign-in'
 
-    REQUEST_PASSWORD_CHANGE = 'request-password-change'
-    VERIFY_PASSWORD_TOKEN = 'verify-password-token'
-    CHANGE_PASSWORD = 'change-password'
+    REQUEST_PASSWORD_CHANGE = 'passwords/request-password-change'
+    VERIFY_PASSWORD_TOKEN = 'passwords/verify-password-token'
+    CHANGE_PASSWORD = 'passwords/change-password'
 
-    VALIDATE_ENROLMENT = 'validate-enrolment'
-    CONFIRM_ORGANISATION_SURVEY = 'confirm-organisation-survey'
-    CREATE_ACCOUNT = 'create-account'
-    VERIFY_EMAIL = 'verify-email'
+    VALIDATE_ENROLMENT = 'register/validate-enrolment'
+    CONFIRM_ORGANISATION_SURVEY = 'register/confirm-organisation-survey'
+    CREATE_ACCOUNT = 'register/create-account'
+    VERIFY_EMAIL = 'register/verify-email'
 
-    SURVEYS_LIST = 'surveys-list'
-    ACCESS_CASE = 'access-case'
-    DOWNLOAD_CI = 'download-ci'
-    UPLOAD_CI = 'upload-ci'
+    SURVEYS_LIST = 'surveys/surveys-list'
+    ACCESS_CASE = 'surveys/access-case'
+    DOWNLOAD_CI = 'surveys/download-ci'
+    UPLOAD_CI = 'surveys/upload-ci'
 
 
 class DevelopmentConfig(Config):

--- a/tests/app/test_secure_message.py
+++ b/tests/app/test_secure_message.py
@@ -6,13 +6,13 @@ import requests_mock
 from frontstage import app
 
 
-url_get_messages = app.config['RAS_FRONTSTAGE_API_SERVICE'] + 'messages-list'
+url_get_messages = app.config['RAS_FRONTSTAGE_API_SERVICE'] + app.config['GET_MESSAGES_URL']
 with open('tests/test_data/secure_messaging/messages_get.json') as json_data:
     messages_get = json.load(json_data)
-url_get_message = app.config['RAS_FRONTSTAGE_API_SERVICE'] + 'message'
+url_get_message = app.config['RAS_FRONTSTAGE_API_SERVICE'] + app.config['GET_MESSAGE_URL']
 with open('tests/test_data/secure_messaging/message.json') as json_data:
     message = json.load(json_data)
-url_send_message = app.config['RAS_FRONTSTAGE_API_SERVICE'] + 'send-message'
+url_send_message = app.config['RAS_FRONTSTAGE_API_SERVICE'] + app.config['SEND_MESSAGE_URL']
 
 
 encoded_jwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJyZWZyZXNoX3Rva2VuIjoiNmY5NjM0ZGEtYTI3ZS00ZDk3LWJhZjktNjN" \

--- a/tests/app/test_surveys.py
+++ b/tests/app/test_surveys.py
@@ -7,10 +7,10 @@ import requests_mock
 from frontstage import app
 
 
-url_get_surveys_list = app.config['RAS_FRONTSTAGE_API_SERVICE'] + 'surveys-list'
-url_access_case = app.config['RAS_FRONTSTAGE_API_SERVICE'] + 'access-case'
-url_download_ci = app.config['RAS_FRONTSTAGE_API_SERVICE'] + 'download-ci'
-url_upload_ci = app.config['RAS_FRONTSTAGE_API_SERVICE'] + 'upload-ci'
+url_get_surveys_list = app.config['RAS_FRONTSTAGE_API_SERVICE'] + app.config['SURVEYS_LIST']
+url_access_case = app.config['RAS_FRONTSTAGE_API_SERVICE'] + app.config['ACCESS_CASE']
+url_download_ci = app.config['RAS_FRONTSTAGE_API_SERVICE'] + app.config['DOWNLOAD_CI']
+url_upload_ci = app.config['RAS_FRONTSTAGE_API_SERVICE'] + app.config['UPLOAD_CI']
 
 with open('tests/test_data/surveys_list.json') as json_data:
     surveys_list = json.load(json_data)


### PR DESCRIPTION
These changes work with the accompanying "add-namespaces" PR in Frontstage-api https://github.com/ONSdigital/ras-frontstage-api/pull/18

Tests also had to be updated to work with these changes