### PR TITLE
Add ability to fetch cases without IAC codes

### DIFF
--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from distutils.util import strtobool
 class Config(object):
     DEBUG = False
     TESTING = False
-    VERSION = '1.11.0'
+    VERSION = '1.9.0'
     PORT = os.getenv('PORT', 8082)
     MAX_UPLOAD_LENGTH = os.getenv('MAX_UPLOAD_LENGTH', 20 * 1024 * 1024)
 

--- a/frontstage/controllers/case_controller.py
+++ b/frontstage/controllers/case_controller.py
@@ -110,12 +110,18 @@ def get_case_data(case_id, party_id, business_party_id, survey_short_name):
     return case_data
 
 
-def get_cases_by_party_id(party_id, case_url, case_auth, case_events=False):
+def get_cases_by_party_id(party_id, case_url, case_auth, case_events=False, iac=True):
     logger.debug('Attempting to retrieve cases by party id', party_id=party_id)
 
     url = f"{case_url}/cases/partyid/{party_id}"
     if case_events:
         url = f'{url}?caseevents=true'
+    if not iac:
+        if case_events:
+            url = f'{url}&'
+        else:
+            url = f'{url}?'
+        url = f'{url}iac=false'
     response = requests.get(url, auth=case_auth)
 
     try:
@@ -202,7 +208,7 @@ def validate_case_category(category):
 def get_cases_for_list_type_by_party_id(party_id, case_url, case_auth, list_type='todo'):
     logger.debug('Get cases for party for list', party_id=party_id, list_type=list_type)
 
-    cases = get_cases_by_party_id(party_id, case_url, case_auth)
+    cases = get_cases_by_party_id(party_id, case_url, case_auth, iac=False)
     history_statuses = ['COMPLETE', 'COMPLETEDBYPHONE', 'NOLONGERREQUIRED']
     if list_type == 'history':
         filtered_cases = [business_case

--- a/tests/app/controllers/test_case_controllers.py
+++ b/tests/app/controllers/test_case_controllers.py
@@ -11,7 +11,8 @@ from frontstage.exceptions.exceptions import ApiError, InvalidCaseCategory, NoSu
 from tests.app.mocked_services import (business_party, case, case_list, categories, collection_exercise,
                                        collection_instrument_seft, eq_payload, respondent_party, survey,
                                        survey_eq, url_get_case, url_get_case_by_enrolment_code,
-                                       url_get_cases_by_party, url_get_case_categories, url_post_case_event_uuid)
+                                       url_get_cases_by_party, url_get_case_categories, url_post_case_event_uuid,
+                                       case_list_with_iac_and_case_events)
 
 
 class TestCaseControllers(unittest.TestCase):
@@ -281,6 +282,28 @@ class TestCaseControllers(unittest.TestCase):
                                                                        self.app_config['CASE_AUTH'])
 
                 self.assertNotEqual(len(returned_cases), 0)
+
+    def test_get_cases_by_party_id_without_iac(self):
+        with responses.RequestsMock() as rsps:
+            rsps.add(rsps.GET, url_get_cases_by_party, json=case_list, status=200)
+            with app.app_context():
+                returned_cases = case_controller.get_cases_by_party_id(case['partyId'], self.app_config['CASE_URL'],
+                                                                       self.app_config['CASE_AUTH'], iac=False)
+
+                self.assertNotEqual(len(returned_cases), 0)
+                self.assertIsNone(returned_cases[0]['iac'])
+
+    def test_get_cases_by_party_id_without_iac_and_with_case_events(self):
+        with responses.RequestsMock() as rsps:
+            rsps.add(rsps.GET, url_get_cases_by_party, json=case_list_with_iac_and_case_events, status=200)
+            with app.app_context():
+                returned_cases = case_controller.get_cases_by_party_id(case['partyId'], self.app_config['CASE_URL'],
+                                                                       self.app_config['CASE_AUTH'], iac=False,
+                                                                       case_events=True)
+
+                self.assertNotEqual(len(returned_cases), 0)
+                self.assertIsNone(returned_cases[0]['iac'])
+                self.assertIsNotNone(returned_cases[0]['caseEvents'][0])
 
     def test_get_cases_by_party_id_fail(self):
         with responses.RequestsMock() as rsps:

