### PR TITLE
582 redirect user to page requested after sign in

### DIFF
--- a/config.py
+++ b/config.py
@@ -147,4 +147,3 @@ class TestingConfig(DevelopmentConfig):
     ACCOUNT_SERVICE_LOG_OUT_URL = 'http://frontstage-url/sign-in/logout'
     EQ_URL = 'https://eq-test/session?token='
     JSON_SECRET_KEYS = open("./tests/test_data/jwt-test-keys/test_key.json").read()
-    SERVER_NAME = 'localhost:8082'

--- a/config.py
+++ b/config.py
@@ -147,3 +147,4 @@ class TestingConfig(DevelopmentConfig):
     ACCOUNT_SERVICE_LOG_OUT_URL = 'http://frontstage-url/sign-in/logout'
     EQ_URL = 'https://eq-test/session?token='
     JSON_SECRET_KEYS = open("./tests/test_data/jwt-test-keys/test_key.json").read()
+    SERVER_NAME = 'localhost:8082'

--- a/frontstage/common/authorisation.py
+++ b/frontstage/common/authorisation.py
@@ -2,9 +2,11 @@ import logging
 from datetime import datetime
 from functools import wraps
 
+from flask import url_for
 from jose import JWTError
 from jose.jwt import decode
 from structlog import wrap_logger
+from werkzeug.utils import redirect
 
 from frontstage import app
 from frontstage.common.session import SessionHandler
@@ -51,7 +53,7 @@ def jwt_authorization(request):
                     raise JWTValidationError
             else:
                 logger.warning('No authorization token provided')
-                raise JWTValidationError
+                return redirect(url_for('sign_in_bp.login', next=request.url))
 
             if app.config['VALIDATE_JWT']:
                 if validate(jwt):

--- a/frontstage/templates/sign-in/sign-in.html
+++ b/frontstage/templates/sign-in/sign-in.html
@@ -32,7 +32,7 @@
     </div>
     <br />
     {% endif %}
-    <form method="post" class="form" action="{{ url_for('sign_in_bp.login', next_url=next_url) }}" role="form">
+    <form method="post" class="form" action="{{ url_for('sign_in_bp.login', next=next) }}" role="form">
         {{ form.csrf_token }}
 
         {% if data['account_activated'] %}

--- a/frontstage/templates/sign-in/sign-in.html
+++ b/frontstage/templates/sign-in/sign-in.html
@@ -32,7 +32,7 @@
     </div>
     <br />
     {% endif %}
-    <form method="post" class="form" action="{{ url_for('sign_in_bp.login') }}" role="form">
+    <form method="post" class="form" action="{{ url_for('sign_in_bp.login', next_url=next_url) }}" role="form">
         {{ form.csrf_token }}
 
         {% if data['account_activated'] %}

--- a/frontstage/views/sign_in/sign_in.py
+++ b/frontstage/views/sign_in/sign_in.py
@@ -27,6 +27,30 @@ def home():
     return redirect(url_for('sign_in_bp.login', _external=True, _scheme=getenv('SCHEME', 'http')))
 
 
+def get_oauth_token(username, password, party_id, party_json, form):
+    try:
+        oauth2_token = oauth_controller.sign_in(username, password)
+        return oauth2_token
+    except OAuth2Error as exc:
+        error_message = exc.oauth2_error
+        if USER_ACCOUNT_LOCKED in error_message:
+            logger.info('User account is locked on the OAuth2 server', party_id=party_id)
+            if party_json['status'] == 'ACTIVE' or party_json['status'] == 'CREATED':
+                notify_party_and_respondent_account_locked(respondent_id=party_id,
+                                                           email_address=username,
+                                                           status='SUSPENDED')
+            return render_template('sign-in/sign-in.account-locked.html', form=form)
+        elif BAD_AUTH_ERROR in error_message:
+            return render_template('sign-in/sign-in.html', form=form, data={"error": {"type": "failed"}})
+        elif NOT_VERIFIED_ERROR in error_message:
+            logger.info('User account is not verified on the OAuth2 server')
+            return render_template('sign-in/sign-in.account-not-verified.html', party_id=party_id,
+                                   email=username)
+        else:
+            logger.info('OAuth 2 server generated 401 which is not understood', oauth2_error=error_message)
+            return render_template('sign-in/sign-in.html', form=form, data={"error": {"type": "failed"}})
+
+
 @sign_in_bp.route('/', methods=['GET', 'POST'])
 def login():
     form = LoginForm(request.form)
@@ -43,33 +67,20 @@ def login():
             return render_template('sign-in/sign-in.html', form=form, data={"error": {"type": "failed"}})
         party_id = party_json['id']
 
-        try:
-            oauth2_token = oauth_controller.sign_in(username, password)
-        except OAuth2Error as exc:
-            error_message = exc.oauth2_error
-            if USER_ACCOUNT_LOCKED in error_message:
-                logger.info('User account is locked on the OAuth2 server', party_id=party_id)
-                if party_json['status'] == 'ACTIVE' or party_json['status'] == 'CREATED':
-                    notify_party_and_respondent_account_locked(respondent_id=party_id,
-                                                               email_address=username,
-                                                               status='SUSPENDED')
-                return render_template('sign-in/sign-in.account-locked.html', form=form)
-            elif BAD_AUTH_ERROR in error_message:
-                return render_template('sign-in/sign-in.html', form=form, data={"error": {"type": "failed"}})
-            elif NOT_VERIFIED_ERROR in error_message:
-                logger.info('User account is not verified on the OAuth2 server')
-                return render_template('sign-in/sign-in.account-not-verified.html', party_id=party_id,
-                                       email=username)
-            else:
-                logger.info('OAuth 2 server generated 401 which is not understood', oauth2_error=error_message)
-                return render_template('sign-in/sign-in.html', form=form, data={"error": {"type": "failed"}})
+        oauth2_token = get_oauth_token(username, password, party_id, party_json, form)
+
+        if not isinstance(oauth2_token, dict):
+            return oauth2_token
 
         # Take our raw token and add a UTC timestamp to the expires_at attribute
         data_dict = {**oauth2_token, 'party_id': party_id}
         data_dict_for_jwt_token = timestamp_token(data_dict)
         encoded_jwt_token = encode(data_dict_for_jwt_token)
