### PR TITLE
Logout RAS RM from EQ

### DIFF
--- a/config.py
+++ b/config.py
@@ -31,6 +31,7 @@ class Config(object):
     ZIPKIN_SAMPLE_RATE = int(os.getenv("ZIPKIN_SAMPLE_RATE", 0))
 
     ACCOUNT_SERVICE_URL = os.getenv('ACCOUNT_SERVICE_URL')
+    ACCOUNT_SERVICE_LOG_OUT_URL = os.getenv('ACCOUNT_SERVICE_LOG_OUT_URL')
     EQ_URL = os.getenv('EQ_URL')
     JSON_SECRET_KEYS = os.getenv('JSON_SECRET_KEYS')
 
@@ -81,7 +82,6 @@ class Config(object):
     SURVEY_AUTH = (SURVEY_USERNAME, SURVEY_PASSWORD)
 
 
-
 class DevelopmentConfig(Config):
     DEVELOPMENT = True
     DEBUG = True
@@ -94,6 +94,7 @@ class DevelopmentConfig(Config):
     BASIC_AUTH = (SECURITY_USER_NAME, SECURITY_USER_PASSWORD)
 
     ACCOUNT_SERVICE_URL = os.getenv('ACCOUNT_SERVICE_URL', 'http://localhost:8082/surveys/todo')
+    ACCOUNT_SERVICE_LOG_OUT_URL = os.getenv('ACCOUNT_SERVICE_LOG_OUT_URL', 'http://localhost:8082/sign-in/logout')
     EQ_URL = os.getenv('EQ_URL', 'https://localhost:5000/session?token=')
     JSON_SECRET_KEYS = os.getenv('JSON_SECRET_KEYS') or open("./tests/test_data/jwt-test-keys/test_key.json").read()
 
@@ -143,5 +144,6 @@ class TestingConfig(DevelopmentConfig):
     JWT_SECRET = 'testsecret'
     REDIS_DB = os.getenv('REDIS_DB', 13)
     ACCOUNT_SERVICE_URL = 'http://frontstage-url/surveys'
+    ACCOUNT_SERVICE_LOG_OUT_URL = 'http://frontstage-url/sign-in/logout'
     EQ_URL = 'https://eq-test/session?token='
     JSON_SECRET_KEYS = open("./tests/test_data/jwt-test-keys/test_key.json").read()

--- a/frontstage/common/eq_payload.py
+++ b/frontstage/common/eq_payload.py
@@ -49,6 +49,7 @@ class EqPayload(object):
         party = party_controller.get_party_by_business_id(business_party_id, collection_exercise_id=collex_id)
 
         account_service_url = current_app.config['ACCOUNT_SERVICE_URL']
+        account_service_log_out_url = current_app.config['ACCOUNT_SERVICE_LOG_OUT_URL']
         iat = time.time()
         exp = time.time() + (5 * 60)
 
@@ -69,6 +70,7 @@ class EqPayload(object):
             'case_id': case['id'],
             'case_ref': case['caseRef'],
             'account_service_url': account_service_url,
+            'account_service_log_out_url': account_service_log_out_url,
             'trad_as': f"{party['tradstyle1']} {party['tradstyle2']} {party['tradstyle3']}"
         }
 

--- a/tests/test_data/eq_payload.json
+++ b/tests/test_data/eq_payload.json
@@ -15,6 +15,7 @@
     "case_id": "8cdc01f9-656a-4715-a148-ffed0dbe1b04",
     "case_ref": "1000000000000022",
     "account_service_url": "http://localhost:8082/surveys/todo",
+    "account_service_log_out_url": "http://localhost:8082/sign-in/logout",
     "trad_as": "TOTAL UK ACTIVITY  ",
     "ref_p_start_date": "2018-06-15",
     "ref_p_end_date": "2018-06-30",


### PR DESCRIPTION
# Motivation and Context
EQ have implemented the logout facility so redirect to our logout page, but they need us to provide the url to redirect to. Although we already pass the location of the todo list we also need to do this as well with another variable we can pass to logout to the relevant page.

# What has changed
Adding in a new variable to pass in the payload to EQ to logout from EQ & RAS to the signed out page.
A new env has also been introduced to Jenkins for this as well.

# How to test?
Ensure AT pass etc.

# Links
Trello Card: https://trello.com/c/6Bfd2jlB/382-logout-ras-rm-from-eq-m
