### PR TITLE
Changed cdn version to latest (v1.5.6)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "/Users/mattsimon/.local/share/virtualenvs/ras-frontstage-zZL9XUSa/bin/python"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/Users/mattsimon/.local/share/virtualenvs/ras-frontstage-zZL9XUSa/bin/python"
+}

--- a/frontstage/templates/layouts/_base.html
+++ b/frontstage/templates/layouts/_base.html
@@ -1,5 +1,5 @@
 <!doctype html>
-{% set cdn_hash = "v1.5.4" %}
+{% set cdn_hash = "v1.5.6" %}
 
 {% set cdn_url_prefix = "https://cdn.ons.gov.uk/sdc/"~cdn_hash %}
 

--- a/frontstage/templates/register/register.almost-done.html
+++ b/frontstage/templates/register/register.almost-done.html
@@ -7,7 +7,7 @@
     <h1 class="saturn">Almost done...</h1>
     <p id="email_confirmation_sent">We've sent an email to {{ email }}</p>
     <p>Please follow the link in the email to confirm your email address and finish setting up your account.</p>
-    <div class="guidance js-details"
+    <div class="guidance js-details u-mb-m"
         data-guidance-label="guidance-help-with-email"
         data-guidance="Guidance help with email"
         data-hide-label="Hide help with email"


### PR DESCRIPTION
# Motivation and Context
Bug observed with the guidance component where the content was hidden when JS was disabled. It should be displayed.

On the "Almost done..." page when signing up, there was a cut off of content on the guidance component.

# What has changed
The no js bug has been fixed in the pattern library and released (v1.5.6). The version has been changed to get the latest code.

A utility class to add a margin to the guidance component fixes the cutting off issue.

# How to test?

Test the component with no js and ensure the element isn't cut off and is visible.

