### PR TITLE
Restore show password and add autocomplete false

### DIFF
--- a/frontstage/templates/passwords/reset-password.html
+++ b/frontstage/templates/passwords/reset-password.html
@@ -61,14 +61,18 @@
         <div class="panel panel--simple panel--error">
             <p class="error-message">{{ errorType['password'][0] }}</p>
         {% endif %}
+            <span>
+                <input class="js-password-obfuscation-toggle" type="checkbox" id="password-toggle" />
+                <label for="password-toggle">Show password</label>
+            </span>
             <div class="field" id="password_field">
                 {{ form.password.label(class_='label') }}
-                {{ form.password(class_='input input--text input-type__input js-new-password js-password-obfuscation-field') }}
+                {{ form.password(class_='input input--text input-type__input js-new-password js-password-obfuscation-field', autocomplete="off") }}
             </div>
             <br/>
             <div class="field">
                 {{ form.password_confirm.label(class_='label') }}
-                {{ form.password_confirm(class_='input input--text input-type__input js-confirm-new-password js-password-obfuscation-field') }}
+                {{ form.password_confirm(class_='input input--text input-type__input js-confirm-new-password js-password-obfuscation-field', autocomplete="off") }}
             </div>
         {% if errorType.password %}
         </div>

--- a/frontstage/templates/sign-in/sign-in.html
+++ b/frontstage/templates/sign-in/sign-in.html
@@ -73,7 +73,11 @@
                         <p class="error-message">{{ errorType['password'][0] }}</p>
                     {% endif %}
                         {{ form.password.label(class_='label') }}
-                        {{ form.password(class_='input input--text input-type__input js-password-obfuscation-field') }}
+                        <span>
+                            <input class="js-password-obfuscation-toggle" type="checkbox" id="password-toggle" />
+                            <label for="password-toggle">Show password</label>
+                        </span>
+                        {{ form.password(class_='input input--text input-type__input js-password-obfuscation-field', autocomplete="off") }}
                         <br />
                         <a href="/passwords/forgot-password">Forgot password?</a>
                     {% if errorType.password %}

--- a/frontstage/templates/sign-in/sign-in.last-attempt.html
+++ b/frontstage/templates/sign-in/sign-in.last-attempt.html
@@ -20,7 +20,11 @@
         <fieldset>
             <div class="field js-password-obfuscation-group">
                 <label class="label">Password</label>
-                <input name="pass" class="input input--text input-type__input js-password-obfuscation-field" id="password-obfuscation-input" value="" type="password" />
+                <span>
+                    <input class="js-password-obfuscation-toggle" type="checkbox"/>
+                    <label>Show password</label>
+                </span>
+                <input name="pass" class="input input--text input-type__input js-password-obfuscation-field" id="password-obfuscation-input" value="" type="password" autocomplete="off"/>
             </div>
             <br />
 


### PR DESCRIPTION
The show password was removed for release 14 as the value was being cache by the browser, meaning on a shared computer this would be an issue. 

This story adds it back in, but stops the browser caching it. I have checked autocomplete works on all browsers that GDS requires using browser stack (https://www.browserstack.com/)

https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices
