### PR TITLE
Set expiry on auth token

### DIFF
--- a/frontstage/common/authorisation.py
+++ b/frontstage/common/authorisation.py
@@ -58,12 +58,11 @@ def jwt_authorization(request):
                 raise JWTValidationError
 
             if app.config['VALIDATE_JWT']:
-                valid = validate(jwt)
-            if valid:
-                session_handler.update_session()
-                return original_function(jwt, *args, **kwargs)
-            else:
-                logger.warning('Token is not valid for this request')
-                raise JWTValidationError
+                if validate(jwt):
+                    session_handler.update_session()
+                    return original_function(jwt, *args, **kwargs)
+                else:
+                    logger.warning('Token is not valid for this request')
+                    raise JWTValidationError
         return extract_session_wrapper
     return extract_session

--- a/frontstage/views/sign_in/sign_in.py
+++ b/frontstage/views/sign_in/sign_in.py
@@ -72,7 +72,9 @@ def login():
         session = SessionHandler()
         logger.info('Creating session', party_id=response_json['party_id'])
         session.create_session(encoded_jwt_token)
-        response.set_cookie('authorization', value=session.session_key)
+        response.set_cookie('authorization',
+                            value=session.session_key,
+                            expires=data_dict_for_jwt_token['expires_at'])
         logger.info('Successfully created session', party_id=response_json['party_id'],
                     session_key=session.session_key)
         return response

--- a/tests/app/test_sign_in.py
+++ b/tests/app/test_sign_in.py
@@ -31,6 +31,15 @@ class TestSignIn(unittest.TestCase):
             "refresh_token": "b7ac07a6-4c28-43bd-a335-00250b490e9f",
             "party_id": "test-id"
         }
+        self.expired_oauth_token = {
+            "id": 1,
+            "access_token": "8c77e013-d8dc-472c-b4d3-d4fbe21f80e7",
+            "expires_in": -1,
+            "token_type": "Bearer",
+            "scope": "",
+            "refresh_token": "b7ac07a6-4c28-43bd-a335-00250b490e9f",
+            "party_id": "test-id"
+        }
         self.sign_in_form = {
             "username": "testuser@email.com",
             "password": "password"
@@ -98,6 +107,16 @@ class TestSignIn(unittest.TestCase):
 
         self.assertEqual(response.status_code, 302)
         self.assertTrue('/surveys/'.encode() in response.data)
+
+    @requests_mock.mock()
+    def test_sign_in_expired(self, mock_object):
+        mock_object.post(url_oauth_token, status_code=200, json=self.expired_oauth_token)
+
+        self.app.get('/sign-in/', data=self.sign_in_form)
+
+        response = self.app.get('/surveys/',  follow_redirects=True)
+        self.assertEqual(response.status_code, 403)
+        self.assertIn(b'Error - Not signed in', response.data)
 
     @requests_mock.mock()
     def test_sign_in_oauth_fail(self, mock_object):


### PR DESCRIPTION
This PR fixes a bug where authorization tokens are not having their expiry set in the client's browser.