### PR TITLE
adding hash to symbols for password

### DIFF
--- a/frontstage/assets/js/modules/validators.spec.js
+++ b/frontstage/assets/js/modules/validators.spec.js
@@ -77,6 +77,9 @@ describe('validator [module]', () => {
 			expect(validateHasSymbol('.')).toBe(true);
 			expect(validateHasSymbol('/')).toBe(true);
 			expect(validateHasSymbol('#')).toBe(true);
+            expect(validateHasSymbol('@')).toBe(true);
+            expect(validateHasSymbol('€')).toBe(true);
+            expect(validateHasSymbol(' ')).toBe(true);
 		});
 
 		it('should return false when supplied a string without a symbol', () => {

--- a/frontstage/assets/js/modules/validators.spec.js
+++ b/frontstage/assets/js/modules/validators.spec.js
@@ -76,6 +76,7 @@ describe('validator [module]', () => {
 			expect(validateHasSymbol(',')).toBe(true);
 			expect(validateHasSymbol('.')).toBe(true);
 			expect(validateHasSymbol('/')).toBe(true);
+			expect(validateHasSymbol('#')).toBe(true);
 		});
 
 		it('should return false when supplied a string without a symbol', () => {

--- a/frontstage/static/js/bundle.js
+++ b/frontstage/static/js/bundle.js
@@ -8652,7 +8652,7 @@ function validateHasCapitalLetter(str) {
  * @returns {boolean}
  */
 function validateHasSymbol(str) {
-  return (/[-!$£%^&*()_+|~=`{}\[\]:";'<>?,.\/]/.test(str)
+  return (/[-!#$£%^&*()_+|~=`{}\[\]:";'<>?,.\/]/.test(str)
   );
 }
 

--- a/frontstage/static/js/bundle.js
+++ b/frontstage/static/js/bundle.js
@@ -8652,7 +8652,7 @@ function validateHasCapitalLetter(str) {
  * @returns {boolean}
  */
 function validateHasSymbol(str) {
-  return (/[-!#$£%^&*()_+|~=`{}\[\]:";'<>?,.\/]/.test(str)
+  return (/[-!#$£%^&*()_+|~=`{}\[\]@€:" ;'<>?,.\/]/.test(str)
   );
 }
 


### PR DESCRIPTION
Allowing the hash symbol to be accepted in the password to stop the client side error message appearing when a hash is entered in the password. This has now been extended to add other special characters that are missing.