### PR TITLE
Add expires_at field to jwt that was removed accidentally

### DIFF
--- a/frontstage/jwt.py
+++ b/frontstage/jwt.py
@@ -16,6 +16,7 @@ def timestamp_token(token):
     data_dict_for_jwt_token = {
         "refresh_token": token['refresh_token'],
         "access_token": token['access_token'],
+        "expires_at": expires_in.timestamp(),
         "role": "respondent",
         "party_id": token['party_id']
     }


### PR DESCRIPTION
The last PR shouldn't have removed this, worrying that it wasn't caught by the tests we should look to add new ones which will cover this.

For now need this as a fix