### PR TITLE
Only show Access Survey button if ...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+TEST_TARGET=tests
+
+docker-test: REDIS_PORT=7379
+docker-test: test
+
+test:
+	APP_SETTINGS=TestingConfig pipenv run pytest $(TEST_TARGET) --cov frontstage --cov-report term-missing	

--- a/README.md
+++ b/README.md
@@ -45,10 +45,20 @@ Install test dependencies with
 ```bash
 pipenv install --dev
 ```
-The [run_tests.py](run_tests.py) script will run the tests in the [/tests](tests) folder using pytest and present a coverage report
+The [run_tests.py](run_tests.py) script will run the tests in the [/tests](tests) folder using pytest and present a coverage report.  This script can be easily run via the following command
 ```bash
-pipenv run python run_tests.py
+make test
 ```
+or if you are running redis in the docker environment
+```bash
+make docker-test
+```
+or if you wish to run a single test file it can be specified as follows
+```bash
+make TEST_TARGET=tests/app/test_surveys.py test
+```
+The syntax above will work equally well with the 'docker-test' target
+
 
 Note that this script will fail if there is a `node_modules` folder in the repo
 

--- a/config.py
+++ b/config.py
@@ -6,7 +6,7 @@ import os
 class Config(object):
     DEBUG = False
     TESTING = False
-    VERSION = '0.2.2'
+    VERSION = '0.2.3'
     PORT = os.getenv('PORT', 8082)
     MAX_UPLOAD_LENGTH = os.getenv('MAX_UPLOAD_LENGTH',  20 * 1024 * 1024)
 

--- a/frontstage/templates/surveys/surveys.html
+++ b/frontstage/templates/surveys/surveys.html
@@ -54,7 +54,7 @@
             <span id="status-{{ loop.index }}">{{ survey.status }}</span>
         </div>
         <div class="grid__col col-2@m">
-            {% if not survey.status == 'Complete' or survey.case.caseEvents|selectattr('category', 'equalto', 'EQ_LAUNCH')|list|length == 0 %}
+            {% if not survey.status == 'Complete' or not survey.collection_instrument_type == 'EQ' %}
             <a href="{{ url_for('surveys_bp.access_survey', case_id=survey.case.id, ci_type = survey.collection_instrument_type) }}">
                 <button id="ACCESS_SURVEY_BUTTON_{{loop.index}}" class="btn action-button btn--primary" type="submit">
                     Access <span class="u-vh">{{ survey.survey.longName|replace("Survey", " ") }}</span> survey

--- a/frontstage/templates/surveys/surveys.html
+++ b/frontstage/templates/surveys/surveys.html
@@ -54,12 +54,14 @@
             <span id="status-{{ loop.index }}">{{ survey.status }}</span>
         </div>
         <div class="grid__col col-2@m">
+            {% if not survey.status == 'Complete' or survey.case.caseEvents|selectattr('category', 'equalto', 'EQ_LAUNCH')|list|length == 0 %}
             <a href="{{ url_for('surveys_bp.access_survey', case_id=survey.case.id, ci_type = survey.collection_instrument_type) }}">
                 <button id="ACCESS_SURVEY_BUTTON_{{loop.index}}" class="btn action-button btn--primary" type="submit">
                     Access <span class="u-vh">{{ survey.survey.longName|replace("Survey", " ") }}</span> survey
                 </button>
             </a>
             <a id="create-message-link-{{loop.index}}" href="/secure-message/create-message/?case_id={{survey.case.id}}&survey={{survey.survey.id}}&ru_ref={{survey.business_party.id}} " class="pluto survey-message history__message">Send a message </span></a>
+            {% endif %}
         </div>
     </li>
     {% endfor %}

--- a/frontstage/templates/surveys/surveys.html
+++ b/frontstage/templates/surveys/surveys.html
@@ -60,8 +60,8 @@
                     Access <span class="u-vh">{{ survey.survey.longName|replace("Survey", " ") }}</span> survey
                 </button>
             </a>
