### PR TITLE
Fix secure message usage of requests session

### DIFF
--- a/frontstage/controllers/conversation_controller.py
+++ b/frontstage/controllers/conversation_controller.py
@@ -35,7 +35,7 @@ def get_conversation(thread_id):
 
     try:
         response.raise_for_status()
-    except RequestException:
+    except HTTPError:
         logger.exception("Thread retrieval failed", thread_id=thread_id)
         raise ApiError(response)
     logger.info("Thread retrieval successful", thread_id=thread_id)
@@ -58,7 +58,7 @@ def get_conversation_list():
 
     try:
         response.raise_for_status()
-    except RequestException:
+    except HTTPError:
         logger.exception("Threads retrieval failed")
         raise ApiError(response)
 
@@ -84,7 +84,7 @@ def send_message(message_json):
         response.raise_for_status()
         logger.info("Send message", party_id=party_id)
         return response.json()
-    except RequestException:
+    except HTTPError:
         logger.exception("Message sending failed due to API Error", party_id=party_id)
         raise ApiError(response)
 


### PR DESCRIPTION
# Background
ras-frontstage uses Session (http://docs.python-requests.org/en/master/user/advanced/) to get retry functionality if a HTTP request fails. When a Session is created the TCP connection is continued to be reused which leads to long running/open TCP connections. Cloundfoundry may do some housekeeping and close long running TCP connections incase they are connection that haven't correctly been closed. If that connection is closed it should reconnect but we're not experiencing this behaviour gracefully when running the services in CF. (https://docs.cloudfoundry.org/services/route-services.html)

All of the above was causing us to experience 500 errors occasionally when sending messages.

# Whats changed
Instead of creating one session at the beginning when the application starts we will now create a new session for each request.

# How to review/test
* Existing tests should pass
* Deploy this branch to cloudfoundry and check no 500 errors occur. I have tested this re-running the same test for over and hour without failure
* Deploy this branch to cloudfoundry and kicked off the secure message acceptance tests builds 12-31 to check the stability of the tests with an audit