### PR TITLE
Sends to specific internal user instead of group, and defaults dev co…

### DIFF
--- a/config.py
+++ b/config.py
@@ -118,9 +118,9 @@ class DevelopmentConfig(Config):
     IAC_PASSWORD = os.getenv('IAC_PASSWORD', 'secret')
     IAC_AUTH = (IAC_USERNAME, IAC_PASSWORD)
 
-    OAUTH_URL = os.getenv('OAUTH_URL', 'http://localhost:8040')
-    OAUTH_CLIENT_ID = os.getenv('OAUTH_CLIENT_ID', 'ons@ons.gov')
-    OAUTH_CLIENT_SECRET = os.getenv('OAUTH_CLIENT_SECRET', 'password')
+    OAUTH_URL = os.getenv('OAUTH_URL', 'http://localhost:8041')
+    OAUTH_CLIENT_ID = os.getenv('OAUTH_CLIENT_ID', 'admin')
+    OAUTH_CLIENT_SECRET = os.getenv('OAUTH_CLIENT_SECRET', 'secret')
     OAUTH_BASIC_AUTH = (OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET)
 
     PARTY_URL = os.getenv('PARTY_URL', 'http://localhost:8081')

--- a/frontstage/common/message_helper.py
+++ b/frontstage/common/message_helper.py
@@ -15,11 +15,25 @@ def refine(message):
         'body': message.get('body'),
         'survey_id': message.get('survey'),
         'ru_ref': get_ru_ref_from_message(message),
-        'from': get_from_name(message),
+        'from': get_from_name(message),                     # As displayed to user
+        'from_internal': from_internal(message),
+        'internal_user': get_internal_user_id(message),
         'sent_date': get_human_readable_date(message.get('sent_date')),
         'unread': get_unread_status(message),
         'message_id': message.get('msg_id')
     }
+
+
+def from_internal(message):
+    """returns True if this message was sent by an internal user, else False"""
+    return message.get('from_internal', False)
+
+
+def get_internal_user_id(message):
+    """Determine the secure message id of the internal user associated with this message. Note the @msg_to field
+    supports multiple recipients and is a list , hence for msg_to we use the 0th element"""
+
+    return message['@msg_from']['id'] if from_internal(message) else message['@msg_to'][0]['id']
 
 
 def get_message_subject(message):
@@ -32,7 +46,7 @@ def get_message_subject(message):
 
 
 def get_from_name(message):
-    if message.get('from_internal', False):
+    if from_internal(message):
         return "ONS Business Surveys Team"
 
     try:
@@ -41,7 +55,7 @@ def get_from_name(message):
         logger.error('Failed to retrieve name from message', message_id=message.get('msg_id'))
         raise
 
-    return "{} {}".format(msg_from.get('firstName'), msg_from.get('lastName'))
+    return f"{msg_from.get('firstName')} {msg_from.get('lastName')}"
 
 
 def get_ru_ref_from_message(message):

--- a/frontstage/views/secure_messaging/create_message.py
+++ b/frontstage/views/secure_messaging/create_message.py
@@ -16,13 +16,14 @@ logger = wrap_logger(logging.getLogger(__name__))
 @secure_message_bp.route('/create-message/', methods=['GET', 'POST'])
 @jwt_authorization(request)
 def create_message(session):
+    """Creates and sends a message outside of the context of an existing conversation"""
     survey = request.args['survey']
     ru_ref = request.args['ru_ref']
     party_id = session['party_id']
     form = SecureMessagingForm(request.form)
     if request.method == 'POST' and form.validate():
         logger.info("Form validation successful", party_id=party_id)
-        sent_message = send_message(party_id, survey, ru_ref)
+        sent_message = _send_new_message(party_id, survey, ru_ref)
         thread_url = url_for("secure_message_bp.view_conversation",
                              thread_id=sent_message['thread_id']) + "#latest-message"
         flash(Markup('Message sent. <a href={}>View Message</a>'.format(thread_url)))
@@ -34,7 +35,7 @@ def create_message(session):
                                form=form, errors=form.errors, message={})
 
 
-def send_message(party_id, survey, ru_ref):
+def _send_new_message(party_id, survey, ru_ref):
     logger.info('Attempting to send message', party_id=party_id)
     form = SecureMessagingForm(request.form)
 

