### PR TITLE
Change log level for page not found message

### DIFF
--- a/frontstage/error_handlers.py
+++ b/frontstage/error_handlers.py
@@ -13,7 +13,7 @@ logger = wrap_logger(logging.getLogger(__name__))
 
 @app.errorhandler(404)
 def not_found_error(error):
-    logger.error('Not found error', url=request.url, status_code=error.code)
+    logger.info('Not found error', url=request.url, status_code=error.code)
     return render_template('errors/404-error.html'), 404
 
 


### PR DESCRIPTION
# Motivation and Context
Currently, when a page that doesn't exist is hit, it generates an error log line.  Enough of those triggers an alert.  This is generally fine, except thanks to outside actors blindly scanning the internet for weaknesses and exposed admin pages, this alert gets triggered frequently.

Making this info means we'll see it in the logs, but not have an alert trigger.
There is a second part to this card that needs to be done when it gets merged/deployed.  We need to create a new alert that checks for this 'Not found error' message and only alert if it appears an abnormally high number of times.