### PR TITLE
Convert utc to local

### DIFF
--- a/frontstage/common/eq_payload.py
+++ b/frontstage/common/eq_payload.py
@@ -5,6 +5,7 @@ import uuid
 import iso8601
 from flask import current_app
 from structlog import wrap_logger
+from datetime import datetime, timezone
 
 from frontstage.controllers import (collection_exercise_controller, collection_instrument_controller,
                                     party_controller)
@@ -122,6 +123,6 @@ class EqPayload(object):
         """
 
         try:
-            return iso8601.parse_date(string_date).strftime('%Y-%m-%d')
+            return iso8601.parse_date(string_date).astimezone().strftime('%Y-%m-%d')
         except (ValueError, iso8601.iso8601.ParseError):
             raise InvalidEqPayLoad(f'Unable to format {string_date}')

--- a/frontstage/common/eq_payload.py
+++ b/frontstage/common/eq_payload.py
@@ -5,7 +5,6 @@ import uuid
 import iso8601
 from flask import current_app
 from structlog import wrap_logger
-from datetime import datetime, timezone
 
 from frontstage.controllers import (collection_exercise_controller, collection_instrument_controller,
                                     party_controller)


### PR DESCRIPTION
# Motivation and Context
When Collection exercise event dates are added through Response-Ops, they are converted to UTC prior to being stored and are converted back to local time to be displayed on the collection exercise page, which is all good.

Frontstage retrieves the collection exercise dates to form part of the eq_payload but doesn't convert the dates from UTC. We only send the date part of the date/time string and this has resulted in us passing incorrect dates to eQ.

# What has changed
Doing `.asTimeZone()` brings the iso8601 parsed date back from UTC to the server local timezone

# How to test?
This isn't testable unless the server local timezone isn't UTC. If you fancy testing it in late March you go wild.