### PR TITLE
Align trace naming.

### DIFF
--- a/frontstage/logger_config.py
+++ b/frontstage/logger_config.py
@@ -42,17 +42,16 @@ def logger_initial_config(service_name=None,  # noqa: C901  pylint: disable=too-
     oauth_log.propagate = False
 
     def zipkin_ids(logger, method_name, event_dict):
-        event_dict['zipkin_trace_id'] = ''
-        event_dict['zipkin_span_id'] = ''
+        event_dict['trace'] = ''
+        event_dict['span'] = ''
+        event_dict['parent'] = ''
         if not flask.has_app_context():
             return event_dict
-
         if '_zipkin_span' not in g:
             return event_dict
-
-        event_dict['zipkin_span_id'] = g._zipkin_span.zipkin_attrs.span_id
-        event_dict['zipkin_trace_id'] = g._zipkin_span.zipkin_attrs.trace_id
-
+        event_dict['span'] = g._zipkin_span.zipkin_attrs.span_id
+        event_dict['trace'] = g._zipkin_span.zipkin_attrs.trace_id
+        event_dict['parent'] = g._zipkin_span.zipkin_attrs.parent_span_id
         return event_dict
 
     def parse_exception(_, __, event_dict):

--- a/tests/app/test_logger_config.py
+++ b/tests/app/test_logger_config.py
@@ -20,8 +20,9 @@ class TestLoggerConfig(unittest.TestCase):
         with self.assertLogs(level='ERROR') as cm:
             logger.error('Test')
         message = cm[0][0].msg
-        self.assertTrue(['{"event": "Test"}, {"level": "error"}, {"service": "ras-frontstage"},'
-                         '{"zipkin_trace_id": ""}, {"zipkin_span_id": ""' in message])
+        message_contents = '\n "event": "Test",\n "trace": "",\n "span": "",\n "parent": "",' \
+                           '\n "level": "error",\n "service": "ras-frontstage"'
+        self.assertIn(message_contents, message)
 
     def test_indent_type_error(self):
         logger_initial_config()
@@ -29,7 +30,8 @@ class TestLoggerConfig(unittest.TestCase):
         with self.assertLogs(level='ERROR') as cm:
             logger.error('Test')
         message = cm[0][0].msg
-        self.assertTrue(['{"event": "Test"}, {"level": "error"}, {"service": "ras-frontstage}" ' in message])
+        self.assertIn('"event": "Test", "trace": "", "span": "", "parent": "",'
+                      ' "level": "error", "service": "ras-frontstage"', message)
 
     def test_indent_value_error(self):
         os.environ['JSON_INDENT_LOGGING'] = 'abc'
@@ -38,4 +40,5 @@ class TestLoggerConfig(unittest.TestCase):
         with self.assertLogs(level='ERROR') as cm:
             logger.error('Test')
         message = cm[0][0].msg
-        self.assertTrue(['{"event": "Test"}, {"level": "error"}, {"service": "ras-frontstage}" ' in message])
+        self.assertIn('"event": "Test", "trace": "", "span": "", "parent": "",'
+                      ' "level": "error", "service": "ras-frontstage"', message)


### PR DESCRIPTION
# Motivation and Context
Align tracing names in log with Java services.
