### PR TITLE
'You have already added that survey' Message

### DIFF
--- a/config.py
+++ b/config.py
@@ -36,7 +36,7 @@ class Config(object):
     JSON_SECRET_KEYS = os.getenv('JSON_SECRET_KEYS')
 
     REDIS_HOST = os.getenv('REDIS_HOST', 'localhost')
-    REDIS_PORT = os.getenv('REDIS_PORT', 6379)
+    REDIS_PORT = os.getenv('REDIS_PORT', 7379)
     REDIS_DB = os.getenv('REDIS_DB', 1)
 
     PASSWORD_MATCH_ERROR_TEXT = 'Your passwords do not match'

--- a/config.py
+++ b/config.py
@@ -36,7 +36,7 @@ class Config(object):
     JSON_SECRET_KEYS = os.getenv('JSON_SECRET_KEYS')
 
     REDIS_HOST = os.getenv('REDIS_HOST', 'localhost')
-    REDIS_PORT = os.getenv('REDIS_PORT', 7379)
+    REDIS_PORT = os.getenv('REDIS_PORT', 6379)
     REDIS_DB = os.getenv('REDIS_DB', 1)
 
     PASSWORD_MATCH_ERROR_TEXT = 'Your passwords do not match'

--- a/frontstage/templates/surveys/surveys-todo.html
+++ b/frontstage/templates/surveys/surveys-todo.html
@@ -2,7 +2,7 @@
 
 {% extends "layouts/_onecol.html" %}
 
-{% block page_title %}Surveys to complete - ONS Business Surveys{% endblock %}
+{% block page_title %}Surveys to complete - ONS Business Surveys{% endblock page_title %}
 
 {% block main %}
 {% include "partials/tab_list.html" %}
@@ -12,6 +12,15 @@
     <div class="panel__body">
         <div>Your <a id="NEW_SURVEY_NOTIF" href="#new-survey">new survey</a> has been added</div>
 
+    </div>
+</div>
+{% endif %}
+
+
+{% if already_enrolled %}
+<div class="panel panel--simple panel--info panel--spacious">
+    <div class="panel__body">
+        <div id="ALREADY_ADDED_NOTIF">You have already added that <a href="#new-survey">survey</a> </div>
     </div>
 </div>
 {% endif %}

--- a/frontstage/views/surveys/add_survey_submit.py
+++ b/frontstage/views/surveys/add_survey_submit.py
@@ -40,8 +40,8 @@ def add_survey_submit(session):
 
         already_enrolled = None
         if is_business_enrolled(info['associations'], case['caseGroup']['surveyId']):
-            logger.error('User tried to enrol onto a survey they are already enrolled on',
-                         case_id=case_id, party_id=party_id)
+            logger.info('User tried to enrol onto a survey they are already enrolled on',
+                        case_id=case_id, party_id=party_id)
             already_enrolled = True
         else:
             case_controller.post_case_event(case_id,

--- a/frontstage/views/surveys/add_survey_submit.py
+++ b/frontstage/views/surveys/add_survey_submit.py
@@ -63,8 +63,6 @@ def add_survey_submit(session):
 
 
 def is_business_enrolled(associations, survey_id):
-    for info in associations:
-        enrolled = [s for s in info['enrolments'] if s['surveyId'] == survey_id]
-        if len(enrolled) > 0:
-                return True
-    return False
+    return any(survey for info in associations
+               for survey in info['enrolments']
+               if survey['surveyId'] == survey_id)

--- a/frontstage/views/surveys/surveys_list.py
+++ b/frontstage/views/surveys/surveys_list.py
@@ -19,6 +19,7 @@ def get_survey_list(session, tag):
     party_id = session.get('party_id')
     business_id = request.args.get('business_party_id')
     survey_id = request.args.get('survey_id')
+    already_enrolled = request.args.get('already_enrolled')
 
     survey_list = party_controller.get_survey_list_details_for_party(party_id, tag, business_party_id=business_id,
                                                                      survey_id=survey_id)
@@ -28,7 +29,9 @@ def get_survey_list(session, tag):
     if tag == 'todo':
         response = make_response(render_template('surveys/surveys-todo.html',
                                                  sorted_surveys_list=sorted_survey_list,
-                                                 added_survey=True if business_id and survey_id else None))
+                                                 added_survey=True if business_id and survey_id and not already_enrolled else None,
+                                                 already_enrolled=already_enrolled
+                                                 ))
 
         # Ensure any return to list of surveys (e.g. browser back) round trips the server to display the latest statuses
         response.headers.set("Cache-Control", "no-cache, max-age=0, must-revalidate, no-store")

--- a/tests/app/mocked_services.py
+++ b/tests/app/mocked_services.py
@@ -17,6 +17,9 @@ with open('tests/test_data/party/party.json') as fp:
 with open('tests/test_data/case/case.json') as fp:
     case = json.load(fp)
 
+with open('tests/test_data/case/case_diff_surveyId.json') as fp:
+    case_diff_surveyId = json.load(fp)
+
 with open('tests/test_data/case/case_list.json') as fp:
     case_list = json.load(fp)
 

--- a/tests/app/views/surveys/test_add_survey_submit.py
+++ b/tests/app/views/surveys/test_add_survey_submit.py
@@ -1,4 +1,5 @@
 import logging
+import json
 import unittest
 from unittest.mock import patch
 
@@ -9,8 +10,8 @@ from frontstage import app
 from frontstage.exceptions.exceptions import ApiError
 from tests.app.mocked_services import active_iac, case, collection_exercise, encoded_jwt_token, \
     encrypted_enrolment_code, \
