### PR TITLE
Catch status codes other then 200 in access survey

### DIFF
--- a/frontstage/views/surveys/access_survey.py
+++ b/frontstage/views/surveys/access_survey.py
@@ -29,6 +29,12 @@ def access_survey(session):
     if collection_instrument_type == 'EQ':
         logger.info('redirecting to EQ', party_id=party_id, case_id=case_id)
         response = api_call('GET', app.config['GENERATE_EQ_URL'], parameters=params)
+
+        if response.status_code != 200:
+            logger.error('Failed to retrieve EQ URL',
+                         party_id=party_id, case_id=case_id, status=response.status_code)
+            raise ApiError(response)
+
         eq_url = json.loads(response.text)['eq_url']
         return redirect(eq_url)
 

--- a/tests/app/test_surveys.py
+++ b/tests/app/test_surveys.py
@@ -126,8 +126,10 @@ class TestSurveys(unittest.TestCase):
     @requests_mock.mock()
     def test_access_survey_eq_forbidden(self, mock_request):
         mock_request.get(url_generate_eq_url, status_code=403)
-        response = self.app.get('/surveys/access_survey?case_id=b2457bd4-004d-42d1-a1c6-a514973d9ae5&ci_type=EQ')
-        self.assertEqual(response.status_code, 403)
+        response = self.app.get('/surveys/access_survey?case_id=b2457bd4-004d-42d1-a1c6-a514973d9ae5&ci_type=EQ', follow_redirects=True)
+
+        self.assertEqual(response.status_code, 500)
+        self.assertTrue('Server error'.encode() in response.data)
 
     @requests_mock.mock()
     def test_access_survey_title(self, mock_request):

--- a/tests/app/test_surveys.py
+++ b/tests/app/test_surveys.py
@@ -124,6 +124,12 @@ class TestSurveys(unittest.TestCase):
         self.assertTrue('http://test-eq-url/session?token=test'.encode() in response.data)
 
     @requests_mock.mock()
+    def test_access_survey_eq_forbidden(self, mock_request):
+        mock_request.get(url_generate_eq_url, status_code=403)
+        response = self.app.get('/surveys/access_survey?case_id=b2457bd4-004d-42d1-a1c6-a514973d9ae5&ci_type=EQ')
+        self.assertEqual(response.status_code, 403)
+
+    @requests_mock.mock()
     def test_access_survey_title(self, mock_request):
         mock_request.get(url_access_case, json=surveys_list_seft[1])
 


### PR DESCRIPTION
As part of defect-r-16-13-stop-mulitple-eq-access a 403 can now be return from frontstage-api. As there was no ability to catch anything other then a 200 I have added one in