### PR TITLE
Templates to use enrolment code

### DIFF
--- a/frontstage/templates/register/register.confirm-organisation-survey.html
+++ b/frontstage/templates/register/register.confirm-organisation-survey.html
@@ -11,7 +11,7 @@
 
 <br/>
 
-<a href="{{ url_for('register_bp.register_enter_your_details', encrypted_enrolment_code=encrypted_enrolment_code) }}" class="btn action-button btn--primary">
+<a href="{{ url_for('register_bp.register_enter_your_details', encrypted_enrolment_code=context.encrypted_enrolment_code) }}" class="btn action-button btn--primary">
     Confirm
 </a>
 

--- a/frontstage/templates/surveys/surveys-confirm-organisation.html
+++ b/frontstage/templates/surveys/surveys-confirm-organisation.html
@@ -11,7 +11,7 @@
 
 <br/>
 
-<a id="CONFIRM_SURVEY_BTN" href="{{ url_for('surveys_bp.add_survey_submit', encrypted_enrolment_code=encrypted_enrolment_code) }}" class="btn action-button btn--primary">
+<a id="CONFIRM_SURVEY_BTN" href="{{ url_for('surveys_bp.add_survey_submit', encrypted_enrolment_code=context.encrypted_enrolment_code) }}" class="btn action-button btn--primary">
     Confirm
 </a>
 <p>

--- a/frontstage/views/register/confirm_organisation_survey.py
+++ b/frontstage/views/register/confirm_organisation_survey.py
@@ -39,6 +39,7 @@ def register_confirm_organisation_survey():
         raise
 
     business_context = {
+        'encrypted_enrolment_code': encrypted_enrolment_code,
         'enrolment_code': enrolment_code,
         'case': case,
         'trading_as': business_party.get('trading_as'),

--- a/frontstage/views/surveys/add_survey_confirm_organisation_survey.py
+++ b/frontstage/views/surveys/add_survey_confirm_organisation_survey.py
@@ -42,6 +42,7 @@ def survey_confirm_organisation(session):
         raise
 
     business_context = {
+        'encrypted_enrolment_code': encrypted_enrolment_code,
         'enrolment_code': enrolment_code,
         'case': case,
         'trading_as': business_party.get('trading_as'),


### PR DESCRIPTION
# Motivation and Context
When confirming business details after entering an enrolment code, get a 500 because enrolment code in template was returning empty string.

# What has changed
template to read enrolment code properly

# How to test?
try to register an account or add a survey
