### PR TITLE
Performance improvement 650 concurrency

### DIFF
--- a/gunicorn.py
+++ b/gunicorn.py
@@ -67,10 +67,10 @@ backlog = 2048
 #       A positive integer. Generally set in the 1-5 seconds range.
 #
 
-workers = 4
+workers = 8
 worker_class = 'sync'
 worker_connections = 1000
-timeout = 120
+timeout = 30
 keepalive = 2
 
 #


### PR DESCRIPTION
# Motivation and Context
Performance Improvement

# What has changed
- Change Gunicorn `sync` workers from 4 to 8.
- Requires 512M instance on cloud foundry environments. 
- Changing worker timeout to 30s.

# How to test?
Has been load tested in Prunes. Just check the deployment pipeline is green after changes are merged to `master`.

# Links
NA

# Screenshots (if appropriate):
