### PR TITLE
Pin the python buildpack version to manifest

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,6 +4,7 @@ name = "pypi"
 verify_ssl = true
 url = "https://pypi.python.org/simple"
 
+
 [requires]
 
 python_version = "3.5"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -5,14 +5,14 @@
         },
         "host-environment-markers": {
             "implementation_name": "cpython",
-            "implementation_version": "3.5.2",
+            "implementation_version": "3.5.4",
             "os_name": "posix",
             "platform_machine": "x86_64",
             "platform_python_implementation": "CPython",
-            "platform_release": "16.7.0",
+            "platform_release": "17.2.0",
             "platform_system": "Darwin",
-            "platform_version": "Darwin Kernel Version 16.7.0: Thu Jun 15 17:36:27 PDT 2017; root:xnu-3789.70.16~2/RELEASE_X86_64",
-            "python_full_version": "3.5.2",
+            "platform_version": "Darwin Kernel Version 17.2.0: Fri Sep 29 18:27:05 PDT 2017; root:xnu-4570.20.62~3/RELEASE_X86_64",
+            "python_full_version": "3.5.4",
             "python_version": "3.5",
             "sys_platform": "darwin"
         },

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,6 @@
 applications:
 - name: ras-frontstage
+  buildpack: https://github.com/cloudfoundry/python-buildpack.git#v1.6.2
   disk_quota: 1G
   health-check-http-endpoint: /info
   health-check-type: http


### PR DESCRIPTION
This ensures a later version of Pipenv is used and avoids [setuptools issue](https://github.com/cloudfoundry/python-buildpack/issues/87).