-            <a id="create-message-link-{{loop.index}}" href="/secure-message/create-message/?case_id={{survey.case.id}}&survey={{survey.survey.id}}&ru_ref={{survey.business_party.id}} " class="pluto survey-message history__message">Send a message </span></a>
             {% endif %}
+            <a id="create-message-link-{{loop.index}}" href="/secure-message/create-message/?case_id={{survey.case.id}}&survey={{survey.survey.id}}&ru_ref={{survey.business_party.id}} " class="pluto survey-message history__message">Send a message </span></a>
         </div>
     </li>
     {% endfor %}

--- a/tests/app/test_surveys.py
+++ b/tests/app/test_surveys.py
@@ -18,8 +18,11 @@ url_add_survey = app.config['RAS_FRONTSTAGE_API_SERVICE'] + app.config['ADD_SURV
 url_confirm_add_organisation_survey = '{}{}'.format(app.config['RAS_FRONTSTAGE_API_SERVICE'],
                                                     app.config['CONFIRM_ADD_ORGANISATION_SURVEY'])
 
-with open('tests/test_data/surveys_list.json') as json_data:
-    surveys_list = json.load(json_data)
+with open('tests/test_data/surveys_list_seft.json') as json_data:
+    surveys_list_seft = json.load(json_data)
+
+with open('tests/test_data/surveys_list_eq.json') as json_data:
+    surveys_list_eq = json.load(json_data)
 
 encoded_jwt_token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJyb2xlIjoicmVzcG9uZGVudCIsImFjY2Vzc190b2tlbiI6ImI5OWIyMjA" \
                     "0LWYxMDAtNDcxZS1iOTQ1LTIyN2EyNmVhNjljZCIsInJlZnJlc2hfdG9rZW4iOiIxZTQyY2E2MS02ZDBkLTQxYjMtODU2Yy0" \
@@ -59,7 +62,7 @@ class TestSurveys(unittest.TestCase):
 
     @requests_mock.mock()
     def test_surveys_todo(self, mock_request):
-        mock_request.get(url_get_surveys_list, json=surveys_list)
+        mock_request.get(url_get_surveys_list, json=surveys_list_seft)
 
         response = self.app.get('/surveys/')
 
@@ -68,14 +71,30 @@ class TestSurveys(unittest.TestCase):
         self.assertTrue('RUNAME1_COMPANY4 RUNNAME2_COMPANY4'.encode() in response.data)
 
     @requests_mock.mock()
-    def test_surveys_history(self, mock_request):
-        mock_request.get(url_get_surveys_list, json=surveys_list)
+    def test_surveys_history_seft(self, mock_request):
+        mock_request.get(url_get_surveys_list, json=surveys_list_seft)
 
         response = self.app.get('/surveys/history')
 
         self.assertEqual(response.status_code, 200)
         self.assertTrue('Business Register and Employment Survey'.encode() in response.data)
         self.assertTrue('RUNAME1_COMPANY4 RUNNAME2_COMPANY4'.encode() in response.data)
+        # Two entries in array, both SEFT. Although 1 is status Complete 2 buttons should show
+        self.assertTrue('ACCESS_SURVEY_BUTTON_1'.encode() in response.data)
+        self.assertTrue('ACCESS_SURVEY_BUTTON_2'.encode() in response.data)
+
+    @requests_mock.mock()
+    def test_surveys_history_eq(self, mock_request):
+        mock_request.get(url_get_surveys_list, json=surveys_list_eq)
+
+        response = self.app.get('/surveys/history')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('Business Register and Employment Survey'.encode() in response.data)
+        self.assertTrue('RUNAME1_COMPANY4 RUNNAME2_COMPANY4'.encode() in response.data)
+        # Two entries in array, one is Complete one is not, so there should be 1 button only
+        self.assertTrue('ACCESS_SURVEY_BUTTON_1'.encode() in response.data)
+        self.assertFalse('ACCESS_SURVEY_BUTTON_2'.encode() in response.data)
 
     @requests_mock.mock()
     def test_surveys_todo_fail(self, mock_request):
@@ -88,7 +107,7 @@ class TestSurveys(unittest.TestCase):
 
     @requests_mock.mock()
     def test_access_survey(self, mock_request):
-        mock_request.get(url_access_case, json=surveys_list[0])
+        mock_request.get(url_access_case, json=surveys_list_seft[0])
 
         response = self.app.get('/surveys/access_survey?case_id=b2457bd4-004d-42d1-a1c6-a514973d9ae5&ci_type=SEFT', follow_redirects=True)
 
@@ -106,7 +125,7 @@ class TestSurveys(unittest.TestCase):
 
     @requests_mock.mock()
     def test_access_survey_title(self, mock_request):
-        mock_request.get(url_access_case, json=surveys_list[1])
+        mock_request.get(url_access_case, json=surveys_list_seft[1])
 
         response = self.app.get('/surveys/access_survey?case_id=t3577bd4-004d-42d1-a1c6-a514973d9ae5&ci_type=SEFT', follow_redirects=True)
 
@@ -301,7 +320,7 @@ class TestSurveys(unittest.TestCase):
     @requests_mock.mock()
     def test_add_survey_submit(self, mock_object):
         mock_object.post(url_add_survey, json={'case_id': "test_case_id"})
-        mock_object.get(url_get_surveys_list, json=surveys_list)
+        mock_object.get(url_get_surveys_list, json=surveys_list_seft)
 
         url = '/surveys/add-survey/add-survey-submit' \
               '?encrypted_enrolment_code=WfwJghohWOZTIYnutlTcVucqnuED5Lm9q8t0L4ASHPo='

--- a/tests/app/test_surveys.py
+++ b/tests/app/test_surveys.py
@@ -80,8 +80,8 @@ class TestSurveys(unittest.TestCase):
         self.assertTrue('Business Register and Employment Survey'.encode() in response.data)
         self.assertTrue('RUNAME1_COMPANY4 RUNNAME2_COMPANY4'.encode() in response.data)
         # Two entries in array, both SEFT. Although 1 is status Complete 2 buttons should show
-        self.assertTrue('ACCESS_SURVEY_BUTTON_1'.encode() in response.data)
-        self.assertTrue('ACCESS_SURVEY_BUTTON_2'.encode() in response.data)
+        self.assertIn('ACCESS_SURVEY_BUTTON_1'.encode(), response.data)
+        self.assertIn('ACCESS_SURVEY_BUTTON_2'.encode(), response.data)
 
     @requests_mock.mock()
     def test_surveys_history_eq(self, mock_request):
@@ -93,8 +93,8 @@ class TestSurveys(unittest.TestCase):
         self.assertTrue('Business Register and Employment Survey'.encode() in response.data)
         self.assertTrue('RUNAME1_COMPANY4 RUNNAME2_COMPANY4'.encode() in response.data)
         # Two entries in array, one is Complete one is not, so there should be 1 button only
-        self.assertTrue('ACCESS_SURVEY_BUTTON_1'.encode() in response.data)
-        self.assertFalse('ACCESS_SURVEY_BUTTON_2'.encode() in response.data)
+        self.assertIn('ACCESS_SURVEY_BUTTON_1'.encode(), response.data)
+        self.assertNotIn('ACCESS_SURVEY_BUTTON_2'.encode(), response.data)
 
     @requests_mock.mock()
     def test_surveys_todo_fail(self, mock_request):

--- a/tests/test_data/surveys_list_eq.json
+++ b/tests/test_data/surveys_list_eq.json
@@ -73,8 +73,9 @@
       "longName": "Business Register and Employment Survey",
       "surveyRef": "221"
     },
