### PR TITLE
Allow a verification link to be resent if using an expired one

### DIFF
--- a/frontstage/controllers/party_controller.py
+++ b/frontstage/controllers/party_controller.py
@@ -145,6 +145,18 @@ def resend_verification_email(party_id):
     logger.debug('Successfully re-sent verification email', party_id=party_id)
 
 
+def resend_verification_email_expired_token(token):
+    logger.debug('Re-sending verification email', token=token)
+    url = f'{app.config["PARTY_URL"]}/party-api/v1/resend-verification-email-expired-token/{token}'
+    response = requests.get(url, auth=app.config['PARTY_AUTH'])
+
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError:
+        logger.exception('Re-sending of verification email for expired token failed', token=token)
+        raise ApiError(response)
+
+
 def reset_password_request(username):
     logger.debug('Attempting to send reset password request to party service')
 

--- a/frontstage/controllers/party_controller.py
+++ b/frontstage/controllers/party_controller.py
@@ -134,13 +134,13 @@ def get_respondent_by_email(email):
 def resend_verification_email(party_id):
     logger.debug('Re-sending verification email', party_id=party_id)
     url = f'{app.config["PARTY_URL"]}/party-api/v1/resend-verification-email/{party_id}'
-    response = requests.get(url, auth=app.config['PARTY_AUTH'])
+    response = requests.post(url, auth=app.config['PARTY_AUTH'])
 
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError:
         logger.exception('Re-sending of verification email failed', party_id=party_id)
-        raise ApiError(response)
+        raise ApiError(logger, response, log_level='exception', message='Re-sending of verification email failed')
 
     logger.debug('Successfully re-sent verification email', party_id=party_id)
 
@@ -148,13 +148,13 @@ def resend_verification_email(party_id):
 def resend_verification_email_expired_token(token):
     logger.debug('Re-sending verification email', token=token)
     url = f'{app.config["PARTY_URL"]}/party-api/v1/resend-verification-email-expired-token/{token}'
-    response = requests.get(url, auth=app.config['PARTY_AUTH'])
+    response = requests.post(url, auth=app.config['PARTY_AUTH'])
 
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError:
-        logger.exception('Re-sending of verification email for expired token failed', token=token)
-        raise ApiError(response)
+        raise ApiError(logger, response, log_level='exception',
+                       message='Re-sending of verification email for expired token failed')
 
 
 def reset_password_request(username):

--- a/frontstage/templates/register/register.link-expired.html
+++ b/frontstage/templates/register/register.link-expired.html
@@ -9,7 +9,7 @@
 
 <div>
     <p>
-        Please call us on <a href="tel:03001234931">0300 1234 931</a> to request another link.
+        You can <a href="{{ url_for('sign_in_bp.resend_verification_expired_token', token=token) }}">request another verification email</a> or call us on <a href="tel:03001234931">0300 1234 931</a>.
     </p>
 </div>
 

--- a/frontstage/views/register/activate_account.py
+++ b/frontstage/views/register/activate_account.py
@@ -23,7 +23,7 @@ def register_activate_account(token):
         if exc.status_code == 409:
             logger.info('Expired email verification token', token=token, api_url=exc.url,
                         api_status_code=exc.status_code)
-            return render_template('register/register.link-expired.html')
+            return render_template('register/register.link-expired.html', token=token)
         elif exc.status_code == 404:
             logger.warning('Unrecognised email verification token', token=token, api_url=exc.url,
                            api_status_code=exc.status_code)

--- a/frontstage/views/sign_in/sign_in.py
+++ b/frontstage/views/sign_in/sign_in.py
@@ -86,3 +86,10 @@ def resend_verification(party_id):
     party_controller.resend_verification_email(party_id)
     logger.info('Re-sent verification email.', party_id=party_id)
     return render_template('sign-in/sign-in.verification-email-sent.html')
+
+
+@sign_in_bp.route('/resend-verification-expired-token/<token>', methods=['GET'])
+def resend_verification_expired_token(token):
+    party_controller.resend_verification_email_expired_token(token)
+    logger.info('Re-sent verification email for expired token.', token=token)
+    return render_template('sign-in/sign-in.verification-email-sent.html')

--- a/tests/app/test_sign_in.py
+++ b/tests/app/test_sign_in.py
@@ -192,14 +192,14 @@ class TestSignIn(unittest.TestCase):
     @requests_mock.mock()
     def test_resend_verification_email(self, mock_object):
         mock_object.get(get_respondent_by_id_url, json=party)
