### PR TITLE
Update confirm organisation page to display RU trading name if present

### DIFF
--- a/frontstage/error_handlers.py
+++ b/frontstage/error_handlers.py
@@ -47,7 +47,8 @@ def jwt_validation_error(error):  # pylint: disable=unused-argument
 
 @app.errorhandler(Exception)
 def server_error(error):  # pylint: disable=unused-argument
-    logger.exception('Generic exception generated', exception=error)
+    logger.exception('Generic exception generated', exc_info=error)
+
     return redirect(url_for('error_bp.server_error_page',
                             _external=True,
                             _scheme=getenv('SCHEME', 'http')))

--- a/frontstage/templates/partials/business_survey_credentials.html
+++ b/frontstage/templates/partials/business_survey_credentials.html
@@ -1,0 +1,14 @@
+<div class="grid">
+    <div class="grid__col col-4@m">Enrolment code:</div>
+    <div class="grid__col col-8@m"><strong>{{ context.enrolment_code }}</strong></div>
+    <div class="grid__col col-4@m">Organisation:</div>
+    <div class="grid__col col-8@m"><strong>{{ context.organisation }}</strong></div>
+
+    {% if context.trading_as %}
+        <div class="grid__col col-4@m">Trading as:</div>
+        <div class="grid__col col-8@m"><strong>{{ context.trading_as }}</strong></div>
+    {% endif %}
+
+    <div class="grid__col col-4@m">Survey to complete:</div>
+    <div class="grid__col col-8@m"><strong>{{ context.survey_name }}</strong></div>
+</div>

--- a/frontstage/templates/register/register.confirm-organisation-survey.html
+++ b/frontstage/templates/register/register.confirm-organisation-survey.html
@@ -7,14 +7,7 @@
 
 <h1 class="saturn">Confirm organisation and survey details</h1>
 
-<div class="grid">
-    <div class="grid__col col-4@m">Enrolment code:</div>
-    <div class="grid__col col-8@m"><strong>{{ enrolment_code }}</strong></div>
-    <div class="grid__col col-4@m">Organisation:</div>
-    <div class="grid__col col-8@m"><strong>{{ organisation_name }}</strong></div>
-    <div class="grid__col col-4@m">Survey to complete:</div>
-    <div class="grid__col col-8@m"><strong>{{ survey_name }}</strong></div>
-</div>
+ {% include('partials/business_survey_credentials.html') %}
 
 <br/>
 
@@ -23,7 +16,8 @@
 </a>
 
 <p>If the organisation or survey details aren't what you were expecting, please contact us on <a class="nowrap" href="tel:+44-300-1234-931">0300 1234 931</a>
-    or send an email to <a href="mailto:surveys@ons.gov.uk">surveys@ons.gov.uk</a>
-</p>
+    or send an <br/>
+    email to <a href="mailto:surveys@ons.gov.uk">surveys@ons.gov.uk</a>
+    </p>
 
 {% endblock main %}

--- a/frontstage/templates/surveys/surveys-confirm-organisation.html
+++ b/frontstage/templates/surveys/surveys-confirm-organisation.html
@@ -7,14 +7,7 @@
 
 <h1 id="confirm-org-title" class="saturn">Confirm organisation and survey details</h1>
 
-<div class="grid">
-    <div class="grid__col col-4@m">Enrolment code:</div>
-    <div class="grid__col col-8@m"><strong>{{ enrolment_code }}</strong></div>
-    <div class="grid__col col-4@m">Organisation:</div>
-    <div class="grid__col col-8@m"><strong>{{ organisation_name }}</strong></div>
-    <div class="grid__col col-4@m">Survey to complete:</div>
-    <div class="grid__col col-8@m"><strong>{{ survey_name }}</strong></div>
-</div>
+ {% include('partials/business_survey_credentials.html') %}
 
 <br/>
 
@@ -25,7 +18,9 @@
   <a id="CANCEL_BTN" href="{{ url_for('surveys_bp.logged_in') }}">Cancel</a>
 </p>
 <p>If the organisation or survey details aren't what you were expecting, please contact us on <a class="nowrap" href="tel:+44-300-1234-931">0300 1234 931</a>
