### PR TITLE
Only display access survey button for eQ when:

### DIFF
--- a/frontstage/controllers/party_controller.py
+++ b/frontstage/controllers/party_controller.py
@@ -8,6 +8,8 @@ from frontstage.controllers import case_controller, collection_exercise_controll
     survey_controller
 from frontstage.exceptions.exceptions import ApiError, UserDoesNotExist
 
+CLOSED_STATE = ['COMPLETE', 'COMPLETEDBYPHONE', 'NOLONGERREQUIRED']
+
 logger = wrap_logger(logging.getLogger(__name__))
 
 
@@ -245,6 +247,9 @@ def get_survey_list_details_for_party(party_id, tag, business_party_id, survey_i
             )
             collection_exercise = collection_exercises_by_id[case['caseGroup']['collectionExerciseId']]
             added_survey = True if business_party_id == business_party['id'] and survey_id == survey['id'] else None
+            display_access_button = should_display_access_button(case['caseGroup']['caseGroupStatus'],
+                                                                 collection_instrument['type'])
+
             yield {
 
                 'case_id': case['id'],
@@ -262,8 +267,15 @@ def get_survey_list_details_for_party(party_id, tag, business_party_id, survey_i
                 'period': collection_exercise['userDescription'],
                 'submit_by': collection_exercise['events']['return_by']['date'],
                 'collection_exercise_ref': collection_exercise['exerciseRef'],
-                'added_survey': added_survey
+                'added_survey': added_survey,
+                'display_access_button': display_access_button
             }
+
+
+def should_display_access_button(status, ci_type):
+    if status not in CLOSED_STATE or not ci_type == 'EQ':
+        return True
+    return False
 
 
 def is_respondent_enrolled(party_id, business_party_id, survey_short_name, return_survey=False):

--- a/frontstage/controllers/party_controller.py
+++ b/frontstage/controllers/party_controller.py
@@ -247,8 +247,7 @@ def get_survey_list_details_for_party(party_id, tag, business_party_id, survey_i
             )
             collection_exercise = collection_exercises_by_id[case['caseGroup']['collectionExerciseId']]
             added_survey = True if business_party_id == business_party['id'] and survey_id == survey['id'] else None
-            display_access_button = should_display_access_button(case['caseGroup']['caseGroupStatus'],
-                                                                 collection_instrument['type'])
+            display_access_button = display_button(case['caseGroup']['caseGroupStatus'], collection_instrument['type'])
 
             yield {
 
@@ -268,14 +267,12 @@ def get_survey_list_details_for_party(party_id, tag, business_party_id, survey_i
                 'submit_by': collection_exercise['events']['return_by']['date'],
                 'collection_exercise_ref': collection_exercise['exerciseRef'],
                 'added_survey': added_survey,
-                'display_access_button': display_access_button
+                'display_button': display_access_button
             }
 
 
-def should_display_access_button(status, ci_type):
-    if status not in CLOSED_STATE or not ci_type == 'EQ':
-        return True
-    return False
+def display_button(status, ci_type):
+    return not(ci_type == 'EQ' and status in CLOSED_STATE)
 
 
 def is_respondent_enrolled(party_id, business_party_id, survey_short_name, return_survey=False):

--- a/frontstage/templates/surveys/surveys.html
+++ b/frontstage/templates/surveys/surveys.html
@@ -49,7 +49,7 @@
             <span id="status-{{ loop.index }}" name="status">{{ survey.status }}</span>
         </div>
         <div class="grid__col col-2@m">
-            {% if not survey.display_access_button %}
+            {% if survey.display_button %}
              <a href="{{ url_for('surveys_bp.access_survey', case_id=survey.case_id, ci_type = survey.collection_instrument_type, business_party_id=survey.business_party_id, survey_short_name=survey.survey_short_name) }}"
                {% if survey.collection_instrument_type == 'EQ' %}
                 onclick="ga('send', 'event', 'survey', 'launcheq', 'survey_ref = {{ survey.survey_ref }} collection_exercise_ref = {{ survey.collection_exercise_ref }}');"

--- a/frontstage/templates/surveys/surveys.html
+++ b/frontstage/templates/surveys/surveys.html
@@ -49,7 +49,7 @@
             <span id="status-{{ loop.index }}" name="status">{{ survey.status }}</span>
         </div>
         <div class="grid__col col-2@m">
-            {% if not survey.status in ['Complete', 'Completed by phone', 'No longer required'] or not survey.collection_instrument_type == 'EQ' %}
+            {% if not survey.display_access_button %}
              <a href="{{ url_for('surveys_bp.access_survey', case_id=survey.case_id, ci_type = survey.collection_instrument_type, business_party_id=survey.business_party_id, survey_short_name=survey.survey_short_name) }}"
                {% if survey.collection_instrument_type == 'EQ' %}
                 onclick="ga('send', 'event', 'survey', 'launcheq', 'survey_ref = {{ survey.survey_ref }} collection_exercise_ref = {{ survey.collection_exercise_ref }}');"

--- a/frontstage/templates/surveys/surveys.html
+++ b/frontstage/templates/surveys/surveys.html
@@ -49,7 +49,7 @@
             <span id="status-{{ loop.index }}" name="status">{{ survey.status }}</span>
         </div>
         <div class="grid__col col-2@m">
-            {% if not survey.status == 'Complete' or not survey.collection_instrument_type == 'EQ' %}
+            {% if not survey.status in ['Complete', 'Completed by phone', 'No longer required'] or not survey.collection_instrument_type == 'EQ' %}
              <a href="{{ url_for('surveys_bp.access_survey', case_id=survey.case_id, ci_type = survey.collection_instrument_type, business_party_id=survey.business_party_id, survey_short_name=survey.survey_short_name) }}"
                {% if survey.collection_instrument_type == 'EQ' %}
                 onclick="ga('send', 'event', 'survey', 'launcheq', 'survey_ref = {{ survey.survey_ref }} collection_exercise_ref = {{ survey.collection_exercise_ref }}');"

--- a/tests/app/controllers/test_party_controller.py
+++ b/tests/app/controllers/test_party_controller.py
@@ -7,6 +7,7 @@ from config import TestingConfig
 from frontstage import app
 from frontstage.controllers import party_controller
 from frontstage.controllers.collection_exercise_controller import convert_events_to_new_format
+from frontstage.controllers.party_controller import should_display_access_button
 from frontstage.exceptions.exceptions import ApiError
 from tests.app.mocked_services import (business_party, case, case_list, collection_exercise,
                                        collection_exercise_by_survey,
@@ -197,7 +198,8 @@ class TestPartyController(unittest.TestCase):
         get_survey.return_value = survey
         get_business.return_value = business_party
 
-        survey_list = party_controller.get_survey_list_details_for_party(respondent_party['id'], 'todo', business_party['id'], survey['id'])
+        survey_list = party_controller.get_survey_list_details_for_party(respondent_party['id'], 'todo',
+                                                                         business_party['id'], survey['id'])
 
         for survey_details in survey_list:
             self.assertTrue(survey_details['case_id'] is not None)
@@ -208,3 +210,12 @@ class TestPartyController(unittest.TestCase):
             self.assertTrue(survey_details['survey_short_name'] is not None)
             self.assertTrue(survey_details['business_party_id'] is not None)
             self.assertTrue(survey_details['collection_exercise_ref'] is not None)
+
+    def test_should_not_display_access_button_for_eQ(self):
+        self.assertFalse(should_display_access_button(status='COMPLETE', ci_type='EQ'))
+
+    def test_should_display_access_button_for_eQ(self):
+        self.assertTrue(should_display_access_button(status='NOTSTARTED', ci_type='SEFT'))
+
+    def test_should_display_access_button_for_SEFT(self):
+        self.assertTrue(should_display_access_button(status='COMPLETE', ci_type='SEFT'))


### PR DESCRIPTION
# Motivation and Context
Only display access survey button for eQ when: 
 - notstarted, 
 - inprogress,
 - reopened

# What has changed
Above

# How to test?
Change casegroup status and see if button disappears

