### PR TITLE
add banner html and config flag

### DIFF
--- a/config.py
+++ b/config.py
@@ -20,6 +20,7 @@ class Config(object):
     GOOGLE_ANALYTICS = os.getenv('GOOGLE_ANALYTICS', None)
     SELENIUM_TEST_URL = os.environ.get('SELENIUM_TEST_URL', 'http://localhost:8080')
     NON_DEFAULT_VARIABLES = ['SECRET_KEY', 'SECURITY_USER_NAME', 'SECURITY_USER_PASSWORD', 'JWT_SECRET']
+    AVAILABILITY_BANNER = os.getenv('AVAILABILITY_BANNER', None)
 
     REDIS_HOST = os.getenv('REDIS_HOST', 'localhost')
     REDIS_PORT = os.getenv('REDIS_PORT', 6379)

--- a/frontstage/templates/sign-in/sign-in.html
+++ b/frontstage/templates/sign-in/sign-in.html
@@ -39,6 +39,17 @@
         <h1 class="saturn">You've activated your account</h1>
         <p>You may now sign in.</p>
         {% else %}
+
+        {% if config.AVAILABILITY_BANNER %}
+        <div class="panel panel--simple panel--error">
+            <h1>Service Availability</h1>
+            <p>Thank you for visiting the Office for National Statistics Secure Data Collection website.</p>
+            <p>We will be carrying out essential maintenance to the service on Friday 13th April 17:00 to Monday 16th April 08:30.
+               You are able to use the system and submit data during this period however your response status may not display as completed until after the maintenance has been completed.</p>
+        </div>
+        <br>
+        {% endif %}
+
         <p>New to this service?
            <a id="create-account" href="/register/create-account/">Create an account</a>
         </p>


### PR DESCRIPTION
This PR is to add a banner to the sign in page of frontstage to alert users of downtime to the service. This is enabled or disabled through a config flag and is needed for this weekend

https://trello.com/c/ZuZx85OD

![screen shot 2018-04-11 at 14 04 16](https://user-images.githubusercontent.com/16239750/38619284-bd483db6-3d93-11e8-8cfd-6224c29e5ae9.png)
