### PR TITLE
Configurable verbose

### DIFF
--- a/frontstage/controllers/party_controller.py
+++ b/frontstage/controllers/party_controller.py
@@ -95,11 +95,12 @@ def get_party_by_business_id(party_id, party_url, party_auth, collection_exercis
     logger.debug('Attempting to retrieve party by business', party_id=party_id)
 
     url = f"{party_url}/party-api/v1/businesses/id/{party_id}"
+    params = {}
     if collection_exercise_id:
-        url += f"?collection_exercise_id={collection_exercise_id}"
+        params['collection_exercise_id'] = collection_exercise_id
     if verbose:
-        url += "&verbose=True"
-    response = requests.get(url, auth=party_auth)
+        params['verbose'] = True
+    response = requests.get(url, params=params, auth=party_auth)
 
     try:
         response.raise_for_status()

--- a/frontstage/controllers/party_controller.py
+++ b/frontstage/controllers/party_controller.py
@@ -91,12 +91,14 @@ def create_account(registration_data):
     logger.debug('Successfully created account')
 
 
-def get_party_by_business_id(party_id, party_url, party_auth, collection_exercise_id=None):
+def get_party_by_business_id(party_id, party_url, party_auth, collection_exercise_id=None, verbose=True):
     logger.debug('Attempting to retrieve party by business', party_id=party_id)
 
     url = f"{party_url}/party-api/v1/businesses/id/{party_id}"
     if collection_exercise_id:
-        url += f"?collection_exercise_id={collection_exercise_id}&verbose=True"
+        url += f"?collection_exercise_id={collection_exercise_id}"
+    if verbose:
+        url += "&verbose=True"
     response = requests.get(url, auth=party_auth)
 
     try:


### PR DESCRIPTION
# Motivation and Context
The verbose parameter is optional when calling the party service, but for some reason, we've hardcoded it to always be true.  In the future we might want to call this function without the verbose mode, so this allows us to do so.

We also improved the unit tests around this area of code slightly.

# What has changed
The way the parameters are passed has been refactored.  Now it uses requests build in parameters argument, which takes a dictionary.  It means we don't have to build the whole url and it's easy to add new parameters if we need to (otherwise we end up having to handle the ? and & characters, which is a huge hassle).

# How to test?
Run the unit tests, they should still pass.
The acceptance tests can also be run, but as the functionality is identical (all we did was add an optional variable and default it to true), it's probably not necessary.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):