-        response = make_response(redirect(url_for('surveys_bp.get_survey_list', tag='todo', _external=True,
-                                                  _scheme=getenv('SCHEME', 'http'))))
+        if request.args.get('next'):
+            response = make_response(redirect(request.args.get('next')))
+        else:
+            response = make_response(redirect(url_for('surveys_bp.get_survey_list', tag='todo', _external=True,
+                                                      _scheme=getenv('SCHEME', 'http'))))
 
         session = SessionHandler()
         logger.info('Creating session', party_id=party_id)
@@ -87,6 +98,9 @@ def login():
         },
         'account_activated': account_activated
     }
+    if request.args.get('next'):
+        return render_template('sign-in/sign-in.html', form=form, data=template_data,
+                               next=request.args.get('next'))
     return render_template('sign-in/sign-in.html', form=form, data=template_data)
 
 

--- a/frontstage/views/sign_in/sign_in.py
+++ b/frontstage/views/sign_in/sign_in.py
@@ -27,7 +27,7 @@ def home():
     return redirect(url_for('sign_in_bp.login', _external=True, _scheme=getenv('SCHEME', 'http')))
 
 
-def get_oauth_token(username, password, party_id, party_json, form):
+def get_oauth_token(username, password, party_id, party_json, form, next):
     try:
         oauth2_token = oauth_controller.sign_in(username, password)
         return oauth2_token
@@ -41,7 +41,7 @@ def get_oauth_token(username, password, party_id, party_json, form):
                                                            status='SUSPENDED')
             return render_template('sign-in/sign-in.account-locked.html', form=form)
         elif BAD_AUTH_ERROR in error_message:
-            return render_template('sign-in/sign-in.html', form=form, data={"error": {"type": "failed"}})
+            return render_template('sign-in/sign-in.html', form=form, data={"error": {"type": "failed"}}, next=next)
         elif NOT_VERIFIED_ERROR in error_message:
             logger.info('User account is not verified on the OAuth2 server')
             return render_template('sign-in/sign-in.account-not-verified.html', party_id=party_id,
@@ -67,7 +67,7 @@ def login():
             return render_template('sign-in/sign-in.html', form=form, data={"error": {"type": "failed"}})
         party_id = party_json['id']
 
-        oauth2_token = get_oauth_token(username, password, party_id, party_json, form)
+        oauth2_token = get_oauth_token(username, password, party_id, party_json, form, request.args.get('next'))
 
         if not isinstance(oauth2_token, dict):
             return oauth2_token

--- a/tests/app/test_jwt_authorization.py
+++ b/tests/app/test_jwt_authorization.py
@@ -48,12 +48,6 @@ class TestJWTAuthorization(unittest.TestCase):
         # If this function runs without exceptions the test is considered passed
         self.decorator_test(request)
 
-    def test_jwt_authorization_no_jwt(self):
-        request = mock.MagicMock()
-
-        with self.assertRaises(JWTValidationError):
-            self.decorator_test(request)
-
     def test_jwt_authorization_expired_jwt(self):
         self.session.create_session(expired_jwt)
         request = mock.MagicMock(cookies={"authorization": self.session.session_key})
@@ -61,7 +55,7 @@ class TestJWTAuthorization(unittest.TestCase):
         with self.assertRaises(JWTValidationError):
             self.decorator_test(request)
 
-    def test_jwt_authorization_no_exipry(self):
+    def test_jwt_authorization_no_expiry(self):
         self.session.create_session(no_expiry_jwt)
         request = mock.MagicMock(cookies={"authorization": self.session.session_key})
 

--- a/tests/app/test_message_get.py
+++ b/tests/app/test_message_get.py
@@ -11,7 +11,7 @@ class TestMessageGet(unittest.TestCase):
 
         to = get_msg_to(conversation)
 
-        self.assertEquals(to, ['GROUP'])
+        self.assertEqual(to, ['GROUP'])
 
     def test_get_msg_to_returns_newest_internal_user_if_known(self):
         msg = {'something': 'somethings'}
@@ -22,4 +22,4 @@ class TestMessageGet(unittest.TestCase):
 
         to = get_msg_to(conversation)
 
-        self.assertEquals(to, ['user2'])
+        self.assertEqual(to, ['user2'])


### PR DESCRIPTION
# Motivation and Context
When a user clicks a link from an email, it would come up with an `JWTValidation` saying the user must sign in. What we want to happen is though, for the user to click the link and be directed to the sign in page. When they sign in they then get brought to the requested page they wanted.

# What has changed
- User now gets redirected to sign in page when attempting to visit a page which requires a login.
- Split up login method as it was too complex

# How to test?
- Send a message from internal to external. When trying to visit that conversation when not signed in, you should be brought to the sign in page. When signed in, you should be redirected to the conversation.
# Links
[Trello](https://trello.com/c/nLsI8fjn)