--- a/tests/app/mocked_services.py
+++ b/tests/app/mocked_services.py
@@ -20,6 +20,9 @@ with open('tests/test_data/case/case.json') as fp:
 with open('tests/test_data/case/case_list.json') as fp:
     case_list = json.load(fp)
 
+with open('tests/test_data/case/case_list_without_iac_and_with_case_events.json') as fp:
+    case_list_with_iac_and_case_events = json.load(fp)
+
 with open('tests/test_data/case/categories.json') as fp:
     categories = json.load(fp)
 

--- a/tests/test_data/case/case_list_without_iac_and_with_case_events.json
+++ b/tests/test_data/case/case_list_without_iac_and_with_case_events.json
@@ -1,0 +1,136 @@
+[
+  {
+    "state": "ACTIONABLE",
+    "id": "3a7c8295-1932-4ab9-b447-a5b251d7d25d",
+    "actionPlanId": "f1a733ae-e5e6-4245-b2bd-550086f871e2",
+    "collectionInstrumentId": "e963b049-8317-4d52-87d0-01bebb31d4ac",
+    "partyId": "be3483c3-f5c9-4b13-bdd7-244db78ff687",
+    "iac": null,
+    "caseRef": "1000000000000017",
+    "createdBy": "SYSTEM",
+    "sampleUnitType": "B",
+    "createdDateTime": "2018-07-12T08:59:41.787Z",
+    "caseGroup": {
+      "collectionExerciseId": "'ed5972f6-d17d-4408-bb9a-7af54f13c88b'",
+      "id": "40d034cf-5875-4022-b160-506e094b157a",
+      "partyId": "be3483c3-f5c9-4b13-bdd7-244db78ff687",
+      "sampleUnitRef": "49900000001",
+      "sampleUnitType": "B",
+      "caseGroupStatus": "NOTSTARTED"
+    },
+    "responses": [],
+    "caseEvents": [
+      {
+        "createdDateTime": 1460736159699,
+        "caseEventPK": 1,
+        "caseFK": 1,
+        "category": "ONLINE_QUESTIONNAIRE_RESPONSE",
+        "subCategory": "subcat 1",
+        "createdBy": "me 1",
+        "description": "desc 1",
+        "metadata": {
+          "partyId": "3b136c4b-7a14-4904-9e01-13364dd7b972"
+        }
+      }
+    ]
+  },
+  {
+    "state": "ACTIONABLE",
+    "id": "6692033f-1d10-4cc5-a058-f2d012ce6af5",
+    "actionPlanId": "c10e98d8-88a3-4fc7-a990-22a7a926f214",
+    "collectionInstrumentId": "e963b049-8317-4d52-87d0-01bebb31d4ac",
+    "partyId": "be3483c3-f5c9-4b13-bdd7-244db78ff687",
+    "iac": null,
+    "caseRef": "1000000000000025",
+    "createdBy": "SYSTEM",
+    "sampleUnitType": "B",
+    "createdDateTime": "2018-07-12T08:59:46.866Z",
+    "caseGroup": {
+      "collectionExerciseId": "4ec73b0c-c9cf-438e-a8b5-0c4bc2cf922d",
+      "id": "40d034cf-5875-4022-b160-506e094b157a",
+      "partyId": "be3483c3-f5c9-4b13-bdd7-244db78ff687",
+      "sampleUnitRef": "49900000001",
+      "sampleUnitType": "B",
+      "caseGroupStatus": "NOTSTARTED"
+    },
+    "responses": [],
+    "caseEvents": {
+      "createdDateTime": 1460736159699,
+      "caseEventPK": 1,
+      "caseFK": 1,
+      "category": "ONLINE_QUESTIONNAIRE_RESPONSE",
+      "subCategory": "subcat 1",
+      "createdBy": "me 1",
+      "description": "desc 1",
+      "metadata": {
+        "partyId": "3b136c4b-7a14-4904-9e01-13364dd7b972"
+      }
+    }
+  },
+  {
+    "state": "INACTIONABLE",
+    "id": "9d5ff134-79ae-4107-9441-374765399cb5",
+    "actionPlanId": "c0d5a501-de2a-4b8c-90c8-e00aa5956fed",
+    "collectionInstrumentId": "3e196ba5-a0dd-4c3d-a105-e0c1085ff882",
+    "partyId": "be3483c3-f5c9-4b13-bdd7-244db78ff687",
+    "iac": null,
+    "caseRef": "1000000000000001",
+    "createdBy": "SYSTEM",
+    "sampleUnitType": "B",
+    "createdDateTime": "2018-07-12T08:59:31.647Z",
+    "caseGroup": {
+      "collectionExerciseId": "8d990a74-5f07-4765-ac66-df7e1a96505b",
+      "id": "32fc3b86-b696-42ee-b905-a5712648711b",
+      "partyId": "be3483c3-f5c9-4b13-bdd7-244db78ff687",
+      "sampleUnitRef": "49900000001",
+      "sampleUnitType": "B",
+      "caseGroupStatus": "NOTSTARTED"
+    },
+    "responses": [],
+    "caseEvents": {
+      "createdDateTime": 1460736159699,
+      "caseEventPK": 1,
+      "caseFK": 1,
+      "category": "ONLINE_QUESTIONNAIRE_RESPONSE",
+      "subCategory": "subcat 1",
+      "createdBy": "me 1",
+      "description": "desc 1",
+      "metadata": {
+        "partyId": "3b136c4b-7a14-4904-9e01-13364dd7b972"
+      }
+    }
+  },
+  {
+    "state": "INACTIONABLE",
+    "id": "f8a5d864-76af-45bd-a701-cc35bbd13a89",
+    "actionPlanId": "288fcc63-b8b1-4812-bb47-3dfefd5f164f",
+    "collectionInstrumentId": "3e196ba5-a0dd-4c3d-a105-e0c1085ff882",
+    "partyId": "0008279d-9425-4e28-897d-bfd876aa7f3f",
+    "iac": null,
+    "caseRef": "1000000000000009",
+    "createdBy": "SYSTEM",
+    "sampleUnitType": "B",
+    "createdDateTime": "2018-07-12T08:59:36.720Z",
+    "caseGroup": {
+      "collectionExerciseId": "ed5972f6-d17d-4408-bb9a-7af54f13c88b",
+      "id": "e3f86bac-e6c3-4a65-82ee-a2217096b283",
+      "partyId": "0008279d-9425-4e28-897d-bfd876aa7f3f",
+      "sampleUnitRef": "49900000001",
+      "sampleUnitType": "B",
+      "caseGroupStatus": "COMPLETE"
+    },
+    "responses": [],
+    "caseEvents": {
+      "createdDateTime": 1460736159699,
+      "caseEventPK": 1,
+      "caseFK": 1,
+      "category": "ONLINE_QUESTIONNAIRE_RESPONSE",
+      "subCategory": "subcat 1",
+      "createdBy": "me 1",
+      "description": "desc 1",
+      "metadata": {
+        "partyId": "3b136c4b-7a14-4904-9e01-13364dd7b972"
+      }
+    }
+  }
+]


### PR DESCRIPTION
# Motivation and Context
To try and make the to-do page even quicker, an IAC boolean is passed to the case service to say if we want it added to the case or not. Passing in false will skip a DB call which should make things quicker.
# What has changed
- Pass in IAC boolean to case service

# How to test?
- Run with [Case service PR](https://github.com/ONSdigital/rm-case-service/pull/105)
- Run with Acceptance tests
- Open up the todo page and make sure everything is working such as accessing survey and completing it.
# Links
[Trello](https://trello.com/c/5xsPP92s)