--- a/tests/app/test_message_get.py
+++ b/tests/app/test_message_get.py
@@ -1,0 +1,25 @@
+import copy
+import unittest
+from frontstage.views.secure_messaging.message_get import get_msg_to
+
+
+class TestMessageGet(unittest.TestCase):
+
+    def test_get_msg_to_returns_group_if_no_internal_user(self):
+        msg = {'something': 'somethings'}
+        conversation = [msg, copy.deepcopy(msg), copy.deepcopy(msg)]
+
+        to = get_msg_to(conversation)
+
+        self.assertEquals(to, ['GROUP'])
+
+    def test_get_msg_to_returns_newest_internal_user_if_known(self):
+        msg = {'something': 'somethings'}
+        first_message_with_user = {'internal_user': 'user1', 'from_internal': True}
+        second_message_with_user = {'internal_user': 'user2', 'from_internal': True}
+
+        conversation = [msg, first_message_with_user, second_message_with_user, copy.deepcopy(msg)]
+
+        to = get_msg_to(conversation)
+
+        self.assertEquals(to, ['user2'])

--- a/tests/app/test_message_helper.py
+++ b/tests/app/test_message_helper.py
@@ -3,26 +3,34 @@ import unittest
 from datetime import datetime, timedelta, timezone, date
 from unittest.mock import patch
 
-from frontstage.common.message_helper import refine, get_formatted_date, convert_to_bst
+from frontstage.common.message_helper import refine, get_formatted_date, convert_to_bst, from_internal
 
 
 with open('tests/test_data/conversation.json') as json_data:
-    test_data = json.load(json_data)
-
-refined_data = {"subject": "testy2", "survey_id": "02b9c366-7397-42f7-942a-76dc5876d86d", "thread_id": "9e3465c0-9172-4974-a7d1-3a01592d1594",
-                "from": "Peter Griffin", "ru_ref": "e359b838-0d89-43e8-b5d0-68079916de80", "sent_date": "02 Apr 2018 10:27",
-                "body": "something else", "message_id": "2ac51b39-a0d7-465d-92a4-263dfe3eb475", "unread": False}
+    test_conversation_data = json.load(json_data)
 
 
 class TestMessageHelper(unittest.TestCase):
 
     def test_from_internal(self):
-        test_copy = test_data.copy()
+
+        expected_data = {"subject": "testy2",
+                         "survey_id": "02b9c366-7397-42f7-942a-76dc5876d86d",
+                         "thread_id": "9e3465c0-9172-4974-a7d1-3a01592d1594",
+                         "from": "ONS Business Surveys Team",
+                         "from_internal": True,
+                         "internal_user": "0282d2f8-d96d-4fd9-bb7a-c1d781c0978f",
+                         "ru_ref": "e359b838-0d89-43e8-b5d0-68079916de80",
+                         "sent_date": "02 Apr 2018 10:27",
+                         "body": "something else",
+                         "message_id": "2ac51b39-a0d7-465d-92a4-263dfe3eb475",
+                         "unread": False
+                         }
+        test_copy = test_conversation_data.copy()
         test_copy['from_internal'] = True
-        refined_data_copy = refined_data.copy()
-        refined_data_copy['from'] = 'ONS Business Surveys Team'
+        test_copy['internal_user'] = '0282d2f8-d96d-4fd9-bb7a-c1d781c0978f'
         refined_message = refine(test_copy)
-        self.assertEqual(refined_message, refined_data_copy)
+        self.assertEqual(refined_message, expected_data)
 
     def test_get_formatted_date_incorrect_date(self):
         date_str = '018-04-04 09:27:11.354399'
@@ -48,34 +56,59 @@ class TestMessageHelper(unittest.TestCase):
         self.assertEqual(formatted_date, '11 Feb 2018 10:15')
 
     def test_missing_date(self):
-        test_copy = test_data.copy()
+        test_copy = test_conversation_data.copy()
         del test_copy['sent_date']
-        refined_data_copy = refined_data.copy()
-        refined_data_copy['sent_date'] = None
+
+        expected_data = {"subject": "testy2",
+                         "survey_id": "02b9c366-7397-42f7-942a-76dc5876d86d",
+                         "thread_id": "9e3465c0-9172-4974-a7d1-3a01592d1594",
+                         "from": "Peter Griffin",
+                         "from_internal": False,
+                         "internal_user": "GROUP",
+                         "ru_ref": "e359b838-0d89-43e8-b5d0-68079916de80",
+                         "sent_date": None,
+                         "body": "something else",
+                         "message_id": "2ac51b39-a0d7-465d-92a4-263dfe3eb475",
+                         "unread": False
+                         }
+
         refined_message = refine(test_copy)
