### PR TITLE
207 resend password reset link if expired

### DIFF
--- a/frontstage/controllers/party_controller.py
+++ b/frontstage/controllers/party_controller.py
@@ -174,6 +174,18 @@ def reset_password_request(username):
     logger.debug('Successfully sent reset password request to party service')
 
 
+def resend_password_email_expired_token(token):
+    logger.debug('Re-sending verification email', token=token)
+    url = f'{app.config["PARTY_URL"]}/party-api/v1/resend-password-email-expired-token/{token}'
+    response = requests.post(url, auth=app.config['PARTY_AUTH'])
+
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError:
+        raise ApiError(logger, response, log_level='exception',
+                       message='Re-sending of password email for expired token failed')
+
+
 def verify_email(token):
     logger.debug('Attempting to verify email address', token=token)
 

--- a/frontstage/templates/passwords/password-expired.html
+++ b/frontstage/templates/passwords/password-expired.html
@@ -9,10 +9,7 @@
 
 <div>
     <p>
-        You can either <a href="/passwords/forgot-password">request another password reset</a>.
-    </p>
-    <p>
-        or <a href="/sign-in">sign in</a> with your existing password.
+        You can <a href="{{ url_for('passwords_bp.resend_password_email_expired_token', token=token) }}">request another password reset email</a> or call us on <a href="tel:03001234931">0300 1234 931</a>.
     </p>
 </div>
 

--- a/frontstage/templates/passwords/password-expired.html
+++ b/frontstage/templates/passwords/password-expired.html
@@ -9,7 +9,8 @@
 
 <div>
     <p>
-        You can <a href="{{ url_for('passwords_bp.resend_password_email_expired_token', token=token) }}">request another password reset email</a> or call us on <a href="tel:03001234931">0300 1234 931</a>.
+        You can <a href="{{ url_for('passwords_bp.resend_password_email_expired_token', token=token) }}">request another password reset email</a>
+        or call us on <a href="tel:03001234931">0300 1234 931</a>.
     </p>
 </div>
 

--- a/frontstage/templates/passwords/password-expired.html
+++ b/frontstage/templates/passwords/password-expired.html
@@ -9,7 +9,7 @@
 
 <div>
     <p>
-        You can <a href="{{ url_for('passwords_bp.resend_password_email_expired_token', token=token) }}">request another password reset email</a>
+        You can <a href="{{ url_for('passwords_bp.resend_password_email_expired_token', token=token) }}">request another password reset email</a><br/>
         or call us on <a href="tel:03001234931">0300 1234 931</a>.
     </p>
 </div>

--- a/frontstage/templates/passwords/password-expired.html
+++ b/frontstage/templates/passwords/password-expired.html
@@ -9,8 +9,8 @@
 
 <div>
     <p>
-        You can <a href="{{ url_for('passwords_bp.resend_password_email_expired_token', token=token) }}">request another password reset email</a><br/>
-        or call us on <a href="tel:03001234931">0300 1234 931</a>.
+        You can <a href="{{ url_for('passwords_bp.resend_password_email_expired_token', token=token) }}">request another password reset email</a> or call us on <br/>
+        <a href="tel:03001234931">0300 1234 931</a>.
     </p>
 </div>
 

--- a/frontstage/templates/passwords/reset-password.check-email.html
+++ b/frontstage/templates/passwords/reset-password.check-email.html
@@ -1,0 +1,36 @@
+{% import 'partials/section.html' as section %}
+{% extends "layouts/_twocol.html" %}
+
+{% block page_title %}Check your email - Forgot password - ONS Business Surveys{% endblock %}
+
+{% block main %}
+
+    <h1 class="saturn">Check your email</h1>
+
+    <p>Please follow the link in the email we've sent you to reset your password and sign in to your account.</p>
+
+    <div class="guidance js-details"
+     data-guidance-label="Help with email"
+     data-guidance="Help with email"
+     data-hide-label="Hide help with email"
+     data-show-label="Show help with email">
+
+    <a class="guidance__link js-details-trigger js-details-label icon--details mars"
+       id="guidance-help-with-email"
+       data-guidance-trigger="true"
+       aria-expanded="false"
+       href="#guidance-help-with-email"
+       aria-controls="guidance-help-with-email">Help with email</a>
+
+    <div class="guidance__main js-details-body" id="guidance-help-with-email" aria-hidden="true">
+        <div class="guidance__content mars">
+            <div>
+              <p>If you don't receive this within 15 minutes, try checking your spam folder.</p>
+              <p>If you're still having problems, call us on <a href="tel:03001234931">0300 1234 931</a>.</p>
+            </div>
+        </div>
+    </div>
+
+</div>
+
+{% endblock main %}