-    or send an email to <a href="mailto:surveys@ons.gov.uk">surveys@ons.gov.uk</a>
+    or send an <br/>
+    email to <a href="mailto:surveys@ons.gov.uk">surveys@ons.gov.uk</a>
+    </p>
 </p>
 
 {% endblock main %}

--- a/frontstage/views/register/confirm_organisation_survey.py
+++ b/frontstage/views/register/confirm_organisation_survey.py
@@ -27,7 +27,7 @@ def register_confirm_organisation_survey():
         # Get organisation name
         case = case_controller.get_case_by_enrolment_code(enrolment_code)
         business_party_id = case['caseGroup']['partyId']
-        organisation_name = party_controller.get_party_by_business_id(business_party_id).get('name')
+        business_party = party_controller.get_party_by_business_id(business_party_id)
 
         # Get survey name
         collection_exercise_id = case['caseGroup']['collectionExerciseId']
@@ -38,8 +38,22 @@ def register_confirm_organisation_survey():
         logger.error('Failed to retrieve data for confirm organisation/survey page', status_code=exc.status_code)
         raise
 
-    logger.info('Successfully retrieved data for confirm organisation/survey page')
+    business_context = {
+        'enrolment_code': enrolment_code,
+        'case': case,
+        'trading_as': business_party.get('trading_as'),
+        'organisation': business_party.get('name'),
+        'collection_exercise_id': collection_exercise_id,
+        'survey_id': collection_exercise,
+        'survey_name': survey_name,
+    }
+
+    logger.info('Successfully retrieved data for confirm organisation/survey page',
+                collection_exercise_id=collection_exercise_id,
+                business_party_id=business_party_id,
+                survey_id=survey_id
+                )
+
     return render_template('register/register.confirm-organisation-survey.html',
-                           encrypted_enrolment_code=encrypted_enrolment_code,
-                           organisation_name=organisation_name,
-                           survey_name=survey_name)
+                           context=business_context,
+                           )

--- a/frontstage/views/surveys/add_survey_confirm_organisation_survey.py
+++ b/frontstage/views/surveys/add_survey_confirm_organisation_survey.py
@@ -30,8 +30,8 @@ def survey_confirm_organisation(session):
         # Get organisation name
         case = case_controller.get_case_by_enrolment_code(enrolment_code)
         business_party_id = case['caseGroup']['partyId']
-        organisation_name = party_controller.get_party_by_business_id(business_party_id).get('name')
-
+        business_party = party_controller.get_party_by_business_id(business_party_id)
+        
         # Get survey name
         collection_exercise_id = case['caseGroup']['collectionExerciseId']
         collection_exercise = collection_exercise_controller.get_collection_exercise(collection_exercise_id)
@@ -41,12 +41,21 @@ def survey_confirm_organisation(session):
         logger.error('Failed to retrieve data for confirm add organisation/survey page', status_code=exc.status_code)
         raise
 
+    business_context = {
+        'enrolment_code': enrolment_code,
+        'case': case,
+        'trading_as': business_party.get('trading_as'),
+        'organisation': business_party.get('name'),
+        'collection_exercise_id': collection_exercise_id,
+        'survey_id': collection_exercise,
+        'survey_name': survey_name,
+    }
+
     logger.info('Successfully retrieved data for confirm add organisation/survey page',
                 collection_exercise_id=collection_exercise_id,
                 business_party_id=business_party_id,
                 survey_id=survey_id)
+
     return render_template('surveys/surveys-confirm-organisation.html',
-                           enrolment_code=enrolment_code,
-                           encrypted_enrolment_code=encrypted_enrolment_code,
-                           organisation_name=organisation_name,
-                           survey_name=survey_name)
+                           context=business_context,
+                           )


### PR DESCRIPTION
### What is the context of this PR?
To fix a current op issue and to stop us getting calls about this when we ramp up from respondents.

Card: https://trello.com/c/QSXFlFjU/233-ext-display-the-ru-trading-as-name-if-it-has-one-on-the-confirm-organisation-page-linked-to-a-current-ops-issue-s

### How to review
- Run and check that when you add a new survey using an enrolment code that for that survey it displays the trading as name if present and check for one that does not have a trading as name as well to check if it displays correctly.
- Check tests pass as usual.