### PR TITLE
ZipKin Tracing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.pytest_cache/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/Pipfile
+++ b/Pipfile
@@ -1,17 +1,12 @@
 [[source]]
-
 name = "pypi"
 verify_ssl = true
 url = "https://pypi.python.org/simple"
 
-
 [requires]
-
 python_version = "3.6"
 
-
 [packages]
-
 cfenv = "*"
 flask = "*"
 flask-wtf = "*"
@@ -28,10 +23,10 @@ structlog = "*"
 sdc-cryptography = "*"
 greenlet = "*"
 dateutils = "*"
-
+requestsdefaulter = "*"
+flask-zipkin = "*"
 
 [dev-packages]
-
 codecov = "*"
 coverage = "*"
 "flake8" = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "bd8a63405d554e5801357aa740f1c90e08f9735fc3245e99766147d5c99a63fd"
+            "sha256": "bc2a6361babfc2803da5fd8c91e90d115ee12d2028d3cc11ad2fe5ad374c0414"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -150,11 +150,19 @@
             "index": "pypi",
             "version": "==0.14.2"
         },
+        "flask-zipkin": {
+            "hashes": [
+                "sha256:402bed9a98d3507d82db98a8f7437fb52ef3684af33c58a241b37779f9013d74",
+                "sha256:fbd3e3c41ceeda922701eebbfce88c8fccb7bc849289d772f5186a14a49827bd"
+            ],
+            "index": "pypi",
+            "version": "==0.0.4"
+        },
         "furl": {
             "hashes": [
-                "sha256:5436226c89536b5fa8c5faa1e34d684d417f69dea91d406edaab102c5da6de8c"
+                "sha256:17654103b8d0cbe42798592db099c728165ac12057d49fe2e69de967d87bf29b"
             ],
-            "version": "==1.2"
+            "version": "==1.2.1"
         },
         "future": {
             "hashes": [
@@ -280,9 +288,33 @@
             "index": "pypi",
             "version": "==8.9.11"
         },
+        "ply": {
+            "hashes": [
+                "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3",
+                "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce"
+            ],
+            "version": "==3.11"
+        },
+        "py-zipkin": {
+            "hashes": [
+                "sha256:1cbf48c8b7e5a30c36e8eb97560b81813c38af0bdb6ad901b23bdbced15a9b79"
+            ],
+            "version": "==0.13.0"
+        },
         "pyasn1": {
             "hashes": [
+                "sha256:0ad0fe0593dde1e599cac0bf65bb1a4ec663032f0bc68ee44850db4251e8c501",
+                "sha256:13794d835643ee970b2c059dbfe4eb5d751e16c693c8baee61c526abd209e5c7",
+                "sha256:49a8ed515f26913049113820b462f698e6ed26df62c389dafb6fa3685ddca8de",
+                "sha256:74ac8521a0480f228549be20bea555ae35678f0e754c2fbc6f1576b0959bec43",
+                "sha256:89399ca8ecd4524f974e926d4ef9e7a787903e01f0a9cdff3131ad1361792fe5",
+                "sha256:8f291e0338d519a1a0d07f0b9d03c9265f6be26eb32fdd21af6d3259d14ea49c",
                 "sha256:b9d3abc5031e61927c82d4d96c1cec1e55676c1a991623cfed28faea73cdd7ca",
+                "sha256:d3bbd726c1a760d4ca596a4d450c380b81737612fe0182f5bb3caebc17461fd9",
+                "sha256:dea873d6c907c1cf1341fd88742a61efce33227d7743cb37564ab7d7e77dd9fd",
+                "sha256:ded5eea5cb88bc1ce9aa074b5a3092f95ce4741887e317e9b49c7ece75d7ea0e",
+                "sha256:e8b69ea2200d42201cbedd486eedb8980f320d4534f83ce2fb468e96aa5545d0",
+                "sha256:edad117649643230493aeb4955456ce19ab4b12e94489dde6f7094cdb5a3c87e",
                 "sha256:f58f2a3d12fd754aa123e9fa74fb7345333000a035f3921dbdaa08597aa53137"
             ],
             "version": "==0.4.4"
@@ -354,6 +386,14 @@
             "index": "pypi",
             "version": "==2.19.1"
         },
+        "requestsdefaulter": {
+            "hashes": [
+                "sha256:5e185d9b38f29215c78446188afd70765a8e876244eec6a5f0e71ae437fdb128",
+                "sha256:bb83e7f96009be470d1dea55c270c9dad06fb231dd33dda483ab3d8ffb6b8102"
+            ],
+            "index": "pypi",
+            "version": "==0.1.0"
+        },
         "rsa": {
             "hashes": [
                 "sha256:25df4e10c263fb88b5ace923dd84bf9aa7f5019687b5e55382ffcdb8bede9db5",
@@ -384,12 +424,17 @@
             "index": "pypi",
             "version": "==18.1.0"
         },
+        "thriftpy": {
+            "hashes": [
+                "sha256:309e57d97b5bfa01601393ad4f245451e989d6206a59279e56866b264a99796d"
+            ],
+            "version": "==0.3.9"
+        },
         "urllib3": {
             "hashes": [
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
-            "markers": "python_version != '3.0.*' and python_version >= '2.6' and python_version != '3.3.*' and python_version != '3.1.*' and python_version < '4' and python_version != '3.2.*'",
             "version": "==1.23"
         },
         "werkzeug": {
@@ -463,8 +508,11 @@
             "hashes": [
                 "sha256:03481e81d558d30d230bc12999e3edffe392d244349a90f4ef9b88425fac74ba",
                 "sha256:0b136648de27201056c1869a6c0d4e23f464750fd9a9ba9750b8336a244429ed",
+                "sha256:104ab3934abaf5be871a583541e8829d6c19ce7bde2923b2751e0d3ca44db60a",
                 "sha256:10a46017fef60e16694a30627319f38a2b9b52e90182dddb6e37dcdab0f4bf95",
+                "sha256:15b111b6a0f46ee1a485414a52a7ad1d703bdf984e9ed3c288a4414d3871dcbd",
                 "sha256:198626739a79b09fa0a2f06e083ffd12eb55449b5f8bfdbeed1df4910b2ca640",
+                "sha256:1c383d2ef13ade2acc636556fd544dba6e14fa30755f26812f54300e401f98f2",
                 "sha256:23d341cdd4a0371820eb2b0bd6b88f5003a7438bbedb33688cd33b8eae59affd",
                 "sha256:28b2191e7283f4f3568962e373b47ef7f0392993bb6660d079c62bd50fe9d162",
                 "sha256:2a5b73210bad5279ddb558d9a2bfedc7f4bf6ad7f3c988641d83c40293deaec1",
@@ -487,11 +535,16 @@
                 "sha256:7e1fe19bd6dce69d9fd159d8e4a80a8f52101380d5d3a4d374b6d3eae0e5de9c",
                 "sha256:8c3cb8c35ec4d9506979b4cf90ee9918bc2e49f84189d9bf5c36c0c1119c6558",
                 "sha256:9d6dd10d49e01571bf6e147d3b505141ffc093a06756c60b053a859cb2128b1f",
+                "sha256:9e112fcbe0148a6fa4f0a02e8d58e94470fc6cb82a5481618fea901699bf34c4",
+                "sha256:ac4fef68da01116a5c117eba4dd46f2e06847a497de5ed1d64bb99a5fda1ef91",
+                "sha256:b8815995e050764c8610dbc82641807d196927c3dbed207f0a079833ffcf588d",
                 "sha256:be6cfcd8053d13f5f5eeb284aa8a814220c3da1b0078fa859011c7fffd86dab9",
                 "sha256:c1bb572fab8208c400adaf06a8133ac0712179a334c09224fb11393e920abcdd",
                 "sha256:de4418dadaa1c01d497e539210cb6baa015965526ff5afc078c57ca69160108d",
                 "sha256:e05cb4d9aad6233d67e0541caa7e511fa4047ed7750ec2510d466e806e0255d6",
-                "sha256:f3f501f345f24383c0000395b26b726e46758b71393267aeae0bd36f8b3ade80"
+                "sha256:e4d96c07229f58cb686120f168276e434660e4358cc9cf3b0464210b04913e77",
+                "sha256:f3f501f345f24383c0000395b26b726e46758b71393267aeae0bd36f8b3ade80",
+                "sha256:f8a923a85cb099422ad5a2e345fe877bbc89a8a8b23235824a93488150e45f6e"
             ],
             "index": "pypi",
             "version": "==4.5.1"
@@ -517,7 +570,6 @@
                 "sha256:b9c40e9750f3d77e6e4d441d8b0266cf555e7cdabdcff33c4fd06366ca761ef8",
                 "sha256:ec9ef8f4a9bc6f71eec99e1806bfa2de401650d996c59330782b89a5555c1497"
             ],
-            "markers": "python_version != '3.2.*' and python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.1.*' and python_version != '3.0.*'",
             "version": "==4.3.4"
         },
         "lazy-object-proxy": {
@@ -589,7 +641,6 @@
                 "sha256:6e3836e39f4d36ae72840833db137f7b7d35105079aee6ec4a62d9f80d594dd1",
                 "sha256:95eb8364a4708392bae89035f45341871286a333f749c3141c20573d2b3876e1"
             ],
-            "markers": "python_version != '3.1.*' and python_version != '3.0.*' and python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.2.*'",
             "version": "==0.7.1"
         },
         "py": {
@@ -597,7 +648,6 @@
                 "sha256:3fd59af7435864e1a243790d322d763925431213b6b8529c6ca71081ace3bbf7",
                 "sha256:e31fb2767eb657cbde86c454f02e99cb846d3cd9d61b318525140214fdc0e98e"
             ],
-            "markers": "python_version != '3.1.*' and python_version != '3.0.*' and python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.2.*'",
             "version": "==1.5.4"
         },
         "pycodestyle": {
@@ -664,7 +714,8 @@
         "requests-oauthlib": {
             "hashes": [
                 "sha256:8886bfec5ad7afb391ed5443b1f697c6f4ae98d0e5620839d8b4499c032ada3f",
-                "sha256:e21232e2465808c0e892e0e4dbb8c2faafec16ac6dc067dd546e9b466f3deac8"
+                "sha256:e21232e2465808c0e892e0e4dbb8c2faafec16ac6dc067dd546e9b466f3deac8",
+                "sha256:fe3282f48fb134ee0035712159f5429215459407f6d5484013343031ff1a400d"
             ],
             "index": "pypi",
             "version": "==1.0.0"
@@ -718,7 +769,6 @@
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
-            "markers": "python_version != '3.0.*' and python_version >= '2.6' and python_version != '3.3.*' and python_version != '3.1.*' and python_version < '4' and python_version != '3.2.*'",
             "version": "==1.23"
         },
         "wrapt": {

--- a/README.md
+++ b/README.md
@@ -65,22 +65,25 @@ Note that this script will fail if there is a `node_modules` folder in the repo
 ## Configuration
 Environment variables available for configuration are listed below:
 
-| Environment Variable            | Description                                        | Default
-|---------------------------------|----------------------------------------------------|-------------------------------
-| APP_SETTINGS                    | Which config to use                                | 'Config' (use DevelopmentConfig) for developers
-| SECRET_KEY                      | Secret key used by flask                           | 'ONS_DUMMY_KEY'
-| SECURITY_USER_NAME              | Username for basic auth                            | 'admin'
-| SECURITY_USER_PASSWORD          | Password for basic auth                            | 'secret'
-| JWT_ALGORITHM                   | Algorithm used to code JWT                         | 'HS256'
-| JWT_SECRET                      | SECRET used to code JWT                            | 'testsecret'
-| VALIDATE_JWT                    | Boolean for turning on/off JWT validation (True=on)| True 
-| GOOGLE_ANALYTICS                | Code for google analytics                          | None
-| GOOGLE_TAG_MANAGER              | Code for google tag manager                        | None
-| REDIS_HOST                      | Host address for the redis instance                | 'localhost' 
-| REDIS_PORT                      | Port for the redis instance                        | 6379
-| REDIS_DB                        | Database number for the redis instance              | 1
-| RAS_FRONTSTAGE_API_PROTOCOL     | Protocol used for frontstage-api uri               | 'http' 
-| RAS_FRONTSTAGE_API_HOST         | Host address used for frontstage-api uri           | 'localhost'
-| RAS_FRONTSTAGE_API_PORT         | Port used for frontstage-api uri                   | 8083
+| Environment Variable            | Description                                                   | Default
+|---------------------------------|---------------------------------------------------------------|-------------------------------
+| APP_SETTINGS                    | Which config to use                                           | 'Config' (use DevelopmentConfig) for developers
+| SECRET_KEY                      | Secret key used by flask                                      | 'ONS_DUMMY_KEY'
+| SECURITY_USER_NAME              | Username for basic auth                                       | 'admin'
+| SECURITY_USER_PASSWORD          | Password for basic auth                                       | 'secret'
+| JWT_ALGORITHM                   | Algorithm used to code JWT                                    | 'HS256'
+| JWT_SECRET                      | SECRET used to code JWT                                       | 'testsecret'
+| VALIDATE_JWT                    | Boolean for turning on/off JWT validation (True=on)           | True 
+| GOOGLE_ANALYTICS                | Code for google analytics                                     | None
+| GOOGLE_TAG_MANAGER              | Code for google tag manager                                   | None
+| REDIS_HOST                      | Host address for the redis instance                           | 'localhost' 
+| REDIS_PORT                      | Port for the redis instance                                   | 6379
+| REDIS_DB                        | Database number for the redis instance                        | 1
+| RAS_FRONTSTAGE_API_PROTOCOL     | Protocol used for frontstage-api uri                          | 'http' 
+| RAS_FRONTSTAGE_API_HOST         | Host address used for frontstage-api uri                      | 'localhost'
+| RAS_FRONTSTAGE_API_PORT         | Port used for frontstage-api uri                              | 8083
+| ZIPKIN_DISABLE                  | Totally disable Zipkin (including tracing headers)            | False
+| ZIPKIN_DSN                      | Zipkin Sample API URL (e.g. http://zipkin:9411/api/v1/spans)  | None
+| ZIPKIN_SAMPLE_RATE              | Percentage of requests to send to zipkin span API             | 0
 
 These are set in [config.py](config.py)

--- a/config.py
+++ b/config.py
@@ -3,6 +3,9 @@ import os
 
 # To choose which config to use when running frontstage set environment variable APP_SETTINGS to the name of the
 # config object e.g. for the dev config set APP_SETTINGS=DevelopmentConfig
+from distutils.util import strtobool
+
+
 class Config(object):
     DEBUG = False
     TESTING = False
@@ -21,7 +24,12 @@ class Config(object):
     GOOGLE_TAG_MANAGER = os.getenv('GOOGLE_TAG_MANAGER', None)
     NON_DEFAULT_VARIABLES = ['SECRET_KEY', 'SECURITY_USER_NAME', 'SECURITY_USER_PASSWORD', 'JWT_SECRET']
     AVAILABILITY_BANNER = os.getenv('AVAILABILITY_BANNER', False)
-    
+
+    # Zipkin
+    ZIPKIN_DISABLE = bool(strtobool(os.getenv("ZIPKIN_DISABLE", "False")))
+    ZIPKIN_DSN = os.getenv("ZIPKIN_DSN", None)
+    ZIPKIN_SAMPLE_RATE = int(os.getenv("ZIPKIN_SAMPLE_RATE", 0))
+
     ACCOUNT_SERVICE_URL = os.getenv('ACCOUNT_SERVICE_URL')
     EQ_URL = os.getenv('EQ_URL')
     JSON_SECRET_KEYS = os.getenv('JSON_SECRET_KEYS')
@@ -71,6 +79,7 @@ class Config(object):
     SURVEY_USERNAME = os.getenv('SURVEY_USERNAME')
     SURVEY_PASSWORD = os.getenv('SURVEY_PASSWORD')
     SURVEY_AUTH = (SURVEY_USERNAME, SURVEY_PASSWORD)
+
 
 
 class DevelopmentConfig(Config):

--- a/frontstage/create_app.py
+++ b/frontstage/create_app.py
@@ -1,7 +1,9 @@
 import logging
 import os
+import requestsdefaulter
 
 from flask import Flask, request
+from flask_zipkin import Zipkin
 from structlog import wrap_logger
 
 from frontstage.cloud.cloudfoundry import ONSCloudFoundry
@@ -21,10 +23,15 @@ CACHE_HEADERS = {
 
 def create_app_object():
     app = Flask(__name__)
+    app.name = "ras-frontstage"
 
     # Load app config
     app_config = 'config.{}'.format(os.environ.get('APP_SETTINGS', 'Config'))
     app.config.from_object(app_config)
+
+    # Zipkin
+    zipkin = Zipkin(app=app, sample_rate=app.config.get("ZIPKIN_SAMPLE_RATE"))
+    requestsdefaulter.default_headers(zipkin.create_http_headers_for_new_span)
 
     # Configure logger
     log_level = 'DEBUG' if app.config['DEBUG'] else None


### PR DESCRIPTION
Motivation and Context
==

Currently there's no way to trace the requests through the application.

# What Changed

This will add the tracing headers to any request that comes through this
application onto another service, or preserve existing headers allowing the user
to follow requests through the application as a whole.

There are also new configuration settings:

```
| ZIPKIN_DISABLE                  | Totally disable Zipkin (including tracing headers)            | False
| ZIPKIN_DSN                      | Zipkin Sample API URL (e.g. http://zipkin:9411/api/v1/spans)  | None
| ZIPKIN_SAMPLE_RATE              | Percentage of requests to send to zipkin span API             | 0
```

By default this will add the tracing headers, but make no requests to Zipkin's neat little UI.

# How to test

No visible functional changes, check to see if downstream services are receiving
the headers: 

* 'X-B3-TraceId'
* 'X-B3-SpanId'
* 'X-B3-ParentSpanId'
* 'X-B3-Flags'
* 'X-B3-Sampled'

You can also set the environment variables

To see the spans go to zipkin:

* Set the environment variable `ZIPKIN_DSN` to a locally running zipkin server
* Set the environment variable `ZIPKIN_SAMPLE_RATE` to 100

Then run the acceptance tests.

# Links
* [Add Call time metrics into Splunk for Python Services (3d)][tkt]
* https://github.com/ONSdigital/ras-collection-instrument/pull/126
* https://github.com/ONSdigital/ras-party/pull/151
* https://github.com/ONSdigital/ras-secure-message/pull/227
* https://github.com/ONSdigital/response-operations-ui/pull/219
* https://github.com/ONSdigital/ras-frontstage/pull/383
* https://github.com/ONSdigital/rm-collection-exercise-service/pull/114
* https://github.com/ONSdigital/rm-case-service/pull/71
* https://github.com/ONSdigital/rm-actionexporter-service/pull/46
* https://github.com/ONSdigital/iac-service/pull/20
* https://github.com/ONSdigital/rm-sample-service/pull/74
* https://github.com/ONSdigital/rm-notify-gateway/pull/44
* https://github.com/ONSdigital/rm-sdx-gateway/pull/20
* https://github.com/ONSdigital/ras-party/pull/155
* https://github.com/ONSdigital/ras-rm-docker-dev/pull/80

[tkt]: https://trello.com/c/eY86bZG9/83-add-call-time-metrics-into-splunk-for-python-services-3d