### PR TITLE
Output time to match BST timezone in secure message

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -139,9 +139,9 @@
         },
         "furl": {
             "hashes": [
-                "sha256:6bb7d9ed238a0104db3a638307be7abc35ec989d883f5882e01cb000b9bdbc32"
+                "sha256:47b25a4c4e48d926c399a5538466134fc7aed8b357a6290dcb83e3a1b9f3aa29"
             ],
-            "version": "==1.0.1"
+            "version": "==1.1"
         },
         "future": {
             "hashes": [
@@ -201,9 +201,9 @@
         },
         "orderedmultidict": {
             "hashes": [
-                "sha256:dc2320ca694d90dca4ecc8b9c5fdf71ca61d6c079d6feb085ef8d41585419a36"
+                "sha256:b89895ba6438038d0bdf88020ceff876cf3eae0d5c66a69b526fab31125db2c5"
             ],
-            "version": "==0.7.11"
+            "version": "==1.0"
         },
         "phonenumbers": {
             "hashes": [
@@ -315,9 +315,10 @@
         },
         "wtforms": {
             "hashes": [
-                "sha256:ffdf10bd1fa565b8233380cb77a304cd36fd55c73023e91d4b803c96bc11d46f"
+                "sha256:0cdbac3e7f6878086c334aa25dc5a33869a3954e9d1e015130d65a69309b3b61",
+                "sha256:e3ee092c827582c50877cdbd49e9ce6d2c5c1f6561f849b3b068c1b8029626f1"
             ],
-            "version": "==2.1"
+            "version": "==2.2.1"
         }
     },
     "develop": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -139,9 +139,9 @@
         },
         "furl": {
             "hashes": [
-                "sha256:47b25a4c4e48d926c399a5538466134fc7aed8b357a6290dcb83e3a1b9f3aa29"
+                "sha256:6bb7d9ed238a0104db3a638307be7abc35ec989d883f5882e01cb000b9bdbc32"
             ],
-            "version": "==1.1"
+            "version": "==1.0.1"
         },
         "future": {
             "hashes": [
@@ -201,9 +201,9 @@
         },
         "orderedmultidict": {
             "hashes": [
-                "sha256:b89895ba6438038d0bdf88020ceff876cf3eae0d5c66a69b526fab31125db2c5"
+                "sha256:dc2320ca694d90dca4ecc8b9c5fdf71ca61d6c079d6feb085ef8d41585419a36"
             ],
-            "version": "==1.0"
+            "version": "==0.7.11"
         },
         "phonenumbers": {
             "hashes": [
@@ -315,10 +315,9 @@
         },
         "wtforms": {
             "hashes": [
-                "sha256:0cdbac3e7f6878086c334aa25dc5a33869a3954e9d1e015130d65a69309b3b61",
-                "sha256:e3ee092c827582c50877cdbd49e9ce6d2c5c1f6561f849b3b068c1b8029626f1"
+                "sha256:ffdf10bd1fa565b8233380cb77a304cd36fd55c73023e91d4b803c96bc11d46f"
             ],
-            "version": "==2.2.1"
+            "version": "==2.1"
         }
     },
     "develop": {

--- a/frontstage/common/message_helper.py
+++ b/frontstage/common/message_helper.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime, date
+from dateutil.tz import tz
 
 from structlog import wrap_logger
 
@@ -74,10 +75,19 @@ def get_formatted_date(datetime_string, string_format='%Y-%m-%d %H:%M:%S'):
         logger.exception("Failed to parse date", sent_date=datetime_string)
         return datetime_string
 
-    time_difference = datetime.date(datetime_parsed) - date.today()
+    time_difference = datetime_parsed.date() - date.today()
+
+    time = convert_to_bst(datetime_parsed).strftime('%H:%M')
 
     if time_difference.days == 0:
-        return "Today at {}".format(datetime_parsed.strftime('%H:%M'))
+        return "Today at {}".format(time)
     elif time_difference.days == -1:
-        return "Yesterday at {}".format(datetime_parsed.strftime('%H:%M'))
-    return "{} {}".format(datetime_parsed.strftime('%d %b %Y').title(), datetime_parsed.strftime('%H:%M'))
+        return "Yesterday at {}".format(time)
+    return "{} {}".format(datetime_parsed.strftime('%d %b %Y'), time)
+
+
+def convert_to_bst(datetime_parsed):
+    """Takes a datetime and adjusts based on BST or GMT.
+    Returns adjusted datetime
+    """
+    return datetime_parsed.replace(tzinfo=tz.gettz('UTC')).astimezone(tz.gettz('Europe/London'))

--- a/frontstage/controllers/party_controller.py
+++ b/frontstage/controllers/party_controller.py
@@ -59,7 +59,7 @@ def create_account(registration_data):
         if response.status_code == 400:
             message = 'Email has already been used'
         else:
-            message = 'Failed to create account',
+            message = 'Failed to create account'
         raise ApiError(logger, response,
                        log_level='debug' if response.status_code == 400 else 'error',
                        message=message)

--- a/tests/app/test_jwt_authorization.py
+++ b/tests/app/test_jwt_authorization.py
@@ -48,13 +48,13 @@ class TestJWTAuthorization(unittest.TestCase):
         # If this function runs without exceptions the test is considered passed
         self.decorator_test(request)
 
-    def test_jwt_authorization_no_JWT(self):
+    def test_jwt_authorization_no_jwt(self):
         request = mock.MagicMock()
 
         with self.assertRaises(JWTValidationError):
             self.decorator_test(request)
 
-    def test_jwt_authorization_expired_JWT(self):
+    def test_jwt_authorization_expired_jwt(self):
         self.session.create_session(expired_jwt)
         request = mock.MagicMock(cookies={"authorization": self.session.session_key})
 

--- a/tests/app/test_message_helper.py
+++ b/tests/app/test_message_helper.py
@@ -1,14 +1,16 @@
 import unittest
 import json
 
-from datetime import datetime, timedelta
-from frontstage.common.message_helper import refine, get_formatted_date
+from datetime import datetime, timedelta, timezone, date
+from unittest.mock import patch
+
+from frontstage.common.message_helper import refine, get_formatted_date, convert_to_bst
 
 with open('tests/test_data/conversation.json') as json_data:
     test_data = json.load(json_data)
 
 refined_data = {"subject": "testy2", "survey_id": "02b9c366-7397-42f7-942a-76dc5876d86d", "thread_id": "9e3465c0-9172-4974-a7d1-3a01592d1594",
-                "from": "Peter Griffin", "ru_ref": "e359b838-0d89-43e8-b5d0-68079916de80", "sent_date": "02 Apr 2018 09:27",
+                "from": "Peter Griffin", "ru_ref": "e359b838-0d89-43e8-b5d0-68079916de80", "sent_date": "02 Apr 2018 10:27",
                 "body": "something else", "message_id": "2ac51b39-a0d7-465d-92a4-263dfe3eb475", "unread": False}
 
 
@@ -18,35 +20,32 @@ class TestMessageHelper(unittest.TestCase):
         test_copy = test_data.copy()
         test_copy['from_internal'] = True
         refined_data_copy = refined_data.copy()
-        refined_data_copy['from'] = "ONS Business Surveys Team"
+        refined_data_copy['from'] = 'ONS Business Surveys Team'
         refined_message = refine(test_copy)
         self.assertEqual(refined_message, refined_data_copy)
 
     def test_get_formatted_date_incorrect_date(self):
-        date_str = "018-04-04 09:27:11.354399"
+        date_str = '018-04-04 09:27:11.354399'
         refined_date = get_formatted_date(date_str)
-        self.assertEqual(refined_date, "018-04-04 09:27:11.354399")
+        self.assertEqual(refined_date, '018-04-04 09:27:11.354399')
 
     def test_get_formatted_date_today_date(self):
-        today_date_str = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-        today_time_str = datetime.now().strftime('%H:%M')
-        refined_date = get_formatted_date(today_date_str)
-        self.assertEqual(refined_date, "Today at " + today_time_str)
+        with patch('frontstage.common.message_helper.date') as mock_date:
+            mock_date.today.return_value = date(2018, 6, 12)
+            today_example_date = get_formatted_date('2018-06-12 14:15:12')
+            self.assertEqual(today_example_date, 'Today at 15:15')
 
     def test_get_formatted_date_yesterday_date(self):
-        yesterday_date = datetime.now() - timedelta(1)
-        yesterday_date_str = yesterday_date.strftime('%Y-%m-%d %H:%M:%S')
-        yesterday_time_str = datetime.now().strftime('%H:%M')
-        refined_date = get_formatted_date(yesterday_date_str)
-        self.assertEqual(refined_date, "Yesterday at " + yesterday_time_str)
+        with patch('frontstage.common.message_helper.date') as mock_date:
+            mock_date.today.return_value = date(2018, 2, 12)
+            yesterday_example_date = get_formatted_date('2018-02-11 14:15:12')
+            self.assertEqual(yesterday_example_date, 'Yesterday at 14:15')
 
     def test_get_formatted_date_multiple_days_ago(self):
         # 2 days ago
-        past_date = datetime.now() - timedelta(2)
-        past_date_str = past_date.strftime('%Y-%m-%d %H:%M:%S')
-        refined_past_date = past_date.strftime('%d %b %Y %H:%M')
-        refined_date = get_formatted_date(past_date_str)
-        self.assertEqual(refined_date, refined_past_date)
+        past_date = datetime(2018, 2, 13, 10, 15, 15) - timedelta(2)
+        formatted_date = get_formatted_date(past_date.strftime('%Y-%m-%d %H:%M:%S'))
+        self.assertEqual(formatted_date, '11 Feb 2018 10:15')
 
     def test_missing_date(self):
         test_copy = test_data.copy()
@@ -77,3 +76,17 @@ class TestMessageHelper(unittest.TestCase):
     def test_refine(self):
         refined_message = refine(test_data)
         self.assertEqual(refined_message, refined_data)
+
+    def test_convert_to_bst_from_utc_during_bst(self):
+        # 13th Jun 2018 at 14.12 should return 13th Jun 2018 at 15.12
+        datetime_parsed = datetime(2018, 6, 13, 14, 12, 0, tzinfo=timezone.utc)
+        returned_datetime = convert_to_bst(datetime_parsed)
+        # Check date returned is in BST format
+        self.assertEqual(datetime.strftime(returned_datetime, '%Y-%m-%d %H:%M:%S'), '2018-06-13 15:12:00')
+
+    def test_convert_to_bst_from_utc_during_gmt(self):
+        # 13th Feb 2018 at 14.12 should return 13th Feb 2018 at 14.12
+        datetime_parsed = datetime(2018, 2, 13, 14, 12, 0, tzinfo=timezone.utc)
+        returned_datetime = convert_to_bst(datetime_parsed)
+        # Check date returned is in BST format
+        self.assertEqual(datetime.strftime(returned_datetime, '%Y-%m-%d %H:%M:%S'), '2018-02-13 14:12:00')


### PR DESCRIPTION
# Motivation and Context
The Business have been informed that the time stamp for secure messaging doesn't reflect BST.

# What has changed
Time displayed for users in secure message is BST

# How to test?
Run RAS/RM, send a message to an internal user, the message should display the correct time
