### PR TITLE
Fixed read full message link

### DIFF
--- a/frontstage/templates/secure-messages/secure-messages.html
+++ b/frontstage/templates/secure-messages/secure-messages.html
@@ -106,17 +106,14 @@
         <a id="read-message-link-{{loop.index}}" href="{{ url_for('secure_message_bp.message_get', label='DRAFT', message_id=message['msg_id']) }}">
     {% elif 'SENT' in message['labels'] %}
         <a id="read-message-link-{{loop.index}}" href="{{ url_for('secure_message_bp.message_get', label='SENT', message_id=message['msg_id']) }}">
-    {% elif 'INBOX' in message['labels'] %}
-    {% if 'UNREAD' in message['labels'] %}
-        <b>
-    {% endif %}
+    {% elif 'UNREAD' in message['labels'] %}
+        <b><a id="read-message-link-{{loop.index}}" href="{{ url_for('secure_message_bp.message_get', label='UNREAD', message_id=message['msg_id']) }}"></b>
+    {% else %}
         <a id="read-message-link-{{loop.index}}" href="{{ url_for('secure_message_bp.message_get', label='INBOX', message_id=message['msg_id']) }}">
     {% endif %}
             Read full message<span class="u-vh"> with subject: {{ message['subject'] }}</span>
-    {% if 'UNREAD' in message['labels'] %}
-        </b>
-    {% endif %}
         </a>
+
 
 
     </li>


### PR DESCRIPTION
Bug fix:

On the messages page on frontstage, inbox counter would not update the message once the read full message link had been clicked.

fixed it by changing the label of the message once the link had been clicked.