### PR TITLE
Fix reply to message

### DIFF
--- a/frontstage/views/__init__.py
+++ b/frontstage/views/__init__.py
@@ -28,7 +28,7 @@ from frontstage.views.surveys import (access_survey, add_survey, add_survey_conf
                                       upload_survey_failed)
 app.register_blueprint(surveys_bp, url_prefix='/surveys')
 
-from frontstage.views.secure_messaging import create_message, message_get, messages_get, send_message
+from frontstage.views.secure_messaging import create_message, message_get, messages_get
 app.register_blueprint(secure_message_bp, url_prefix='/secure-message')
 
 app.register_blueprint(cookies_privacy_bp, url_prefix='/cookies-privacy')

--- a/frontstage/views/secure_messaging/create_message.py
+++ b/frontstage/views/secure_messaging/create_message.py
@@ -19,7 +19,7 @@ logger = wrap_logger(logging.getLogger(__name__))
 @secure_message_bp.route('/create-message/', methods=['GET', 'POST'])
 @jwt_authorization(request)
 def create_message(session):
-    case_id = request.args['case_id']
+    case_id = request.args.get('case_id')
     survey = request.args['survey']
     ru_ref = request.args['ru_ref']
     party_id = session['party_id']
@@ -59,8 +59,9 @@ def send_message(party_id, is_draft, case_id, survey, ru_ref):
         'thread_id': form['thread_id'].data,
         'ru_id': ru_ref,
         'survey': survey,
-        'collection_case': case_id
     }
+    if case_id:
+        message_json['collection_case'] = case_id
 
     # If message has previously been saved as a draft add through the message id
     if form["msg_id"].data:

--- a/frontstage/views/secure_messaging/message_get.py
+++ b/frontstage/views/secure_messaging/message_get.py
@@ -32,6 +32,9 @@ def message_get(session, label, message_id):
     return render_template('secure-messages/secure-messages-view.html',
                            _theme='default',
                            message=message_json['message'],
+                           ru_ref=message_json['message'].get('ru_id'),
+                           survey=message_json['message'].get('survey'),
+                           case_id=message_json['message'].get('case_id'),
                            draft=message_json['draft'],
                            form=form,
                            label=label)

--- a/tests/app/test_secure_message.py
+++ b/tests/app/test_secure_message.py
@@ -236,8 +236,9 @@ class TestSecureMessage(unittest.TestCase):
 
     def test_create_message_post_no_case_id(self):
         response = self.app.post("/secure-message/create-message/?ru_ref=456&survey=789", data=self.message_form, headers=self.headers, follow_redirects=True)
-
-        self.assertEqual(response.status_code, 400)
+        # case id is optional
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('Message sent'.encode() in response.data)
 
     def test_create_message_post_no_survey_id(self):
         response = self.app.post("/secure-message/create-message/?case_id=123&ru_ref=456", data=self.message_form, headers=self.headers, follow_redirects=True)

--- a/tests/app/test_secure_message.py
+++ b/tests/app/test_secure_message.py
@@ -234,7 +234,13 @@ class TestSecureMessage(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue('Subject field length must not be greater than 100'.encode() in response.data)
 
-    def test_create_message_post_no_case_id(self):
+    @requests_mock.mock()
+    def test_create_message_post_no_case_id(self, mock_request):
+        sent_message_response = {'msg_id': 'd43b6609-0875-4ef8-a34e-f7df1bcc8029', 'status': '201',
+                                 'thread_id': '8caeff79-6067-4f2a-96e0-08617fdeb496'}
+        mock_request.post(url_send_message, json=sent_message_response)
+        mock_request.get(url_get_messages, json=messages_get)
+
         response = self.app.post("/secure-message/create-message/?ru_ref=456&survey=789", data=self.message_form, headers=self.headers, follow_redirects=True)
         # case id is optional
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
RU_REF, CASE_ID and Survey were all missing from the template so were not sent by the frontstage application.

Case ID is now also optional in secure messaging so doesn't always need to be sent