### PR TITLE
Fixed issue with survey access button breaking outside grid

### DIFF
--- a/frontstage/static/css/theme.css
+++ b/frontstage/static/css/theme.css
@@ -40,7 +40,6 @@
 
 .survey-list .action-button {
   text-align: center;
-  width: 140px;
   padding: 10px;
 }
 


### PR DESCRIPTION
# Motivation and Context
Bug fix required for survey listing page. The access survey button broke the grid on medium screen size between 745 -> 960. See screenshot below:

![image](https://user-images.githubusercontent.com/1015442/45039903-90f11a80-b05c-11e8-9c1b-957f50343b1e.png)

# What has changed

The width value has been removed from the `button` so the text can wrap correctly. See screenshot below:

![image](https://user-images.githubusercontent.com/1015442/45039955-b9791480-b05c-11e8-86db-7254279435b6.png)

# How to test?
Check that the button doesn't break out of the grid when the browser in resized.

# Links
https://trello.com/c/UZH0y6TA/346-xbrowser-testing-for-cdn-implementation
