### PR TITLE
posting metadata to case service

### DIFF
--- a/frontstage/controllers/case_controller.py
+++ b/frontstage/controllers/case_controller.py
@@ -169,7 +169,7 @@ def post_case_event(case_id, party_id, category, description):
     message = {
         'description': description,
         'category': category,
-        'partyId': party_id,
+        'metadata': {'partyId': party_id},
         'createdBy': 'RAS_FRONTSTAGE'
     }
     response = requests.post(url, auth=app.config['CASE_AUTH'], json=message)


### PR DESCRIPTION
# Motivation and Context
In response-operation-ui, we want to be able to see the respondent name on the responses status page when a external user has completed a collection exercise. For this to happen, Frontstage needs to post a case event with metadata containing the party_id of the respondent. This can then be used for the response status page.

# What has changed
- Changed party_id to metadata when posting case event message

# How to test?
- Run `mvn clean install` and it should build successfully
- Run with the [case-svc-api PR](https://github.com/ONSdigital/rm-casesvc-api/pull/33), [R-ops branch](https://github.com/ONSdigital/response-operations-ui/tree/us211-display-respondent-for-seft-rus-ce-in-response-status), [Case service PR](https://github.com/ONSdigital/rm-case-service/pull/100) and complete a SEFT collection exercise. When completed, look on response ops response status page and the completed collex should have a respondent name attached to it.
- Run with acceptance tests

# Links
[Trello](https://trello.com/c/1rcfmtok)
