### PR TITLE
Port missing api eq functionality

### DIFF
--- a/frontstage/common/eq_payload.py
+++ b/frontstage/common/eq_payload.py
@@ -90,7 +90,7 @@ class EqPayload(object):
         collex_events = collection_exercise_controller.get_collection_exercise_events(collex_id)
         return {
              "ref_p_start_date": self._find_event_date_by_tag('ref_period_start', collex_events, collex_id),
-             "ref_p_end_date": self._find_event_date_by_tag('exercise_end', collex_events, collex_id),
+             "ref_p_end_date": self._find_event_date_by_tag('ref_period_end', collex_events, collex_id),
              "return_by": self._find_event_date_by_tag('return_by', collex_events, collex_id)
         }
 

--- a/frontstage/common/eq_payload.py
+++ b/frontstage/common/eq_payload.py
@@ -57,7 +57,7 @@ class EqPayload(object):
         iat = time.time()
         exp = time.time() + (5 * 60)
 
-        return {
+        payload = {
             'jti': str(uuid.uuid4()),
             'tx_id': tx_id,
             'user_id': case['partyId'],
@@ -68,17 +68,21 @@ class EqPayload(object):
             'period_id': collex['exerciseRef'],
             'form_type': form_type,
             'collection_exercise_sid': collex['id'],
-            'ref_p_start_date': collex_event_dates['ref_p_start_date'],
-            'ref_p_end_date': collex_event_dates['ref_p_end_date'],
             'ru_ref': party['sampleUnitRef'] + party['checkletter'],
             'ru_name': party['name'],
-            'return_by': collex_event_dates['return_by'],
             'survey_id': survey['surveyRef'],
             'case_id': case['id'],
             'case_ref': case['caseRef'],
             'account_service_url': account_service_url,
             'trad_as': f"{party['tradstyle1']} {party['tradstyle2']} {party['tradstyle3']}"
         }
+
+        # Add any non null event dates that exist for this collection exercise
+        payload.update([(key, value) for key, value in collex_event_dates.items() if value is not None])
+
+        logger.debug(payload=payload)
+
+        return payload
 
     def _get_collex_event_dates(self, collex_id):
         """
@@ -89,23 +93,28 @@ class EqPayload(object):
 
         collex_events = collection_exercise_controller.get_collection_exercise_events(collex_id)
         return {
-             "ref_p_start_date": self._find_event_date_by_tag('ref_period_start', collex_events, collex_id),
-             "ref_p_end_date": self._find_event_date_by_tag('ref_period_end', collex_events, collex_id),
-             "return_by": self._find_event_date_by_tag('return_by', collex_events, collex_id)
+             "ref_p_start_date": self._find_event_date_by_tag('ref_period_start', collex_events, collex_id, True),
+             "ref_p_end_date": self._find_event_date_by_tag('ref_period_end', collex_events, collex_id, True),
+             "employment_date": self._find_event_date_by_tag('employment', collex_events, collex_id, False),
+             "return_by": self._find_event_date_by_tag('return_by', collex_events, collex_id, True),
         }
 
-    def _find_event_date_by_tag(self, search_param, collex_events, collex_id):
+    def _find_event_date_by_tag(self, search_param, collex_events, collex_id, mandatory):
         """
         Finds the required date from the list of all the events
         :param search_param: the string name of the date searching for
         :param collex_events: All the Collection Exercise dates
+        :param mandatory: Specifies if the event date being searched for is mandatory
         :return exercise
+        :raises InvalidEqPayLoad if a mandatory event tag is not found in the collectionexercise events
         """
 
         for event in collex_events:
             if event['tag'] == search_param and event.get('timestamp'):
                 return self._format_string_long_date_time_to_short_date(event['timestamp'])
-        raise InvalidEqPayLoad(f'Event not found for collection {collex_id} for search param {search_param}')
+
+        if mandatory:
+            raise InvalidEqPayLoad(f'Mandatory event not found for collection {collex_id} for search param {search_param}')
 
     @staticmethod
     def _format_string_long_date_time_to_short_date(string_date):

--- a/tests/app/test_generate_eq.py
+++ b/tests/app/test_generate_eq.py
@@ -155,13 +155,44 @@ class TestGenerateEqURL(unittest.TestCase):
         result = EqPayload()._format_string_long_date_time_to_short_date(date)
         self.assertEqual(result, '2007-01-25')
 
-    def test_generate_eq_url_missing_event_date(self):
+    def test_generate_eq_url_missing_mandatory_event_date(self):
 
-        # Given no event dates
-        collex_events_dates = []
+        # Given a mandatory event date does not exist
+        collex_events_dates = [{'id': 'e82e7ec9-b14e-412c-813e-edfd2e03e773',
+                                'collectionExerciseId': '8d926ae3-fb3c-4c25-9f0f-356ded7d1ac0',
+                                'tag': 'return_by', 'timestamp': '2018-03-27T01:00:00.000+01:00'},
+                               {'id': '8a24731e-3d79-4f3c-b6eb-3b199f53694f',
+                                'collectionExerciseId': '8d926ae3-fb3c-4c25-9f0f-356ded7d1ac0',
+                                'tag': 'reminder', 'timestamp': '2018-04-03T01:00:00.000+01:00'}]
+
         # When find_event_date_by_tag is called with a search param
         # Then an InvalidEqPayLoad is raised
 
         with self.assertRaises(InvalidEqPayLoad) as e:
-            EqPayload()._find_event_date_by_tag('return by', collex_events_dates, '123')
-        self.assertEqual(e.exception.message, 'Event not found for collection 123 for search param return by')
+            EqPayload()._find_event_date_by_tag('return by', collex_events_dates, '123', True)
+        self.assertEqual(e.exception.message, 'Mandatory event not found for collection 123 for search param return by')
+
+    def test_generate_eq_url_non_mandatory_event_date_is_none(self):
+
+        # Given a non mandatory event date does not exist
+        collex_events_dates = []
+        # When find_event_date_by_tag is called with a search param
+        # Then a None response is returned and no exception is raised
+
+        response = EqPayload()._find_event_date_by_tag('employment', collex_events_dates, '123', False)
+        self.assertEqual(response, None)
+
+    def test_generate_eq_url_non_mandatory_event_date_is_returned(self):
+
+        # Given a non mandatory event date exists
+        collex_events_dates = [{'id': 'e82e7ec9-b14e-412c-813e-edfd2e03e773',
+                                'collectionExerciseId': '8d926ae3-fb3c-4c25-9f0f-356ded7d1ac0',
+                                'tag': 'return_by', 'timestamp': '2018-03-27T01:00:00.000+01:00'},
+                               {'id': '8a24731e-3d79-4f3c-b6eb-3b199f53694f',
+                                'collectionExerciseId': '8d926ae3-fb3c-4c25-9f0f-356ded7d1ac0',
+                                'tag': 'employment', 'timestamp': '2018-04-03T01:00:00.000+01:00'}]
+        # When find_event_date_by_tag is called with a search param
+        # Then the formatted date is returned
+
+        response = EqPayload()._find_event_date_by_tag('employment', collex_events_dates, '123', False)
+        self.assertEqual(response, '2018-04-03')

--- a/tests/test_data/collection_exercise/collection_exercise_events.json
+++ b/tests/test_data/collection_exercise/collection_exercise_events.json
@@ -14,7 +14,7 @@
     {
     "id": "db4bf724-cec8-4114-866d-06443efbb1cb",
     "collectionExerciseId": "df634637-2aac-487f-9d2f-eb56615ed80e",
-    "tag": "exercise_end",
+    "tag": "ref_period_end",
     "timestamp": "2020-05-31T00:00:00.000Z"
     }
 ]


### PR DESCRIPTION
# Motivation and Context
Some of the last changes added into https://github.com/ONSdigital/ras-frontstage-api were missed off and not ported into this code base in #333. This PR brings those orphaned changes in.

# What has changed
Ported changes from:
- ONSdigital/ras-frontstage-api#66
- ONSdigital/ras-frontstage-api#67

# How to test?
Follow the PR's listed above for further information, run the tests, and check that the code does what it says on the tin.