### PR TITLE
Adding validation on email address for whitespace

### DIFF
--- a/frontstage/models.py
+++ b/frontstage/models.py
@@ -63,6 +63,14 @@ class RegistrationForm(FlaskForm):
             raise ValidationError('This should be a valid UK number e.g. 01632 496 0018. ')
 
     @staticmethod
+    def validate_email_address(form, field):
+        logger.debug('Checking if the email address contains a space')
+        # this extends the email validator to check if there is whitespace in the email
+        if " " in field.data:
+            logger.debug('Space found in email address')
+            raise ValidationError('The email address should not contain a space. ')
+
+    @staticmethod
     def validate_password(form, field):
         password = field.data
         if password.isalnum() or not any(char.isupper() for char in password) or not any(char.isdigit() for char in password):

--- a/frontstage/models.py
+++ b/frontstage/models.py
@@ -10,7 +10,6 @@ from wtforms.validators import InputRequired, EqualTo, Length, DataRequired, Ema
 
 from frontstage import app
 
-
 logger = wrap_logger(logging.getLogger(__name__))
 
 
@@ -68,7 +67,7 @@ class RegistrationForm(FlaskForm):
         # this extends the email validator to check if there is whitespace in the email
         if " " in field.data:
             logger.debug('Space found in email address')
-            raise ValidationError('The email address should not contain a space. ')
+            raise ValidationError("Your email should be of the form myname@email.com")
 
     @staticmethod
     def validate_password(form, field):

--- a/tests/app/test_registration.py
+++ b/tests/app/test_registration.py
@@ -151,6 +151,21 @@ class TestRegistration(unittest.TestCase):
         self.assertTrue('Enter your account details'.encode() in response.data)
 
     @requests_mock.mock()
+    def test_create_account_register_space_in_email_address(self, mock_object):
+        mock_object.post(url_validate_enrolment, status_code=200)
+        self.test_user['email_address'] = 'testuser 2@email.com'
+
+        response = self.app.post('/register/create-account/enter-account-details',
+                                 query_string=self.params,
+                                 data=self.test_user,
+                                 headers=self.headers,
+                                 follow_redirects=True)
+
+        self.assertEqual(response.status_code, 200)
+        print(response.data)
+        self.assertTrue("Your email should be of the form myname@email.com".encode() in response.data)
+
+    @requests_mock.mock()
     def test_create_account_register_no_password(self, mock_object):
         mock_object.post(url_validate_enrolment, status_code=200)
         del self.test_user['password']


### PR DESCRIPTION
When submitting an email address with whitespace in the account registration the application gives a 500 error. This PR adds validation to the email address to check if there is whitespace and gives an error to the user.