### PR TITLE
317 updating secure message text box

### DIFF
--- a/frontstage/templates/secure-messages/secure-messages-view.html
+++ b/frontstage/templates/secure-messages/secure-messages-view.html
@@ -51,7 +51,7 @@
                     {% else %}
                         <label class="venus" for="body">Message</label>
                     {% endif %}
-                    {{ form.body(id='secure-message-body', class_='input input--textarea input--textarea-message', rows='10') }}
+                    {{ form.body(id='secure-message-body', class_='input input--textarea input--textarea-message', rows='10', maxlength='10000') }}
                     {% if "body" in errors %}
                         </div>
                     {% endif %}

--- a/frontstage/templates/secure-messages/secure-messages-view.html
+++ b/frontstage/templates/secure-messages/secure-messages-view.html
@@ -20,7 +20,7 @@
 
             {% if not message %}<h1 class="saturn">Create message</h1>{% endif %}
 
-            <div class="secure-message-form">
+            <div class="secure-message-form" id="secure-message-form">
                 <form action="{{ url_for('secure_message_bp.create_message', ru_ref=ru_ref, survey=survey) }}" method="post">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
                     {{ form.thread_id }}


### PR DESCRIPTION
# Motivation and Context
On frontstage, when creating a secure-message the respondent was able to enter in more than 10,000 characters in to the body of the message. This would cause a `Something went wrong ` page to appear when trying to send a message and it would be blocked by WAF. This PR adds a max length to the text box to stop this happening.
# What has changed
- Added a max length to the secure message body text box

# How to test?
- Attempt to type more than 10,000 characters and the text box should stop you from doing so
- All tests pass
- Acceptance tests pass with the respective branch ([Acceptance tests branch](https://github.com/ONSdigital/rasrm-acceptance-tests/pull/174))

# Links
[Trello card](https://trello.com/c/1Oga8Jnv/317-frontstage-secure-message-rejected-by-waf-if-the-body-is-too-long)

### This needs to be merged in with the acceptance test PR associated with it