-    "collection_instrument_size": 5302,
-    "status": "None"
+    "status": "None",
+    "collection_instrument_type": "EQ",
+    "collection_instrument_size": 5302
   },
   {
     "case": {
@@ -151,7 +152,8 @@
       "longName": "Test Survey",
       "surveyRef": "221"
     },
-    "collection_instrument_size": 5302,
-    "status": "None"
+    "status": "Complete",
+    "collection_instrument_type": "EQ",
+    "collection_instrument_size": 5302
   }
 ]

--- a/tests/test_data/surveys_list_seft.json
+++ b/tests/test_data/surveys_list_seft.json
@@ -1,0 +1,159 @@
+[
+  {
+    "case": {
+      "state": "ACTIONABLE",
+      "id": "b2457bd4-004d-42d1-a1c6-a514973d9ae5",
+      "actionPlanId": "0009e978-0932-463b-a2a1-b45cb3ffcb2a",
+      "collectionInstrumentId": "68ad4018-2ddd-4894-89e7-33f0135887a2",
+      "partyId": "07d672bc-497b-448f-a406-a20a7e6013d7",
+      "iac": "None",
+      "caseRef": "1000000000000002",
+      "createdBy": "SYSTEM",
+      "sampleUnitType": "BI",
+      "createdDateTime": "2017-11-06T16:08:14.115+0000",
+      "caseGroup": {
+        "collectionExerciseId": "14fb3e68-4dca-46db-bf49-04b84e07e77c",
+        "id": "3a12e68f-aba3-4d0d-9247-3017a319a058",
+        "partyId": "1216a88f-ee2a-420c-9e6a-ee34893c29cf",
+        "sampleUnitRef": "49900000004",
+        "sampleUnitType": "B"
+      },
+      "responses": [],
+      "caseEvents": "None"
+    },
+    "collection_exercise": {
+      "id": "14fb3e68-4dca-46db-bf49-04b84e07e77c",
+      "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
+      "name": "BRES_2017",
+      "actualExecutionDateTime": "2017-11-06T16:06:19.966+0000",
+      "scheduledExecutionDateTime": "2017-09-10T23:00:00.000+0000",
+      "scheduledStartDateTime": "2017-09-11T23:00:00.000+0000",
+      "actualPublishDateTime": "2017-11-06T16:08:26.100+0000",
+      "periodStartDateTime": "2017-09-14T23:00:00.000+0000",
+      "periodEndDateTime": "2017-09-15T22:59:59.000+0000",
+      "scheduledReturnDateTime": "2017-10-06T00:00:00.000+0000",
+      "scheduledEndDateTime": "2018-06-29T23:00:00.000+0000",
+      "executedBy": "None",
+      "state": "PUBLISHED",
+      "caseTypes": [
+        {
+          "actionPlanId": "e71002ac-3575-47eb-b87f-cd9db92bf9a7",
+          "sampleUnitType": "B"
+        }, {
+          "actionPlanId": "0009e978-0932-463b-a2a1-b45cb3ffcb2a",
+          "sampleUnitType": "BI"
+        }
+      ],
+      "exerciseRef": "221_201712",
+      "periodStartDateTimeFormatted": "14 Sep 2017",
+      "periodEndDateTimeFormatted": "15 Sep 2017",
+      "scheduledReturnDateTimeFormatted": "6 Oct 2017"
+    },
+    "business_party": {
+      "associations": [
+        {
+          "enrolments": [
+            {
+              "enrolmentStatus": "ENABLED",
+              "name": "Business Register and Employment Survey",
+              "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
+            }
+          ],
+          "partyId": "07d672bc-497b-448f-a406-a20a7e6013d7"
+        }
+      ],
+      "id": "1216a88f-ee2a-420c-9e6a-ee34893c29cf",
+      "name": "RUNAME1_COMPANY4 RUNNAME2_COMPANY4",
+      "sampleUnitRef": "49900000004",
+      "sampleUnitType": "B"
+    },
+    "survey": {
+      "id": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
+      "shortName": "BRES",
+      "longName": "Business Register and Employment Survey",
+      "surveyRef": "221"
+    },
+    "collection_instrument_type": "SEFT",
+    "collection_instrument_size": 5302,
+    "status": "Complete"
+  },
+  {
+    "case": {
+      "state": "ACTIONABLE",
+      "id": "b2457bd4-004d-42d1-a1c6-a514973d9ae5",
+      "actionPlanId": "0009e978-0932-463b-a2a1-b45cb3ffcb2a",
+      "collectionInstrumentId": "68ad4018-2ddd-4894-89e7-33f0135887a2",
+      "partyId": "07d672bc-497b-448f-a406-a20a7e6013d7",
+      "iac": "None",
+      "caseRef": "1000000000000002",
+      "createdBy": "SYSTEM",
+      "sampleUnitType": "BI",
+      "createdDateTime": "2017-11-06T16:08:14.115+0000",
+      "caseGroup": {
+        "collectionExerciseId": "14fb3e68-4dca-46db-bf49-04b84e07e77c",
+        "id": "3a12e68f-aba3-4d0d-9247-3017a319a058",
+        "partyId": "1216a88f-ee2a-420c-9e6a-ee34893c29cf",
+        "sampleUnitRef": "49900000004",
+        "sampleUnitType": "B"
+      },
+      "responses": [],
+      "caseEvents": "None"
+    },
+    "collection_exercise": {
+      "id": "14fb3e68-4dca-46db-bf49-04b84e07e77c",
+      "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
+      "name": "BRES_2017",
+      "actualExecutionDateTime": "2017-11-06T16:06:19.966+0000",
+      "scheduledExecutionDateTime": "2017-09-10T23:00:00.000+0000",
+      "scheduledStartDateTime": "2017-09-11T23:00:00.000+0000",
+      "actualPublishDateTime": "2017-11-06T16:08:26.100+0000",
+      "periodStartDateTime": "2017-09-14T23:00:00.000+0000",
+      "periodEndDateTime": "2017-09-15T22:59:59.000+0000",
+      "scheduledReturnDateTime": "2017-10-06T00:00:00.000+0000",
+      "scheduledEndDateTime": "2018-06-29T23:00:00.000+0000",
+      "executedBy": "None",
+      "state": "PUBLISHED",
+      "caseTypes": [
+        {
+          "actionPlanId": "e71002ac-3575-47eb-b87f-cd9db92bf9a7",
+          "sampleUnitType": "B"
+        }, {
+          "actionPlanId": "0009e978-0932-463b-a2a1-b45cb3ffcb2a",
+          "sampleUnitType": "BI"
+        }
+      ],
+      "exerciseRef": "221_201712",
+      "periodStartDateTimeFormatted": "14 Sep 2017",
+      "periodEndDateTimeFormatted": "15 Sep 2017",
+      "scheduledReturnDateTimeFormatted": "6 Oct 2017",
+      "userDescription": "December 2017"
+    },
+    "business_party": {
+      "associations": [
+        {
+          "enrolments": [
+            {
+              "enrolmentStatus": "ENABLED",
+              "name": "Business Register and Employment Survey",
+              "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
+            }
+          ],
+          "partyId": "07d672bc-497b-448f-a406-a20a7e6013d7"
+        }
+      ],
+      "id": "1216a88f-ee2a-420c-9e6a-ee34893c29cf",
+      "name": "RUNAME1_COMPANY4 RUNNAME2_COMPANY4",
+      "sampleUnitRef": "49900000004",
+      "sampleUnitType": "B"
+    },
+    "survey": {
+      "id": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
+      "shortName": "TEST",
+      "longName": "Test Survey",
+      "surveyRef": "221"
+    },
+    "collection_instrument_type": "SEFT",
+    "collection_instrument_size": 5302,
+    "status": "None"
+  }
+]


### PR DESCRIPTION
the survey is not Complete or there are no EQ_LAUNCH case events

This works for the positive case (when it's a Complete EQ survey).  I haven't been able to test it for the SEFT case (for some reason uploading a completed SEFT response is causing my docker frontstage to hang).  However I am off tomorrow (Tuesday 20/3) so I wanted to get the PR raised.   