-    enrolment_code, url_validate_enrolment
-
+    enrolment_code, url_validate_enrolment, business_party, case_diff_surveyId
+from frontstage.views.surveys.add_survey_submit import is_business_enrolled
 
 logger = wrap_logger(logging.getLogger(__name__))
 
@@ -32,16 +33,40 @@ class TestAddSurveySubmit(unittest.TestCase):
 
     @patch('frontstage.controllers.party_controller.add_survey')
     @patch('frontstage.controllers.case_controller.post_case_event')
+    @patch('frontstage.controllers.party_controller.get_party_by_business_id')
     @patch('frontstage.controllers.collection_exercise_controller.get_collection_exercise')
     @patch('frontstage.controllers.case_controller.get_case_by_enrolment_code')
     @patch('frontstage.controllers.iac_controller.get_iac_from_enrolment')
     @patch('frontstage.common.cryptographer.Cryptographer.decrypt')
     def test_add_survey_submit_success_redirect_to_survey_todo_list(self, decrypt_enrolment_code, get_iac_by_enrolment_code,
-                                                                    get_case_by_enrolment, get_collection_exercise, *_):
+                                                                    get_case_by_enrolment, get_collection_exercise, get_party_by_business_id, *_):
         decrypt_enrolment_code.return_value = enrolment_code.encode()
         get_iac_by_enrolment_code.return_value = active_iac
         get_case_by_enrolment.return_value = case
         get_collection_exercise.return_value = collection_exercise
+        get_party_by_business_id.return_value = business_party
+
+        response = self.app.get(f'/surveys/add-survey/add-survey-submit?encrypted_enrolment_code={encrypted_enrolment_code}')
+
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue('/surveys/todo'.encode() in response.data)
+        self.assertTrue(case['partyId'].encode() in response.data)
+        self.assertTrue(collection_exercise['surveyId'].encode() in response.data)
+
+    @patch('frontstage.controllers.party_controller.add_survey')
+    @patch('frontstage.controllers.case_controller.post_case_event')
+    @patch('frontstage.controllers.party_controller.get_party_by_business_id')
+    @patch('frontstage.controllers.collection_exercise_controller.get_collection_exercise')
+    @patch('frontstage.controllers.case_controller.get_case_by_enrolment_code')
+    @patch('frontstage.controllers.iac_controller.get_iac_from_enrolment')
+    @patch('frontstage.common.cryptographer.Cryptographer.decrypt')
+    def test_add_survey_submit_already_enrolled(self, decrypt_enrolment_code, get_iac_by_enrolment_code,
+                                                get_case_by_enrolment, get_collection_exercise, get_party_by_business_id, *_):
+        decrypt_enrolment_code.return_value = enrolment_code.encode()
+        get_iac_by_enrolment_code.return_value = active_iac
+        get_case_by_enrolment.return_value = case_diff_surveyId
+        get_collection_exercise.return_value = collection_exercise
+        get_party_by_business_id.return_value = business_party
 
         response = self.app.get(f'/surveys/add-survey/add-survey-submit?encrypted_enrolment_code={encrypted_enrolment_code}')
 
@@ -66,3 +91,17 @@ class TestAddSurveySubmit(unittest.TestCase):
 
         self.assertEqual(response.status_code, 500)
         self.assertTrue('Error 500 - Server error'.encode() in response.data)
+
+    def test_already_enrolled(self, ):
+        with open('tests/test_data/party/business_party.json') as j:
+            data = json.load(j)
+        survey = 'cb8accda-6118-4d3b-85a3-149e28960c54'
+
+        self.assertTrue(is_business_enrolled(data['associations'], survey))
+
+    def test_not_already_enrolled(self, ):
+        with open('tests/test_data/party/business_party.json') as j:
+            data = json.load(j)
+        survey = '64ad4018-2ddd-4894-89e7-33f0135887a2'
+
+        self.assertFalse(is_business_enrolled(data['associations'], survey))

--- a/tests/test_data/associations.json
+++ b/tests/test_data/associations.json
@@ -1,0 +1,16 @@
+[
+  {
+    "associations": [
+      {
+        "enrolments": [
+          {
+            "enrolmentStatus": "ENABLED",
+            "name": "Business Register and Employment Survey",
+            "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
+          }
+        ],
+        "partyId": "07d672bc-497b-448f-a406-a20a7e6013d7"
+      }
+    ]
+  }
+]

--- a/tests/test_data/case/case_diff_surveyId.json
+++ b/tests/test_data/case/case_diff_surveyId.json
@@ -13,7 +13,7 @@
         "collectionExerciseId": "8d990a74-5f07-4765-ac66-df7e1a96505b",
         "id": "d24e6267-e3f9-4378-898e-4df75c59cdea",
         "partyId": "be3483c3-f5c9-4b13-bdd7-244db78ff687",
-        "surveyId": "cb8accda-6118-4d3b-85a3-149e28960c54",
+        "surveyId": "qb8accda-6118-4d3b-85a3-149e28960c89",
         "sampleUnitRef": "49900000001",
         "sampleUnitType": "B",
         "caseGroupStatus": "NOTSTARTED"


### PR DESCRIPTION

# Motivation and Context
Makes the use case scenario with a respondent using a new enrolment code to add a survey they have already added more friendly.

# What has changed
Added a check to see if the user is already enrolled before making the database requests, prevents 500 error.

# How to test?
Run acceptance tests on the already_added_survey_test branch

# Links
Acceptance Test PR: https://github.com/ONSdigital/rasrm-acceptance-tests/pull/239
https://trello.com/c/gfNFRVsR/569-569-add-validation-for-respondents-adding-another-survey-to-their-enrolment

