### PR TITLE
Tbl129 ensure correct survey and ce values displayed to respondents

### DIFF
--- a/frontstage/templates/surveys/surveys-access.html
+++ b/frontstage/templates/surveys/surveys-access.html
@@ -23,7 +23,7 @@
 
 <p>
     {{ survey_info.shortName }} spreadsheet for <strong>{{ business_info.name }}</strong>
-    for the period {{ collection_exercise_info.periodStartDateTimeFormatted }} to {{ collection_exercise_info.periodEndDateTimeFormatted }}
+    for the period {{ collection_exercise_info.userDescription }}
 </p>
 
 <p>If actual figures are not available, please provide informed estimates.</p>

--- a/frontstage/templates/surveys/surveys-access.html
+++ b/frontstage/templates/surveys/surveys-access.html
@@ -2,7 +2,7 @@
 
 {% extends "layouts/_onecol.html" %}
 
-{% block page_title %}Business Register and Employment Survey 2017 - ONS Business Surveys{% endblock %}
+{% block page_title %}{{ survey_info.longName }} {{ collection_exercise_info.userDescription }} - ONS Business Surveys{% endblock %}
 
 {% block main %}
 

--- a/frontstage/templates/surveys/surveys.html
+++ b/frontstage/templates/surveys/surveys.html
@@ -37,7 +37,7 @@
 
         <div class="grid__col col-2@m">
             <span class="survey-list-item__label mercury">PERIOD COVERED: </span>
-            <span class="survey-list-item__nowrap">{{ data.collection_exercise.periodEndDateTimeFormatted}}</span>
+            <span class="survey-list-item__nowrap">{{ data.collection_exercise.userDescription}}</span>
         </div>
 
         <div class="grid__col col-2@m">

--- a/tests/app/test_surveys.py
+++ b/tests/app/test_surveys.py
@@ -81,6 +81,15 @@ class TestSurveys(unittest.TestCase):
         self.assertTrue('RUNAME1_COMPANY4 RUNNAME2_COMPANY4'.encode() in response.data)
 
     @requests_mock.mock()
+    def test_access_survey_title(self, mock_request):
+        mock_request.get(url_access_case, json=surveys_list[1])
+
+        response = self.app.get('/surveys/access_survey?case_id=t3577bd4-004d-42d1-a1c6-a514973d9ae5', follow_redirects=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('Test Survey December 2017 - ONS Business Surveys'.encode() in response.data)
+
+    @requests_mock.mock()
     def test_access_survey_fail(self, mock_request):
         mock_request.get(url_access_case, status_code=500)
 

--- a/tests/test_data/surveys_list.json
+++ b/tests/test_data/surveys_list.json
@@ -75,5 +75,83 @@
     },
     "collection_instrument_size": 5302,
     "status": "None"
+  },
+  {
+    "case": {
+      "state": "ACTIONABLE",
+      "id": "b2457bd4-004d-42d1-a1c6-a514973d9ae5",
+      "actionPlanId": "0009e978-0932-463b-a2a1-b45cb3ffcb2a",
+      "collectionInstrumentId": "68ad4018-2ddd-4894-89e7-33f0135887a2",
+      "partyId": "07d672bc-497b-448f-a406-a20a7e6013d7",
+      "iac": "None",
+      "caseRef": "1000000000000002",
+      "createdBy": "SYSTEM",
+      "sampleUnitType": "BI",
+      "createdDateTime": "2017-11-06T16:08:14.115+0000",
+      "caseGroup": {
+        "collectionExerciseId": "14fb3e68-4dca-46db-bf49-04b84e07e77c",
+        "id": "3a12e68f-aba3-4d0d-9247-3017a319a058",
+        "partyId": "1216a88f-ee2a-420c-9e6a-ee34893c29cf",
+        "sampleUnitRef": "49900000004",
+        "sampleUnitType": "B"
+      },
+      "responses": [],
+      "caseEvents": "None"
+    },
+    "collection_exercise": {
+      "id": "14fb3e68-4dca-46db-bf49-04b84e07e77c",
+      "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
+      "name": "BRES_2017",
+      "actualExecutionDateTime": "2017-11-06T16:06:19.966+0000",
+      "scheduledExecutionDateTime": "2017-09-10T23:00:00.000+0000",
+      "scheduledStartDateTime": "2017-09-11T23:00:00.000+0000",
+      "actualPublishDateTime": "2017-11-06T16:08:26.100+0000",
+      "periodStartDateTime": "2017-09-14T23:00:00.000+0000",
+      "periodEndDateTime": "2017-09-15T22:59:59.000+0000",
+      "scheduledReturnDateTime": "2017-10-06T00:00:00.000+0000",
+      "scheduledEndDateTime": "2018-06-29T23:00:00.000+0000",
+      "executedBy": "None",
+      "state": "PUBLISHED",
+      "caseTypes": [
+        {
+          "actionPlanId": "e71002ac-3575-47eb-b87f-cd9db92bf9a7",
+          "sampleUnitType": "B"
+        }, {
+          "actionPlanId": "0009e978-0932-463b-a2a1-b45cb3ffcb2a",
+          "sampleUnitType": "BI"
+        }
+      ],
+      "exerciseRef": "221_201712",
+      "periodStartDateTimeFormatted": "14 Sep 2017",
+      "periodEndDateTimeFormatted": "15 Sep 2017",
+      "scheduledReturnDateTimeFormatted": "6 Oct 2017",
+      "userDescription": "December 2017"
+    },
+    "business_party": {
+      "associations": [
+        {
+          "enrolments": [
+            {
+              "enrolmentStatus": "ENABLED",
+              "name": "Business Register and Employment Survey",
+              "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
+            }
+          ],
+          "partyId": "07d672bc-497b-448f-a406-a20a7e6013d7"
+        }
+      ],
+      "id": "1216a88f-ee2a-420c-9e6a-ee34893c29cf",
+      "name": "RUNAME1_COMPANY4 RUNNAME2_COMPANY4",
+      "sampleUnitRef": "49900000004",
+      "sampleUnitType": "B"
+    },
+    "survey": {
+      "id": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
+      "shortName": "TEST",
+      "longName": "Test Survey",
+      "surveyRef": "221"
+    },
+    "collection_instrument_size": 5302,
+    "status": "None"
   }
 ]


### PR DESCRIPTION
Uses the ["user visible name"](https://github.com/ONSdigital/rm-collection-exercise-service/blob/master/API.md#example-json-request-body-1) (from the collection exercise) in a survey page title and "period covered" in survey lists (historic and todo).

NB: Additional test data provided to check title is rendered as expected in unit tests.