-        mock_object.get(url_resend_verification_email, status_code=200)
+        mock_object.post(url_resend_verification_email, status_code=200)
         response = self.app.get(f"/sign-in/resend_verification/{respondent_party_id}", follow_redirects=True)
         self.assertEqual(response.status_code, 200)
         self.assertTrue('Check your email'.encode() in response.data)
 
     @requests_mock.mock()
     def test_fail_resent_verification_email(self, mock_request):
-        mock_request.get(url_resend_verification_email, status_code=500)
+        mock_request.post(url_resend_verification_email, status_code=500)
         response = self.app.get(f"sign-in/resend_verification/{respondent_party_id}",
                                 follow_redirects=True)
         self.assertEqual(response.status_code, 500)
@@ -207,7 +207,7 @@ class TestSignIn(unittest.TestCase):
 
     @requests_mock.mock()
     def test_resend_verification_email_using_expired_token(self, mock_object):
-        mock_object.get(url_resend_verification_expired_token, status_code=200)
+        mock_object.post(url_resend_verification_expired_token, status_code=200)
 
         response = self.app.get(f'sign-in/resend-verification-expired-token/{token}',
                                 follow_redirects=True)
@@ -217,7 +217,7 @@ class TestSignIn(unittest.TestCase):
 
     @requests_mock.mock()
     def test_fail_resend_verification_email_using_expired_token(self, mock_object):
-        mock_object.get(url_resend_verification_expired_token, status_code=500)
+        mock_object.post(url_resend_verification_expired_token, status_code=500)
 
         response = self.app.get(f'sign-in/resend-verification-expired-token/{token}',
                                 follow_redirects=True)

--- a/tests/app/test_sign_in.py
+++ b/tests/app/test_sign_in.py
@@ -4,7 +4,7 @@ import requests_mock
 
 from config import TestingConfig
 from frontstage import app
-from tests.app.mocked_services import url_get_respondent_email, url_oauth_token, party
+from tests.app.mocked_services import token, url_get_respondent_email, url_oauth_token, party
 
 respondent_party_id = "cd592e0f-8d07-407b-b75d-e01fbdae8233"
 
@@ -16,6 +16,8 @@ encoded_jwt_token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJyZWZyZXNoX3Rva2VuIj
 
 url_resend_verification_email = f'{TestingConfig.PARTY_URL}/party-api/v1/resend-verification-email' \
                                 f'/{respondent_party_id}'
+url_resend_verification_expired_token = f'{TestingConfig.PARTY_URL}/party-api/v1' \
+                                        f'/resend-verification-email-expired-token/{token}'
 get_respondent_by_id_url = f'{TestingConfig.PARTY_URL}/party-api/v1/respondents/id/{respondent_party_id}'
 
 
@@ -200,5 +202,25 @@ class TestSignIn(unittest.TestCase):
         mock_request.get(url_resend_verification_email, status_code=500)
         response = self.app.get(f"sign-in/resend_verification/{respondent_party_id}",
                                 follow_redirects=True)
+        self.assertEqual(response.status_code, 500)
+        self.assertTrue('Server error'.encode() in response.data)
+
+    @requests_mock.mock()
+    def test_resend_verification_email_using_expired_token(self, mock_object):
+        mock_object.get(url_resend_verification_expired_token, status_code=200)
+
+        response = self.app.get(f'sign-in/resend-verification-expired-token/{token}',
+                                follow_redirects=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('Check your email'.encode() in response.data)
+
+    @requests_mock.mock()
+    def test_fail_resend_verification_email_using_expired_token(self, mock_object):
+        mock_object.get(url_resend_verification_expired_token, status_code=500)
+
+        response = self.app.get(f'sign-in/resend-verification-expired-token/{token}',
+                                follow_redirects=True)
+
         self.assertEqual(response.status_code, 500)
         self.assertTrue('Server error'.encode() in response.data)


### PR DESCRIPTION
# Motivation and Context
If a respondent attempts to use an expired verification token (older than 80 hours) then they have to phone us and request to be sent another link.  This change allows respondents to resend the verification link to their email.

# What has changed
- Amended the page that is displayed when users attempt to us an expired link, giving them the option to send another.
- Call to a new endpoint in party to use the expired token to send another mail.
- Added tests.

# How to test?
- Run against branch`206-resend-verification-if-using-expired-link` in ras-party.  Ensure that `EMAIL_TOKEN_EXPIRY` is set to 0 in party so that the links immediately expire when manually testing.
- Using the new link to resend the verification email should generate a new verification link - check in party logs.
- All tests should pass.

# Links
- https://trello.com/c/fqc35BzO
