### PR TITLE
Remove unnecessary auth call

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ install:
   - pipenv install --dev --deploy
 
 script:
+  - make lint
   - APP_SETTINGS=TestingConfig pipenv run pytest --cov=frontstage --cov-report xml --ignore=node_modules
   - pipenv run coverage report
 

--- a/frontstage/controllers/oauth_controller.py
+++ b/frontstage/controllers/oauth_controller.py
@@ -10,36 +10,6 @@ from frontstage.exceptions.exceptions import ApiError, OAuth2Error
 logger = wrap_logger(logging.getLogger(__name__))
 
 
-def check_account_valid(username):
-    logger.debug('Attempting to check if account is valid in OAuth2 service')
-
-    url = f"{app.config['OAUTH_URL']}/api/v1/tokens/"
-    data = {
-        'grant_type': 'reset_password',
-        'client_id': app.config['OAUTH_CLIENT_ID'],
-        'client_secret': app.config['OAUTH_CLIENT_SECRET'],
-        'username': username,
-    }
-    headers = {
-        'Accept': 'application/json',
-        'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
-    }
-    response = requests.post(url, headers=headers, auth=app.config['OAUTH_BASIC_AUTH'], data=data)
-
-    try:
-        response.raise_for_status()
-    except requests.exceptions.HTTPError:
-        if response.status_code == 401:
-            oauth2_error = response.json().get('detail', '')
-            message = 'Authentication error in OAuth2 service'
-            raise OAuth2Error(logger, response, log_level='warning', message=message, oauth2_error=oauth2_error)
-        else:
-            message = 'Failed to check if account is valid in OAuth2 service'
-            raise ApiError(logger, response, log_level='exception', message=message)
-
-    logger.debug('Successfully checked account state, account is valid')
-
-
 def sign_in(username, password):
     logger.debug('Attempting to retrieve OAuth2 token for sign-in')
 

--- a/frontstage/controllers/party_controller.py
+++ b/frontstage/controllers/party_controller.py
@@ -6,8 +6,7 @@ from structlog import wrap_logger
 
 from frontstage.controllers import case_controller, collection_exercise_controller, collection_instrument_controller, \
     survey_controller
-from frontstage.exceptions.exceptions import ApiError
-
+from frontstage.exceptions.exceptions import ApiError, UserDoesNotExist
 
 logger = wrap_logger(logging.getLogger(__name__))
 
@@ -167,9 +166,10 @@ def reset_password_request(username):
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError:
-        log_level = 'warning' if response.status_code == 404 else 'exception'
+        if response.status_code == 404:
+            raise UserDoesNotExist("User does not exist in party service")
         message = 'Failed to send reset password request to party service'
-        raise ApiError(logger, response, log_level=log_level, message=message)
+        raise ApiError(logger, response, log_level='exception', message=message)
 
     logger.debug('Successfully sent reset password request to party service')
 

--- a/frontstage/exceptions/exceptions.py
+++ b/frontstage/exceptions/exceptions.py
@@ -87,3 +87,9 @@ class InvalidEqPayLoad(Exception):
     def __init__(self, message):
         super().__init__()
         self.message = message
+
+
+class UserDoesNotExist(Exception):
+    def __init__(self, message):
+        super().__init__()
+        self.message = message

--- a/tests/app/test_passwords.py
+++ b/tests/app/test_passwords.py
@@ -4,7 +4,7 @@ import requests_mock
 
 from config import TestingConfig
 from frontstage import app
-from tests.app.mocked_services import token, url_get_token, url_password_change, url_reset_password_request, \
+from tests.app.mocked_services import token, url_password_change, url_reset_password_request, \
     url_verify_token
 
 
@@ -39,7 +39,6 @@ class TestPasswords(unittest.TestCase):
 
     @requests_mock.mock()
     def test_forgot_password_post_success(self, mock_object):
-        mock_object.post(url_get_token, status_code=201, json=self.oauth2_response)
         mock_object.post(url_reset_password_request, status_code=200)
 
         response = self.app.post("passwords/forgot-password", data=self.email_form, follow_redirects=True)
@@ -64,47 +63,19 @@ class TestPasswords(unittest.TestCase):
         self.assertTrue('Invalid email'.encode() in response.data)
 
     @requests_mock.mock()
-    def test_forgot_password_post_unrecognised_email_oauth(self, mock_object):
-        mock_object.post(url_get_token, status_code=401, json={"detail": "Unauthorized user credentials"})
-
-        response = self.app.post("passwords/forgot-password", follow_redirects=True)
-
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue('Invalid email'.encode() in response.data)
-
-    @requests_mock.mock()
     def test_forgot_password_post_unrecognised_email_party(self, mock_object):
-        mock_object.post(url_get_token, status_code=201, json=self.oauth2_response)
         mock_object.post(url_reset_password_request, status_code=404)
 
         self.email_form['email_address'] = "test@email.com"
 
         response = self.app.post("passwords/forgot-password", data=self.email_form, follow_redirects=True)
 
-        self.assertEqual(response.status_code, 500)
-        self.assertTrue('Server error'.encode() in response.data)
-
-    @requests_mock.mock()
-    def test_forgot_password_post_locked_email(self, mock_object):
-        mock_object.post(url_get_token, status_code=401, json={"detail": "User account locked"})
-
-        response = self.app.post("passwords/forgot-password", data=self.email_form, follow_redirects=True)
-
         self.assertEqual(response.status_code, 200)
-        self.assertTrue('Something went wrong'.encode() in response.data)
-
-    @requests_mock.mock()
-    def test_forgot_password_post_not_understood_401(self, mock_object):
-        mock_object.post(url_get_token, status_code=401, json={"detail": "is not understood"})
-
-        response = self.app.post("passwords/forgot-password", data=self.email_form, follow_redirects=True)
-
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue('Something went wrong'.encode() in response.data)
+        self.assertTrue('Check your email'.encode() in response.data)
 
     @requests_mock.mock()
     def test_forgot_password_post_api_call_fail(self, mock_object):
-        mock_object.post(url_get_token, status_code=500)
+        mock_object.post(url_reset_password_request, status_code=500)
 
         response = self.app.post("passwords/forgot-password", data=self.email_form, follow_redirects=True)
 


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
A call to authentication service was introduced as a way to stop locked users to reset their password in [PR230](https://github.com/ONSdigital/ras-frontstage/pull/230).

The requirements around this has changed so locked users can now reset their password and unlock
their account (changed logic in django-oauth-test [PR46](https://github.com/ONSdigital/django-oauth2-test/pull/46) ). Which now makes the call to the django-oauth-test service redundant.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Removed the call to django-oauth-test for send reset password email

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Ran AT and check you can still reset your password for both locked and unlocked account.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):