-        self.assertEqual(refined_message, refined_data_copy)
+        self.assertEqual(refined_message, expected_data)
 
     def test_missing_subject(self):
-        test_copy = test_data.copy()
+        test_copy = test_conversation_data.copy()
         del test_copy['subject']
         with self.assertRaises(KeyError):
             refine(test_copy)
 
     def test_missing_name(self):
-        test_copy = test_data.copy()
+        test_copy = test_conversation_data.copy()
         del test_copy['@msg_from']
         with self.assertRaises(KeyError):
             refine(test_copy)
 
     def test_missing_ru_id(self):
-        test_copy = test_data.copy()
+        test_copy = test_conversation_data.copy()
         del test_copy['@ru_id']
         with self.assertRaises(KeyError):
             refine(test_copy)
 
     def test_refine(self):
-        refined_message = refine(test_data)
-        self.assertEqual(refined_message, refined_data)
+        expected_data = {"subject": "testy2",
+                         "survey_id": "02b9c366-7397-42f7-942a-76dc5876d86d",
+                         "thread_id": "9e3465c0-9172-4974-a7d1-3a01592d1594",
+                         "from": "Peter Griffin",
+                         "from_internal": False,
+                         "internal_user": "GROUP",
+                         "ru_ref": "e359b838-0d89-43e8-b5d0-68079916de80",
+                         "sent_date": "02 Apr 2018 10:27",
+                         "body": "something else",
+                         "message_id": "2ac51b39-a0d7-465d-92a4-263dfe3eb475",
+                         "unread": False
+                         }
+
+        refined_message = refine(test_conversation_data)
+        self.assertEqual(refined_message, expected_data)
 
     def test_convert_to_bst_from_utc_during_bst(self):
         # 13th Jun 2018 at 14.12 should return 13th Jun 2018 at 15.12
@@ -90,3 +123,15 @@ class TestMessageHelper(unittest.TestCase):
         returned_datetime = convert_to_bst(datetime_parsed)
         # Check date returned is in BST format
         self.assertEqual(datetime.strftime(returned_datetime, '%Y-%m-%d %H:%M:%S'), '2018-02-13 14:12:00')
+
+    def test_from_internal_returns_false_if_not_specified(self):
+        test_dict = {}
+
+        is_from_internal = from_internal(test_dict)
+        self.assertFalse(is_from_internal)
+
+    def test_from_internal_returns_value_of_from_internal(self):
+        test_dict = {'from_internal': True}
+
+        is_from_internal = from_internal(test_dict)
+        self.assertTrue(is_from_internal)


### PR DESCRIPTION
# Motivation and Context
Internal users could not see the name of a user who had sent a reply to a message. It was showing Survey team. So in order to get context they needed to open up the thread which then marked it as read leading to messages not being replied to .
This change is to show the name of the last internal person who sent a message on that thread. So that internal users do not need to open up messages if they know another internal person is dealing with it .
 In order to attain this Ras-frontsgae should not display the internal user name to the respondent , but retain the internal user so that it can be set in the msg_to field at the point of sending the secure_message to the secure message service


# What has changed
This change only required a chance to ras-frontstage and the acceptance tests. Ras-frontstage now 
sends a reply back to the internal person who sent the message being replied to. if the respondent sends a message on a different subject it still gets sent to the survey team.

# How to test?
Manual testing: 
Run frontstage and response ops  . Send a new message from frontstage . Send a reply from response-op-ui . Validate that the user name is displayed in response ops in the conversation list view. And that ONS Survey team shown in the conversation list on frontstage. Reply from frontstage about 3 times. ( in order to prove later that frontstage sends the details of the last known internal user in a conversation and not just looking at the previous message in conversation)

Now go to response-ops ui and log in as a new user ( may have to get details from post gres , and auto standalone test users have numbers as first and last name ) . The to field should be the original internal user .Reply to the message from this new internal user . Validate the from is this new internal user .Go to Fronstage validate that they still dont see the name of the internal user. Reply . 


The automatic acceptance tests validate that the secure message is sent with the id of the internal user if known.Unit tests validate that the correct internal user id . (If a respondent starts a new conversation they send to'GROUP' as the to, if they reply it should be the user id of the internal person who sent the original)

# Links
https://trello.com/c/PGjxHXYA
