### PR TITLE
Fix/ga event goal action

### DIFF
--- a/frontstage/templates/surveys/surveys.html
+++ b/frontstage/templates/surveys/surveys.html
@@ -60,7 +60,7 @@
             {% if not survey.status == 'Complete' or not survey.collection_instrument_type == 'EQ' %}
             <a href="{{ url_for('surveys_bp.access_survey', case_id=survey.case.id, ci_type = survey.collection_instrument_type) }}"
                {% if survey.collection_instrument_type == 'EQ' %}
-                onclick="ga('send', 'event', 'survey', 'download', 'survey_ref = {{ survey.survey.surveyRef }} collection_exercise_ref = {{ survey.collection_exercise.exerciseRef }}');"
+                onclick="ga('send', 'event', 'survey', 'launcheq', 'survey_ref = {{ survey.survey.surveyRef }} collection_exercise_ref = {{ survey.collection_exercise.exerciseRef }}');"
                {% endif %}>
                 <button id="ACCESS_SURVEY_BUTTON_{{loop.index}}" class="btn action-button btn--primary" type="submit">
                     Access <span class="u-vh">{{ survey.survey.longName|replace("Survey", " ") }}</span> survey


### PR DESCRIPTION
ga will be configured to log goals that match the actions sent in these events. While the survey id will indeed give enough context to log the goal as an EQ, the action should really be 'launcheq' rather than 'download'.

To test ensure the rendered page shows the correct event action e.g `onclick="ga('send', 'event', 'survey', 'launcheq', 'survey_ref = 023 collection_exercise_ref = 201806');"`