### PR TITLE
Use smaller base layer for Docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM python:3.6
-MAINTAINER David Carboni
+FROM python:3.6-slim
 
 WORKDIR /app
 COPY . /app
 EXPOSE 8082
+RUN apt-get update -y && apt-get install -y python-pip
 RUN pip3 install pipenv==8.3.2 && pipenv install --system --deploy
 
 ENTRYPOINT ["python3"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.6-slim
 WORKDIR /app
 COPY . /app
 EXPOSE 8082
-RUN apt-get update -y && apt-get install -y python-pip
+RUN apt-get update -y && apt-get install -y python-pip && apt-get install -y curl
 RUN pip3 install pipenv==8.3.2 && pipenv install --system --deploy
 
 ENTRYPOINT ["python3"]


### PR DESCRIPTION
# Motivation and Context
Reduce size of Docker image from 1.08Gb to 643Mb using smaller python:3.6-slim base layer.

