### PR TITLE
Already added survey message fix

### DIFF
--- a/config.py
+++ b/config.py
@@ -36,7 +36,7 @@ class Config(object):
     JSON_SECRET_KEYS = os.getenv('JSON_SECRET_KEYS')
 
     REDIS_HOST = os.getenv('REDIS_HOST', 'localhost')
-    REDIS_PORT = os.getenv('REDIS_PORT', 6379)
+    REDIS_PORT = os.getenv('REDIS_PORT', 7379)
     REDIS_DB = os.getenv('REDIS_DB', 1)
 
     PASSWORD_MATCH_ERROR_TEXT = 'Your passwords do not match'

--- a/config.py
+++ b/config.py
@@ -36,7 +36,7 @@ class Config(object):
     JSON_SECRET_KEYS = os.getenv('JSON_SECRET_KEYS')
 
     REDIS_HOST = os.getenv('REDIS_HOST', 'localhost')
-    REDIS_PORT = os.getenv('REDIS_PORT', 7379)
+    REDIS_PORT = os.getenv('REDIS_PORT', 6379)
     REDIS_DB = os.getenv('REDIS_DB', 1)
 
     PASSWORD_MATCH_ERROR_TEXT = 'Your passwords do not match'

--- a/frontstage/templates/surveys/surveys-todo.html
+++ b/frontstage/templates/surveys/surveys-todo.html
@@ -2,7 +2,7 @@
 
 {% extends "layouts/_onecol.html" %}
 
-{% block page_title %}Surveys to complete - ONS Business Surveys{% endblock %}
+{% block page_title %}Surveys to complete - ONS Business Surveys{% endblock page_title %}
 
 {% block main %}
 {% include "partials/tab_list.html" %}
@@ -12,6 +12,15 @@
     <div class="panel__body">
         <div>Your <a id="NEW_SURVEY_NOTIF" href="#new-survey">new survey</a> has been added</div>
 
+    </div>
+</div>
+{% endif %}
+
+
+{% if already_enrolled %}
+<div class="panel panel--simple panel--info panel--spacious">
+    <div class="panel__body">
+        <div id="ALREADY_ADDED_NOTIF">You have already added that <a href="#new-survey">survey</a> </div>
     </div>
 </div>
 {% endif %}

--- a/frontstage/views/surveys/add_survey_submit.py
+++ b/frontstage/views/surveys/add_survey_submit.py
@@ -40,8 +40,8 @@ def add_survey_submit(session):
 
         already_enrolled = None
         if is_business_enrolled(info['associations'], case['caseGroup']['surveyId']):
