### PR TITLE
Get only the live collection excercises for survey

### DIFF
--- a/frontstage/controllers/collection_exercise_controller.py
+++ b/frontstage/controllers/collection_exercise_controller.py
@@ -53,10 +53,13 @@ def get_collection_exercise_events(collection_exercise_id):
     return response.json()
 
 
-def get_collection_exercises_for_survey(survey_id):
+def get_collection_exercises_for_survey(survey_id, live_only=None):
     logger.debug('Retrieving collection exercises for survey', survey_id=survey_id)
 
-    url = f"{app.config['COLLECTION_EXERCISE_URL']}/collectionexercises/survey/{survey_id}"
+    if live_only is True:
+        url = f"{app.config['COLLECTION_EXERCISE_URL']}/collectionexercises/survey/{survey_id}?liveOnly=true"
+    else:
+        url = f"{app.config['COLLECTION_EXERCISE_URL']}/collectionexercises/survey/{survey_id}"
 
     response = requests.get(url, auth=app.config['COLLECTION_EXERCISE_AUTH'])
 
@@ -79,11 +82,7 @@ def get_collection_exercises_for_survey(survey_id):
 
 
 def get_live_collection_exercises_for_survey(survey_id):
-    collection_exercises = get_collection_exercises_for_survey(survey_id)
-    return [collection_exercise
-            for collection_exercise in collection_exercises
-            if collection_exercise['state'] == 'LIVE'
-            and not collection_exercise['events']['go_live']['is_in_future']]
+    return get_collection_exercises_for_survey(survey_id, True)
 
 
 def convert_events_to_new_format(events):

--- a/tests/app/controllers/test_collection_exercise_controller.py
+++ b/tests/app/controllers/test_collection_exercise_controller.py
@@ -1,5 +1,4 @@
 import unittest
-from unittest.mock import patch
 
 import responses
 from iso8601 import ParseError
@@ -8,7 +7,7 @@ from config import TestingConfig
 from frontstage import app
 from frontstage.controllers import collection_exercise_controller
 from frontstage.exceptions.exceptions import ApiError
-from tests.app.mocked_services import collection_exercise, collection_exercise_by_survey, survey, \
+from tests.app.mocked_services import collection_exercise, collection_exercise_by_survey, \
     url_get_collection_exercises_by_survey
 
 
@@ -34,20 +33,6 @@ class TestCollectionExerciseController(unittest.TestCase):
             with app.app_context():
                 with self.assertRaises(ApiError):
                     collection_exercise_controller.get_collection_exercises_for_survey(collection_exercise['surveyId'])
-
-    @patch('frontstage.controllers.collection_exercise_controller.get_collection_exercises_for_survey')
-    def test_get_live_collection_exercises_for_survey(self, get_collection_exercises_for_survey):
-        for ce in collection_exercise_by_survey:
-            if ce['events']:
-                ce['events'] = collection_exercise_controller.convert_events_to_new_format(ce['events'])
-
-        get_collection_exercises_for_survey.return_value = collection_exercise_by_survey
-
-        live_collection_exercises = collection_exercise_controller.get_live_collection_exercises_for_survey(survey['id'])
-
-        for live_collection_exercise in live_collection_exercises:
-            self.assertEqual(live_collection_exercise['state'], 'LIVE')
-            self.assertFalse(live_collection_exercise['events']['go_live']['is_in_future'])
 
     def test_convert_events_to_new_format_successful(self):
         formatted_events = collection_exercise_controller.convert_events_to_new_format(collection_exercise['events'])

--- a/tests/app/controllers/test_party_controller.py
+++ b/tests/app/controllers/test_party_controller.py
@@ -6,6 +6,7 @@ import responses
 from config import TestingConfig
 from frontstage import app
 from frontstage.controllers import party_controller
+from frontstage.controllers.collection_exercise_controller import convert_events_to_new_format
 from frontstage.controllers.party_controller import change_respondent_status
 from frontstage.exceptions.exceptions import ApiError
 from tests.app.mocked_services import (business_party, case, case_list, collection_exercise,
@@ -180,6 +181,11 @@ class TestPartyController(unittest.TestCase):
             'business_id': business_party['id'],
             'survey_id': survey['id']
         }]
+
+        for collection_exercise_index in collection_exercise_by_survey:
+            if collection_exercise_index['events']:
+                collection_exercise_index['events'] = convert_events_to_new_format(collection_exercise_index['events'])
+
         get_respondent_enrolments.return_value = enrolments
         get_collection_exercises.return_value = collection_exercise_by_survey
         get_cases.return_value = case_list


### PR DESCRIPTION
# Motivation and Context
The Collection Exercise service has been enhanced to be able to return only collexes which are in LIVE state, so that they don't have to be received and filtered by Response-Ops and Frontstage.

# What has changed
Updated method `get_collection_exercises_for_survey` so that it has an optional parameter to only return the live collexes and updated `get_live_collection_exercises_for_survey` to use that method instead of doing the filtering.

# How to test?
Load frontstage and check that only live collection exercises can be viewed.

# Links
Trello: https://trello.com/c/NFKGLLkV/370-logic-to-be-removed-in-affected-services-ie-frontstage-rops-m