--- a/frontstage/views/passwords/reset_password.py
+++ b/frontstage/views/passwords/reset_password.py
@@ -21,7 +21,7 @@ def get_reset_password(token, form_errors=None):
     except ApiError as exc:
         if exc.status_code == 409:
             logger.warning('Token expired', api_url=exc.url, api_status_code=exc.status_code, token=token)
-            return render_template('passwords/password-expired.html')
+            return render_template('passwords/password-expired.html', token=token)
         elif exc.status_code == 404:
             logger.warning('Invalid token sent to party service', api_url=exc.url, api_status_code=exc.status_code,
                            token=token)
@@ -52,7 +52,7 @@ def post_reset_password(token):
     except ApiError as exc:
         if exc.status_code == 409:
             logger.warning('Token expired', api_url=exc.url, api_status_code=exc.status_code, token=token)
-            return render_template('passwords/password-expired.html')
+            return render_template('passwords/password-expired.html', token=token)
         elif exc.status_code == 404:
             logger.warning('Invalid token sent to party service', api_url=exc.url, api_status_code=exc.status_code,
                            token=token)
@@ -67,3 +67,10 @@ def post_reset_password(token):
 @passwords_bp.route('/reset-password/confirmation', methods=['GET'])
 def reset_password_confirmation():
     return render_template('passwords/reset-password.confirmation.html')
+
+
+@passwords_bp.route('/resend-password-email-expired-token/<token>', methods=['GET'])
+def resend_password_email_expired_token(token):
+    party_controller.resend_password_email_expired_token(token)
+    logger.info('Re-sent password email for expired token.', token=token)
+    return render_template('sign-in/sign-in.verification-email-sent.html')

--- a/frontstage/views/passwords/reset_password.py
+++ b/frontstage/views/passwords/reset_password.py
@@ -73,4 +73,9 @@ def reset_password_confirmation():
 def resend_password_email_expired_token(token):
     party_controller.resend_password_email_expired_token(token)
     logger.info('Re-sent password email for expired token.', token=token)
+    return redirect(url_for('passwords_bp.reset_password_check_email'))
+
+
+@passwords_bp.route('/reset-password/check-email', methods=['GET'])
+def reset_password_check_email():
     return render_template('passwords/reset-password.check-email.html')

--- a/frontstage/views/passwords/reset_password.py
+++ b/frontstage/views/passwords/reset_password.py
@@ -73,4 +73,4 @@ def reset_password_confirmation():
 def resend_password_email_expired_token(token):
     party_controller.resend_password_email_expired_token(token)
     logger.info('Re-sent password email for expired token.', token=token)
-    return render_template('sign-in/sign-in.verification-email-sent.html')
+    return render_template('passwords/reset-password.check-email.html')


### PR DESCRIPTION
# Motivation and Context
When a respondent requests a change of password, they are emailed a link that expires after 80 hours.  If they try to use the link after the 80 hours then they are redirected to a page that tells them to phone us for another link.  This PR allows the respondent to generate a new link which is then sent to the email registered to their account.

# What has changed
<!--- What code changes has been made -->
New and amended pages to allow a user to resend a password reset link if the one they attempt to use has expired. 

# How to test?
- All unit tests should pass
- Set the EMAIL_TOKEN_EXPIRY in party config to -1 so that tokens expire as soon as they're created (otherwise you'll be waiting 80 hours for one to expire)
- Run this branch alongside `207-resend-password-reset-link-if-expired` in ras-party
- In frontstage, request a password reset for an active account - check the party logs to find it
- Follow the link to reset the password.  The link should be expired and you should be redirected to a page and given the option to resend a password reset link
- Click the link to send another and check in the party logs that another link has been generated
- You should finally be redirected to the 'Check your email page'
- The new link that's been generated in party should allow you to reset your password as normal (if you change the EMAIL_TOKEN_EXPIRY back)


# Links
- https://trello.com/c/1FXbQiA2