### PR TITLE
Add Zipkin IDs to logs.

### DIFF
--- a/frontstage/logger_config.py
+++ b/frontstage/logger_config.py
@@ -10,7 +10,6 @@ from structlog.threadlocal import wrap_dict
 from flask import g
 
 
-
 def logger_initial_config(service_name=None,  # noqa: C901  pylint: disable=too-complex
                           log_level=None,
                           logger_format=None,

--- a/frontstage/logger_config.py
+++ b/frontstage/logger_config.py
@@ -43,9 +43,12 @@ def logger_initial_config(service_name=None,  # noqa: C901  pylint: disable=too-
     oauth_log.propagate = False
 
     def zipkin_ids(logger, method_name, event_dict):
+        event_dict['zipkin_trace_id'] = ''
+        event_dict['zipkin_span_id'] = ''
         if not flask.has_app_context():
-            event_dict['zipkin_trace_id'] = ''
-            event_dict['zipkin_span_id'] = ''
+            return event_dict
+
+        if '_zipkin_span' not in g:
             return event_dict
 
         event_dict['zipkin_span_id'] = g._zipkin_span.zipkin_attrs.span_id

--- a/frontstage/logger_config.py
+++ b/frontstage/logger_config.py
@@ -1,18 +1,20 @@
 import logging
 import os
 import sys
+import flask
 
 from structlog import configure
 from structlog.processors import JSONRenderer, TimeStamper, format_exc_info
 from structlog.stdlib import add_log_level, filter_by_level, LoggerFactory
 from structlog.threadlocal import wrap_dict
+from flask import g
+
 
 
 def logger_initial_config(service_name=None,  # noqa: C901  pylint: disable=too-complex
                           log_level=None,
                           logger_format=None,
                           logger_date_format=None):
-
     if not logger_date_format:
         logger_date_format = os.getenv('LOGGING_DATE_FORMAT', "%Y-%m-%dT%H:%M%s")
     if not log_level:
@@ -40,6 +42,17 @@ def logger_initial_config(service_name=None,  # noqa: C901  pylint: disable=too-
     oauth_log.addHandler(logging.NullHandler())
     oauth_log.propagate = False
 
+    def zipkin_ids(logger, method_name, event_dict):
+        if not flask.has_app_context():
+            event_dict['zipkin_trace_id'] = ''
+            event_dict['zipkin_span_id'] = ''
+            return event_dict
+
+        event_dict['zipkin_span_id'] = g._zipkin_span.zipkin_attrs.span_id
+        event_dict['zipkin_trace_id'] = g._zipkin_span.zipkin_attrs.trace_id
+
+        return event_dict
+
     def parse_exception(_, __, event_dict):
         exception = event_dict.get('exception')
         if exception:
@@ -48,7 +61,7 @@ def logger_initial_config(service_name=None,  # noqa: C901  pylint: disable=too-
 
     # setup file logging
     renderer_processor = JSONRenderer(indent=indent)
-    processors = [add_log_level, filter_by_level, add_service, format_exc_info,
+    processors = [zipkin_ids, add_log_level, filter_by_level, add_service, format_exc_info,
                   TimeStamper(fmt=logger_date_format, utc=True, key='created_at'), parse_exception, renderer_processor]
     configure(context_class=wrap_dict(dict), logger_factory=LoggerFactory(), processors=processors,
               cache_logger_on_first_use=True)

--- a/tests/app/test_logger_config.py
+++ b/tests/app/test_logger_config.py
@@ -20,7 +20,8 @@ class TestLoggerConfig(unittest.TestCase):
         with self.assertLogs(level='ERROR') as cm:
             logger.error('Test')
         message = cm[0][0].msg
-        self.assertTrue('{\n "event": "Test",\n "level": "error",\n "service": "ras-frontstage"' in message)
+        self.assertTrue(['{"event": "Test"}, {"level": "error"}, {"service": "ras-frontstage"},'
+                         '{"zipkin_trace_id": ""}, {"zipkin_span_id": ""' in message])
 
     def test_indent_type_error(self):
         logger_initial_config()


### PR DESCRIPTION
# Motivation and Context
Currently there's no way to trace the requests through the application.

# What has changed
This will add the trace and span IDs into all log statements.

# How to test?
Run unit and acceptance tests.

# Links
https://trello.com/c/5cYDTILb/156-add-the-zipkin-correlation-and-span-id-into-the-logs-for-python-services-2d
