### PR TITLE
Message from internal now has line breaks

### DIFF
--- a/frontstage/templates/secure-messages/thread-message.html
+++ b/frontstage/templates/secure-messages/thread-message.html
@@ -22,6 +22,6 @@
         </div>
 
         <br />
-        <p>{{ message['body'] }}</p>
+        <span style="white-space:pre-line">{{ message['body'] }}</span>
     </div>
 {% endif %}


### PR DESCRIPTION
Bug Fix:

When the external user looked at a message from the internal user, it would not add any line breaks for the message.

This fix just adds a span for the message body to allow line breaks