### PR TITLE
Defect - Forgot password has incorrect message when user submits an unregistered email address

### DIFF
--- a/frontstage/templates/passwords/forgot-password.check-email.html
+++ b/frontstage/templates/passwords/forgot-password.check-email.html
@@ -5,10 +5,9 @@
 
 {% block main %}
 
-    <h1 class="saturn">Check your email</h1>
+    <h1 class="saturn">Password reset request sent</h1>
 
-    <p>If your account is verified, you will receive an email at the registered email address.</p>
-    <p>Please follow the link in the email to reset your password.</p>
+    <p>If {{ email }} is registered to an account, you'll receive an email with instructions to reset your password</p>
 
     <div class="details js-details" data-guidance-label="Help with email" data-guidance="Help with email" data-hide-label="Help with email" data-show-label="Help with email">
 
@@ -17,8 +16,11 @@
       <div class="details__main js-details-body" id="guidance-help-with-email-body">
         <div class="details__content mars">
           <div>
-            <p>Email not arrived? It might be in your spam folder.</p>
-            <p>If it doesn’t arrive in the next 15 minutes, please call 0300 1234 931 or send an email to <a href="mailto:surveys.ons@gov.uk">surveys.ons@gov.uk</a>.</p>
+            <p>If you don't receive this within 15 minutes, try the following: </p>
+              <li>Check your spam folder</li>
+              <li>Check that you've entered your email address correctly </li>
+              <li>Ensure that you've registered an account using this email address </li>
+              <br>If you're still having problems, call us on 0300 1234 931 or send an <br/>email to <a href="mailto:surveys.ons@gov.uk">surveys.ons@gov.uk</a>.</p>
           </div>
         </div>
       </div>

--- a/frontstage/templates/passwords/forgot-password.html
+++ b/frontstage/templates/passwords/forgot-password.html
@@ -1,13 +1,11 @@
 {% import 'partials/section.html' as section %}
 {% extends "layouts/_twocol.html" %}
 
-{% set errorType = data['error']['type'] %}
-
 {% block page_title %}Forgot password - ONS Business Surveys{% endblock %}
 
 {% block main %}
 
-{% if errorType %}
+{% if form.errors %}
 <div class="panel panel--error">
     <div class="panel__header">
         <h1 class="panel__title venus">Invalid email address</h1>
@@ -31,9 +29,9 @@
     {{ form.csrf_token }}
 
     <fieldset id="forgot-details">
-        {% if errorType.email_address %}
+        {% if email %}
         <div class="panel panel--simple panel--error">
-            <p class="error-message">{{ errorType['email_address'][0] }}</p>
+            <p class="error-message">{{ email }}</p>
         {% endif %}
             <div class="field">
 
@@ -44,9 +42,7 @@
                 {{ form.email_address(class_='input input--text input-type__input') }}
 
             </div>
-        {% if errorType %}
         </div>
-        {% endif %}
     </fieldset>
     <br />
 

--- a/frontstage/views/passwords/forgot_password.py
+++ b/frontstage/views/passwords/forgot_password.py
@@ -18,52 +18,40 @@ BAD_AUTH_ERROR = 'Unauthorized user credentials'
 @passwords_bp.route('/forgot-password', methods=['GET'])
 def get_forgot_password():
     form = ForgotPasswordForm(request.form)
-    template_data = {
-        "error": {
-            "type": {}
-        }
-    }
-    return render_template('passwords/forgot-password.html', form=form, data=template_data)
+    return render_template('passwords/forgot-password.html', form=form)
 
 
 @passwords_bp.route('/forgot-password', methods=['POST'])
 def post_forgot_password():
     form = ForgotPasswordForm(request.form)
+    email = form.data.get('email_address')
 
     if form.validate():
-        email_address = request.form.get('email_address')
 
         try:
-            oauth_controller.check_account_valid(email_address)
+            oauth_controller.check_account_valid(email)
         except OAuth2Error as exc:
             error_message = exc.oauth2_error
             if BAD_AUTH_ERROR in error_message:
                 exc.logger('Requesting password change for unregistered email on OAuth2 server', log_level='info')
-                template_data = {"error": {"type": {"Email address is not registered"}}}
-                return render_template('passwords/forgot-password.html', form=form, data=template_data)
+                return render_template('passwords/forgot-password.check-email.html', email=email)
             else:
                 exc.logger(exc.message, oauth2_error=error_message, log_level='info')
             return render_template('passwords/reset-password.trouble.html')
 
         try:
-            party_controller.reset_password_request(email_address)
+            party_controller.reset_password_request(email)
         except ApiError as exc:
             if exc.status_code == 404:
                 logger.error('Requesting password change for email registered'
                              ' on OAuth2 server but not in party service')
-                template_data = {"error": {"type": {"Email address is not registered"}}}
-                return render_template('passwords/forgot-password.html', form=form, data=template_data)
+                return render_template('passwords/forgot-password.check-email.html', email=email)
             raise exc
 
         logger.info('Successfully sent password change request email')
         return redirect(url_for('passwords_bp.forgot_password_check_email'))
 
-    template_data = {
-        "error": {
-            "type": form.errors
-        }
-    }
-    return render_template('passwords/forgot-password.html', form=form, data=template_data)
+    return render_template('passwords/forgot-password.html', form=form, email=email)
 
 
 @passwords_bp.route('/forgot-password/check-email', methods=['GET'])

--- a/tests/app/test_passwords.py
+++ b/tests/app/test_passwords.py
@@ -57,7 +57,7 @@ class TestPasswords(unittest.TestCase):
     def test_forgot_password_post_unrecognised_email_oauth(self, mock_object):
         mock_object.post(url_get_token, status_code=401, json={"detail": "Unauthorized user credentials"})
 
-        response = self.app.post("passwords/forgot-password", data=self.email_form, follow_redirects=True)
+        response = self.app.post("passwords/forgot-password", follow_redirects=True)
 
         self.assertEqual(response.status_code, 200)
         self.assertTrue('Invalid email'.encode() in response.data)
@@ -67,7 +67,7 @@ class TestPasswords(unittest.TestCase):
         mock_object.post(url_get_token, status_code=201, json=self.oauth2_response)
         mock_object.post(url_reset_password_request, status_code=404)
 
-        response = self.app.post("passwords/forgot-password", data=self.email_form, follow_redirects=True)
+        response = self.app.post("passwords/forgot-password", follow_redirects=True)
 
         self.assertEqual(response.status_code, 200)
         self.assertTrue('Invalid email'.encode() in response.data)


### PR DESCRIPTION
### What is the context of this PR?
Current defect where the forgot password page has an incorrect message displayed to the user when they submit an unregistered email address

Card: https://trello.com/c/M8KCuVwm/235-ext-defect-us012-forgot-password-has-incorrect-message-when-user-submits-an-unregistered-email-address-m

### How to review
Check that the correct content is displayed on the password reset page as well as validation when you enter a non valid email address as well on the forgot password screen.