### PR TITLE
Add validation for enrolment code length

### DIFF
--- a/frontstage/models.py
+++ b/frontstage/models.py
@@ -14,35 +14,37 @@ logger = wrap_logger(logging.getLogger(__name__))
 
 
 class EnrolmentCodeForm(FlaskForm):
-    enrolment_code = StringField('Enrolment Code', [InputRequired(), Length(min=12, max=12,
-                                                                            message='Your code must be 12 characters')])
+    enrolment_code = StringField('Enrolment Code', [InputRequired(), Length(min=12,
+                                                                            max=12,
+                                                                            message='Please re-enter '
+                                                                                    'the code and try again')])
 
 
 class RegistrationForm(FlaskForm):
     first_name = StringField('First name',
-                             validators=[InputRequired("First name is required"),
+                             validators=[InputRequired('First name is required'),
                                          Length(max=254,
                                                 message='Your first name must be less than 254 characters')])
     last_name = StringField('Last name',
-                            validators=[InputRequired("Last name is required"),
+                            validators=[InputRequired('Last name is required'),
                                         Length(max=254, message='Your last name must be less than 254 characters')])
     email_address = StringField('Enter your email address',
-                                validators=[InputRequired("Email address is required"),
+                                validators=[InputRequired('Email address is required'),
                                             Email(message="Your email should be of the form 'myname@email.com' "),
                                             Length(max=254,
                                                    message='Your email must be less than 254 characters')])
     password = PasswordField('Create a password',
-                             validators=[DataRequired("Password is required"),
+                             validators=[DataRequired('Password is required'),
                                          EqualTo('password_confirm', message=app.config['PASSWORD_MATCH_ERROR_TEXT']),
                                          Length(min=app.config['PASSWORD_MIN_LENGTH'],
                                                 max=app.config['PASSWORD_MAX_LENGTH'],
                                                 message=app.config['PASSWORD_CRITERIA_ERROR_TEXT'])])
     password_confirm = PasswordField('Re-type your password')
     phone_number = StringField('Enter your phone number',
-                               validators=[DataRequired("Phone number is required"),
+                               validators=[DataRequired('Phone number is required'),
                                            Length(min=9,
                                                   max=15,
-                                                  message="This should be a valid phone number between 9 and 15 digits")],
+                                                  message='This should be a valid phone number between 9 and 15 digits')],
                                default=None)
     enrolment_code = HiddenField('Enrolment Code')
 
@@ -50,7 +52,7 @@ class RegistrationForm(FlaskForm):
     def validate_phone_number(form, field):
         try:
             logger.debug('Checking this is a valid GB phone number')
-            input_number = phonenumbers.parse(field.data, "GB")  # Tell the parser we are looking for a GB number
+            input_number = phonenumbers.parse(field.data, 'GB')  # Tell the parser we are looking for a GB number
 
             if not phonenumbers.is_possible_number(input_number):
                 raise ValidationError('This should be a valid phone number between 9 and 15 digits')
@@ -65,9 +67,9 @@ class RegistrationForm(FlaskForm):
     def validate_email_address(form, field):
         logger.debug('Checking if the email address contains a space')
         # this extends the email validator to check if there is whitespace in the email
-        if " " in field.data:
+        if ' ' in field.data:
             logger.debug('Space found in email address')
-            raise ValidationError("Your email should be of the form myname@email.com")
+            raise ValidationError('Your email should be of the form myname@email.com')
 
     @staticmethod
     def validate_password(form, field):
@@ -77,14 +79,14 @@ class RegistrationForm(FlaskForm):
 
 
 class LoginForm(FlaskForm):
-    username = StringField('Email Address', [InputRequired("Email Address is required"),
+    username = StringField('Email Address', [InputRequired('Email Address is required'),
                                              Email("Your email should be of the form 'myname@email.com' ")])
-    password = PasswordField('Password', [InputRequired("Password is required")])
+    password = PasswordField('Password', [InputRequired('Password is required')])
 
 
 class ForgotPasswordForm(FlaskForm):
     email_address = StringField('Enter your email address',
-                                validators=[InputRequired("Email address is required"),
+                                validators=[InputRequired('Email address is required'),
                                             Email(message="Your email should be of the form 'myname@email.com' "),
                                             Length(max=254,
                                                    message='Your email must be less than 254 characters')])
@@ -92,7 +94,7 @@ class ForgotPasswordForm(FlaskForm):
 
 class ResetPasswordForm(FlaskForm):
     password = PasswordField('New password',
-                             validators=[DataRequired("Password is required"),
+                             validators=[DataRequired('Password is required'),
                                          EqualTo('password_confirm', message=app.config['PASSWORD_MATCH_ERROR_TEXT']),
                                          Length(min=app.config['PASSWORD_MIN_LENGTH'],
                                                 max=app.config['PASSWORD_MAX_LENGTH'],

--- a/frontstage/templates/errors/validation_error.html
+++ b/frontstage/templates/errors/validation_error.html
@@ -1,0 +1,13 @@
+{% block main %}
+
+<div class="panel panel--error">
+    <div class="panel__header">
+        <h1 class="panel__title venus">{{ panel_title }}</h1>
+    </div>
+    <div class="panel__body" data-qa="error-body">
+        <p class="mars"><a onclick="focusOn({{ focus_on }});" href="#enrolment_code">{{ error_message }}</a></p>
+    </div>
+</div>
+<br/>
+
+{% endblock main %}

--- a/frontstage/templates/errors/validation_error.html
+++ b/frontstage/templates/errors/validation_error.html
@@ -5,7 +5,7 @@
         <h1 class="panel__title venus">{{ panel_title }}</h1>
     </div>
     <div class="panel__body" data-qa="error-body">
-        <p class="mars"><a onclick="focusOn({{ focus_on }});" href="#enrolment_code">{{ error_message }}</a></p>
+        <p class="mars"><a onclick="focusOn({{ focus_on }});" href="{{ context }}">{{ error_message }}</a></p>
     </div>
 </div>
 <br/>

--- a/frontstage/templates/register/register.enter-enrolment-code.html
+++ b/frontstage/templates/register/register.enter-enrolment-code.html
@@ -9,11 +9,13 @@
 {% block main %}
 
 {% if errorType == "failed" %}
-    {% with panel_title='Enrolment code not valid', forcus_on='enrolment_code', error_message='Please re-enter the code and try again' %}
+    {% with panel_title='Enrolment code not valid', forcus_on='enrolment_code', context='#enrolment_code',
+    error_message='Please re-enter the code and try again' %}
         {% include './errors/validation_error.html' %}
     {%  endwith %}
 {% elif errors %}
-    {% with panel_title='Enrolment code not valid', focus_on='enrolment_code', error_message=errors.enrolment_code[0] %}
+    {% with panel_title='Enrolment code not valid', focus_on='enrolment_code', context='#enrolment_code',
+    error_message=errors.enrolment_code[0] %}
         {% include './errors/validation_error.html' %}
     {%  endwith %}
 {% endif %}

--- a/frontstage/templates/register/register.enter-enrolment-code.html
+++ b/frontstage/templates/register/register.enter-enrolment-code.html
@@ -1,22 +1,21 @@
+{% extends 'layouts/_twocol.html' %}
 {% import 'partials/section.html' as section %}
-{% extends "layouts/_twocol.html" %}
 
 {% set errorType = data['error']['type'] %}
+{% set errors = form['errors'] %}
 
 {% block page_title %}Create an account - ONS Business Surveys{% endblock %}
 
 {% block main %}
 
 {% if errorType == "failed" %}
-<div class="panel panel--error">
-    <div class="panel__header">
-        <h1 class="panel__title venus">Enrolment code not valid</h1>
-    </div>
-    <div class="panel__body" data-qa="error-body">
-        <p class="mars"><a onclick="focusOn('enrolment_code');" href="#enrolment_code">Please re-enter the code and try again</a></p>
-    </div>
-</div>
-<br/>
+    {% with panel_title='Enrolment code not valid', forcus_on='enrolment_code', error_message='Please re-enter the code and try again' %}
+        {% include './errors/validation_error.html' %}
+    {%  endwith %}
+{% elif errors %}
+    {% with panel_title='Enrolment code not valid', focus_on='enrolment_code', error_message=errors.enrolment_code[0] %}
+        {% include './errors/validation_error.html' %}
+    {%  endwith %}
 {% endif %}
 
 <section>
@@ -30,7 +29,7 @@
 
         <h1 class="saturn">Create an account</h1>
 
-        {% if errorType == "failed" %}
+        {% if errorType == "failed" or errors|length > 0 %}
         <div class="panel panel--simple panel--error panel--spacious">
             <p class="error-message">Please enter a valid enrolment code</p>
         {% endif %}
@@ -43,7 +42,7 @@
                 {{ form.enrolment_code(class_='input input--text input-type__input') }}
             </div>
 
-        {% if errorType == "failed" %}
+        {% if errorType == "failed" or errors|length > 0 %}
         </div>
         {% endif %}
 

--- a/frontstage/views/register/create_account.py
+++ b/frontstage/views/register/create_account.py
@@ -18,10 +18,12 @@ logger = wrap_logger(logging.getLogger(__name__))
 def register():
     cryptographer = Cryptographer()
     form = EnrolmentCodeForm(request.form)
+    if form.enrolment_code.data:
+        form.enrolment_code.data = form.enrolment_code.data.strip()
 
     if request.method == 'POST' and form.validate():
         logger.info('Enrolment code submitted')
-        enrolment_code = request.form.get('enrolment_code', '').lower()
+        enrolment_code = form.enrolment_code.data.lower()
 
         # Validate the enrolment code
         try:


### PR DESCRIPTION
# Motivation and Context
Currently when a user enters an enrolment code longer or shorter than 12 character, nothing happens. This introduces validation on that error. Also we were counting leading/trailing white spaces as characters, so this PR stops that also.

# How to test?
Run Frontstage enter an enrolment code too long/short and view validation error, try with spaces they shouldn't count