-            logger.error('User tried to enrol onto a survey they are already enrolled on',
-                         case_id=case_id, party_id=party_id)
+            logger.info('User tried to enrol onto a survey they are already enrolled on',
+                        case_id=case_id, party_id=party_id)
             already_enrolled = True
         else:
             case_controller.post_case_event(case_id,

--- a/frontstage/views/surveys/add_survey_submit.py
+++ b/frontstage/views/surveys/add_survey_submit.py
@@ -58,17 +58,17 @@ def add_survey_submit(session):
 
     logger.info('Successfully retrieved data for confirm add organisation/survey page',
                 case_id=case_id, party_id=party_id)
-    return redirect(url_for('surveys_bp.get_survey_list', _anchor=(business_party_id, added_survey_id), _external=True, business_party_id=business_party_id,
+    return redirect(url_for('surveys_bp.get_survey_list', _anchor=(business_party_id, added_survey_id), _external=True,
+                            business_party_id=business_party_id,
                             survey_id=added_survey_id, tag='todo', already_enrolled=already_enrolled))
 
 
 def is_respondent_and_business_enrolled(associations, survey_id, party_id):
     """
-    This function checks that the business AND the respondent are enrolled in a survey. We first check if the respondent
-    is enrolled, then if not, we check that the business is enrolled on the survey. A business can have multiple
-    respondents enrolled for a survey, and a respondent can be enrolled for multiple surveys. If we only checked if the
-    business was enrolled, then there could only ever be one respondent that could be able to answer the survey, which
-    isn't the desired functionality.
+    This function checks whether or not a respondent's associated party is associated with the survey. If yes,
+    we then check if the survey_id of the survey we are trying to add is found within the enrolments of the respondent.
+    We do this because a respondent can be responding on behalf of several businesses, and a business can have several
+    people enrolled on the same survey.
 
     :param associations: List of respondents and their enrolled surveys
     :param survey_id: id of the added survey
@@ -81,3 +81,4 @@ def is_respondent_and_business_enrolled(associations, survey_id, party_id):
                 if survey['surveyId'] == survey_id:
                     return True
     return False
+

--- a/frontstage/views/surveys/add_survey_submit.py
+++ b/frontstage/views/surveys/add_survey_submit.py
@@ -63,8 +63,6 @@ def add_survey_submit(session):
 
 
 def is_business_enrolled(associations, survey_id):
-    for info in associations:
-        enrolled = [s for s in info['enrolments'] if s['surveyId'] == survey_id]
-        if len(enrolled) > 0:
-                return True
-    return False
+    return any(survey for info in associations
+               for survey in info['enrolments']
+               if survey['surveyId'] == survey_id)

--- a/frontstage/views/surveys/add_survey_submit.py
+++ b/frontstage/views/surveys/add_survey_submit.py
@@ -81,4 +81,3 @@ def is_respondent_and_business_enrolled(associations, survey_id, party_id):
                 if survey['surveyId'] == survey_id:
                     return True
     return False
-

--- a/frontstage/views/surveys/add_survey_submit.py
+++ b/frontstage/views/surveys/add_survey_submit.py
@@ -39,7 +39,7 @@ def add_survey_submit(session):
                                                                    app.config['PARTY_AUTH'], collection_exercise_id)
 
         already_enrolled = None
-        if is_business_enrolled(info['associations'], case['caseGroup']['surveyId'], party_id):
+        if is_respondent_and_business_enrolled(info['associations'], case['caseGroup']['surveyId'], party_id):
             logger.info('User tried to enrol onto a survey they are already enrolled on',
                         case_id=case_id, party_id=party_id)
             already_enrolled = True
@@ -62,10 +62,13 @@ def add_survey_submit(session):
                             survey_id=added_survey_id, tag='todo', already_enrolled=already_enrolled))
 
 
-def is_business_enrolled(associations, survey_id, party_id):
+def is_respondent_and_business_enrolled(associations, survey_id, party_id):
     """
-    Makes two checks as a business can be enrolled  on a survey but not the respondent, which would causes a single
-    check to break if another respondent from the business had previously enrolled on that survey
+    This function checks that the business AND the respondent are enrolled in a survey. We first check if the respondent
+    is enrolled, then if not, we check that the business is enrolled on the survey. A business can have multiple
+    respondents enrolled for a survey, and a respondent can be enrolled for multiple surveys. If we only checked if the
+    business was enrolled, then there could only ever be one respondent that could be able to answer the survey, which
+    isn't the desired functionality.
 
     :param associations: List of respondents and their enrolled surveys
     :param survey_id: id of the added survey

--- a/frontstage/views/surveys/add_survey_submit.py
+++ b/frontstage/views/surveys/add_survey_submit.py
@@ -1,9 +1,8 @@
 
 import logging
 
-from flask import redirect, request, url_for
+from flask import redirect, request, url_for, current_app as app
 from structlog import wrap_logger
-
 from frontstage.common.authorisation import jwt_authorization
 from frontstage.common.cryptographer import Cryptographer
 from frontstage.controllers import case_controller, collection_exercise_controller, iac_controller, party_controller
@@ -36,7 +35,8 @@ def add_survey_submit(session):
         added_survey_id = collection_exercise_controller.get_collection_exercise(
             case['caseGroup']['collectionExerciseId']).get('surveyId')
 
-        info = party_controller.get_party_by_business_id(business_party_id, collection_exercise_id)
+        info = party_controller.get_party_by_business_id(business_party_id, app.config['PARTY_URL'],
+                                                                   app.config['PARTY_AUTH'], collection_exercise_id)
 
         already_enrolled = None
         if is_business_enrolled(info['associations'], case['caseGroup']['surveyId'], party_id):

--- a/frontstage/views/surveys/add_survey_submit.py
+++ b/frontstage/views/surveys/add_survey_submit.py
@@ -72,9 +72,9 @@ def is_business_enrolled(associations, survey_id, party_id):
     :param party_id: id of the respondent
     :return: True if respondent and the business is enrolled on the survey and false otherwise
     """
-    for info in associations:
-        if info['partyId'] == party_id:
-            for survey in info['enrolments']:
+    for association in associations:
+        if association['partyId'] == party_id:
+            for survey in association['enrolments']:
                 if survey['surveyId'] == survey_id:
                     return True
     return False

--- a/frontstage/views/surveys/add_survey_submit.py
+++ b/frontstage/views/surveys/add_survey_submit.py
@@ -36,7 +36,7 @@ def add_survey_submit(session):
             case['caseGroup']['collectionExerciseId']).get('surveyId')
 
         info = party_controller.get_party_by_business_id(business_party_id, app.config['PARTY_URL'],
-                                                                   app.config['PARTY_AUTH'], collection_exercise_id)
+                                                         app.config['PARTY_AUTH'], collection_exercise_id)
 
         already_enrolled = None
         if is_respondent_and_business_enrolled(info['associations'], case['caseGroup']['surveyId'], party_id):

--- a/frontstage/views/surveys/surveys_list.py
+++ b/frontstage/views/surveys/surveys_list.py
@@ -19,6 +19,7 @@ def get_survey_list(session, tag):
     party_id = session.get('party_id')
     business_id = request.args.get('business_party_id')
     survey_id = request.args.get('survey_id')
+    already_enrolled = request.args.get('already_enrolled')
 
     survey_list = party_controller.get_survey_list_details_for_party(party_id, tag, business_party_id=business_id,
                                                                      survey_id=survey_id)
@@ -28,7 +29,9 @@ def get_survey_list(session, tag):
     if tag == 'todo':
         response = make_response(render_template('surveys/surveys-todo.html',
                                                  sorted_surveys_list=sorted_survey_list,
-                                                 added_survey=True if business_id and survey_id else None))
+                                                 added_survey=True if business_id and survey_id and not already_enrolled else None,
+                                                 already_enrolled=already_enrolled
+                                                 ))
 
         # Ensure any return to list of surveys (e.g. browser back) round trips the server to display the latest statuses
         response.headers.set("Cache-Control", "no-cache, max-age=0, must-revalidate, no-store")

--- a/frontstage/views/surveys/surveys_list.py
+++ b/frontstage/views/surveys/surveys_list.py
@@ -27,11 +27,10 @@ def get_survey_list(session, tag):
     sorted_survey_list = sorted(survey_list, key=lambda k: datetime.strptime(k['submit_by'], '%d %b %Y'))
 
     if tag == 'todo':
+        added_survey = True if business_id and survey_id and not already_enrolled else None
         response = make_response(render_template('surveys/surveys-todo.html',
                                                  sorted_surveys_list=sorted_survey_list,
-                                                 added_survey=True if business_id and survey_id and not already_enrolled else None,
-                                                 already_enrolled=already_enrolled
-                                                 ))
+                                                 added_survey=added_survey, already_enrolled=already_enrolled))
 
         # Ensure any return to list of surveys (e.g. browser back) round trips the server to display the latest statuses
         response.headers.set("Cache-Control", "no-cache, max-age=0, must-revalidate, no-store")

--- a/tests/app/mocked_services.py
+++ b/tests/app/mocked_services.py
@@ -17,6 +17,9 @@ with open('tests/test_data/party/party.json') as fp:
 with open('tests/test_data/case/case.json') as fp:
     case = json.load(fp)
 
+with open('tests/test_data/case/case_diff_surveyId.json') as fp:
+    case_diff_surveyId = json.load(fp)
+
 with open('tests/test_data/case/case_list.json') as fp:
     case_list = json.load(fp)
 

--- a/tests/app/views/surveys/test_add_survey.py
+++ b/tests/app/views/surveys/test_add_survey.py
@@ -9,6 +9,7 @@ from frontstage import app
 from frontstage.exceptions.exceptions import ApiError
 from tests.app.mocked_services import active_iac, encrypted_enrolment_code, enrolment_code, inactive_iac, \
     url_validate_enrolment
+from frontstage.views.surveys.add_survey_submit import is_business_enrolled
 
 
 logger = wrap_logger(logging.getLogger(__name__))
@@ -98,3 +99,21 @@ class TestAddSurvey(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue('Enrolment code not valid'.encode() in response.data)
         self.assertTrue('Please re-enter the code and try again'.encode() in response.data)
+
+    def test_is_business_enrolled_true(self):
+        associations = [{'businessRespondentStatus': 'ACTIVE',
+                        'enrolments': [{'enrolmentStatus': 'ENABLED',
+                                        'surveyId': 'cb8accda-6118-4d3b-85a3-149e28960c54'}],
+                        'partyId': 'f26cc19e-a8c0-4b0c-ba38-b6d36a271166'}]
+        survey_id = 'cb8accda-6118-4d3b-85a3-149e28960c54'
+        party_id = 'f26cc19e-a8c0-4b0c-ba38-b6d36a271166'
+        assert is_business_enrolled(associations, survey_id, party_id) is True
+
+    def test_is_business_enrolled_false(self):
+        associations = [{'businessRespondentStatus': 'ACTIVE',
+                         'enrolments': [{'enrolmentStatus': 'ENABLED',
+                                         'surveyId': 'cb8accda-6118-4d3b-85a3-149e28960c54'}],
+                         'partyId': 'f26cc19e-a8c0-4b0c-ba38-b6d36a271166'}]
+        survey_id = '02b9c366-7397-42f7-942a-76dc5876d86d'
+        party_id = 'f26cc19e-a8c0-4b0c-ba38-b6d36a271166'
+        assert is_business_enrolled(associations, survey_id, party_id) is False

--- a/tests/app/views/surveys/test_add_survey.py
+++ b/tests/app/views/surveys/test_add_survey.py
@@ -9,7 +9,6 @@ from frontstage import app
 from frontstage.exceptions.exceptions import ApiError
 from tests.app.mocked_services import active_iac, encrypted_enrolment_code, enrolment_code, inactive_iac, \
     url_validate_enrolment
-from frontstage.views.surveys.add_survey_submit import is_business_enrolled
 
 
 logger = wrap_logger(logging.getLogger(__name__))
@@ -99,21 +98,3 @@ class TestAddSurvey(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue('Enrolment code not valid'.encode() in response.data)
         self.assertTrue('Please re-enter the code and try again'.encode() in response.data)
-
-    def test_is_business_enrolled_true(self):
-        associations = [{'businessRespondentStatus': 'ACTIVE',
-                        'enrolments': [{'enrolmentStatus': 'ENABLED',
-                                        'surveyId': 'cb8accda-6118-4d3b-85a3-149e28960c54'}],
-                        'partyId': 'f26cc19e-a8c0-4b0c-ba38-b6d36a271166'}]
-        survey_id = 'cb8accda-6118-4d3b-85a3-149e28960c54'
-        party_id = 'f26cc19e-a8c0-4b0c-ba38-b6d36a271166'
-        assert is_business_enrolled(associations, survey_id, party_id) is True
-
-    def test_is_business_enrolled_false(self):
-        associations = [{'businessRespondentStatus': 'ACTIVE',
-                         'enrolments': [{'enrolmentStatus': 'ENABLED',
-                                         'surveyId': 'cb8accda-6118-4d3b-85a3-149e28960c54'}],
-                         'partyId': 'f26cc19e-a8c0-4b0c-ba38-b6d36a271166'}]
-        survey_id = '02b9c366-7397-42f7-942a-76dc5876d86d'
-        party_id = 'f26cc19e-a8c0-4b0c-ba38-b6d36a271166'
-        assert is_business_enrolled(associations, survey_id, party_id) is False

--- a/tests/app/views/surveys/test_add_survey_submit.py
+++ b/tests/app/views/surveys/test_add_survey_submit.py
@@ -11,7 +11,7 @@ from frontstage.exceptions.exceptions import ApiError
 from tests.app.mocked_services import active_iac, case, collection_exercise, encoded_jwt_token, \
     encrypted_enrolment_code, \
     enrolment_code, url_validate_enrolment, business_party, case_diff_surveyId
-from frontstage.views.surveys.add_survey_submit import is_business_enrolled
+from frontstage.views.surveys.add_survey_submit import is_respondent_and_business_enrolled
 
 logger = wrap_logger(logging.getLogger(__name__))
 
@@ -99,7 +99,7 @@ class TestAddSurveySubmit(unittest.TestCase):
 
         party_id = 'f956e8ae-6e0f-4414-b0cf-a07c1aa3e37b'
 
-        self.assertTrue(is_business_enrolled(data['associations'], survey, party_id))
+        self.assertTrue(is_respondent_and_business_enrolled(data['associations'], survey, party_id))
 
     def test_not_already_enrolled(self):
         with open('tests/test_data/party/business_party.json') as business_json_data:
@@ -108,4 +108,4 @@ class TestAddSurveySubmit(unittest.TestCase):
 
         party_id = '40ed60a3-2bbb-4f94-8f0d-56890f70865d'
 
-        self.assertFalse(is_business_enrolled(data['associations'], survey, party_id))
+        self.assertFalse(is_respondent_and_business_enrolled(data['associations'], survey, party_id))

--- a/tests/app/views/surveys/test_add_survey_submit.py
+++ b/tests/app/views/surveys/test_add_survey_submit.py
@@ -1,4 +1,5 @@
 import logging
+import json
 import unittest
 from unittest.mock import patch
 
@@ -9,8 +10,8 @@ from frontstage import app
 from frontstage.exceptions.exceptions import ApiError
 from tests.app.mocked_services import active_iac, case, collection_exercise, encoded_jwt_token, \
     encrypted_enrolment_code, \
-    enrolment_code, url_validate_enrolment
-
+    enrolment_code, url_validate_enrolment, business_party, case_diff_surveyId
+from frontstage.views.surveys.add_survey_submit import is_business_enrolled
 
 logger = wrap_logger(logging.getLogger(__name__))
 
@@ -32,16 +33,40 @@ class TestAddSurveySubmit(unittest.TestCase):
 
     @patch('frontstage.controllers.party_controller.add_survey')
     @patch('frontstage.controllers.case_controller.post_case_event')
+    @patch('frontstage.controllers.party_controller.get_party_by_business_id')
     @patch('frontstage.controllers.collection_exercise_controller.get_collection_exercise')
     @patch('frontstage.controllers.case_controller.get_case_by_enrolment_code')
     @patch('frontstage.controllers.iac_controller.get_iac_from_enrolment')
     @patch('frontstage.common.cryptographer.Cryptographer.decrypt')
     def test_add_survey_submit_success_redirect_to_survey_todo_list(self, decrypt_enrolment_code, get_iac_by_enrolment_code,
-                                                                    get_case_by_enrolment, get_collection_exercise, *_):
+                                                                    get_case_by_enrolment, get_collection_exercise, get_party_by_business_id, *_):
         decrypt_enrolment_code.return_value = enrolment_code.encode()
         get_iac_by_enrolment_code.return_value = active_iac
         get_case_by_enrolment.return_value = case
         get_collection_exercise.return_value = collection_exercise
+        get_party_by_business_id.return_value = business_party
+
+        response = self.app.get(f'/surveys/add-survey/add-survey-submit?encrypted_enrolment_code={encrypted_enrolment_code}')
+
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue('/surveys/todo'.encode() in response.data)
+        self.assertTrue(case['partyId'].encode() in response.data)
+        self.assertTrue(collection_exercise['surveyId'].encode() in response.data)
+
+    @patch('frontstage.controllers.party_controller.add_survey')
+    @patch('frontstage.controllers.case_controller.post_case_event')
+    @patch('frontstage.controllers.party_controller.get_party_by_business_id')
+    @patch('frontstage.controllers.collection_exercise_controller.get_collection_exercise')
+    @patch('frontstage.controllers.case_controller.get_case_by_enrolment_code')
+    @patch('frontstage.controllers.iac_controller.get_iac_from_enrolment')
+    @patch('frontstage.common.cryptographer.Cryptographer.decrypt')
+    def test_add_survey_submit_already_enrolled(self, decrypt_enrolment_code, get_iac_by_enrolment_code,
+                                                get_case_by_enrolment, get_collection_exercise, get_party_by_business_id, *_):
+        decrypt_enrolment_code.return_value = enrolment_code.encode()
+        get_iac_by_enrolment_code.return_value = active_iac
+        get_case_by_enrolment.return_value = case_diff_surveyId
+        get_collection_exercise.return_value = collection_exercise
+        get_party_by_business_id.return_value = business_party
 
         response = self.app.get(f'/surveys/add-survey/add-survey-submit?encrypted_enrolment_code={encrypted_enrolment_code}')
 
@@ -66,3 +91,17 @@ class TestAddSurveySubmit(unittest.TestCase):
 
         self.assertEqual(response.status_code, 500)
         self.assertTrue('Error 500 - Server error'.encode() in response.data)
+
+    def test_already_enrolled(self, ):
+        with open('tests/test_data/party/business_party.json') as j:
+            data = json.load(j)
+        survey = 'cb8accda-6118-4d3b-85a3-149e28960c54'
+
+        self.assertTrue(is_business_enrolled(data['associations'], survey))
+
+    def test_not_already_enrolled(self, ):
+        with open('tests/test_data/party/business_party.json') as j:
+            data = json.load(j)
+        survey = '64ad4018-2ddd-4894-89e7-33f0135887a2'
+
+        self.assertFalse(is_business_enrolled(data['associations'], survey))

--- a/tests/app/views/surveys/test_add_survey_submit.py
+++ b/tests/app/views/surveys/test_add_survey_submit.py
@@ -97,11 +97,15 @@ class TestAddSurveySubmit(unittest.TestCase):
             data = json.load(j)
         survey = 'cb8accda-6118-4d3b-85a3-149e28960c54'
 
-        self.assertTrue(is_business_enrolled(data['associations'], survey))
+        party_id = 'f956e8ae-6e0f-4414-b0cf-a07c1aa3e37b'
+
+        self.assertTrue(is_business_enrolled(data['associations'], survey, party_id))
 
     def test_not_already_enrolled(self, ):
         with open('tests/test_data/party/business_party.json') as j:
             data = json.load(j)
         survey = '64ad4018-2ddd-4894-89e7-33f0135887a2'
 
-        self.assertFalse(is_business_enrolled(data['associations'], survey))
+        party_id = '40ed60a3-2bbb-4f94-8f0d-56890f70865d'
+
+        self.assertFalse(is_business_enrolled(data['associations'], survey, party_id))

--- a/tests/app/views/surveys/test_add_survey_submit.py
+++ b/tests/app/views/surveys/test_add_survey_submit.py
@@ -92,18 +92,18 @@ class TestAddSurveySubmit(unittest.TestCase):
         self.assertEqual(response.status_code, 500)
         self.assertTrue('Error 500 - Server error'.encode() in response.data)
 
-    def test_already_enrolled(self, ):
-        with open('tests/test_data/party/business_party.json') as j:
-            data = json.load(j)
+    def test_already_enrolled(self):
+        with open('tests/test_data/party/business_party.json') as business_json_data:
+            data = json.load(business_json_data)
         survey = 'cb8accda-6118-4d3b-85a3-149e28960c54'
 
         party_id = 'f956e8ae-6e0f-4414-b0cf-a07c1aa3e37b'
 
         self.assertTrue(is_business_enrolled(data['associations'], survey, party_id))
 
-    def test_not_already_enrolled(self, ):
-        with open('tests/test_data/party/business_party.json') as j:
-            data = json.load(j)
+    def test_not_already_enrolled(self):
+        with open('tests/test_data/party/business_party.json') as business_json_data:
+            data = json.load(business_json_data)
         survey = '64ad4018-2ddd-4894-89e7-33f0135887a2'
 
         party_id = '40ed60a3-2bbb-4f94-8f0d-56890f70865d'

--- a/tests/test_data/associations.json
+++ b/tests/test_data/associations.json
@@ -1,0 +1,16 @@
+[
+  {
+    "associations": [
+      {
+        "enrolments": [
+          {
+            "enrolmentStatus": "ENABLED",
+            "name": "Business Register and Employment Survey",
+            "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
+          }
+        ],
+        "partyId": "07d672bc-497b-448f-a406-a20a7e6013d7"
+      }
+    ]
+  }
+]

--- a/tests/test_data/case/case_diff_surveyId.json
+++ b/tests/test_data/case/case_diff_surveyId.json
@@ -13,7 +13,7 @@
         "collectionExerciseId": "8d990a74-5f07-4765-ac66-df7e1a96505b",
         "id": "d24e6267-e3f9-4378-898e-4df75c59cdea",
         "partyId": "be3483c3-f5c9-4b13-bdd7-244db78ff687",
-        "surveyId": "cb8accda-6118-4d3b-85a3-149e28960c54",
+        "surveyId": "qb8accda-6118-4d3b-85a3-149e28960c89",
         "sampleUnitRef": "49900000001",
         "sampleUnitType": "B",
         "caseGroupStatus": "NOTSTARTED"


### PR DESCRIPTION
# Motivation and Context
Didn't work before, now it does.

# What has changed
Added true/false unit tests for the check to see if a user is already enrolled
Made a change to the check which removed unexpected behaviour (preventing people from enrolling who should be able to.)

# How to test?
1) Run the unit tests for add_survey_submit.py
2) Try and enrol to a survey on a users account that they are already enrolled to using a new enrolment code (should fail and show Already added survey' message).
3) Try and enrol to a survey that the user is not enrolled on (should succeed and show survey added message).
# Links
https://trello.com/c/gfNFRVsR/569-569-add-validation-for-respondents-adding-another-survey-to-their-enrolment
