### PR TITLE
restricted enrolments as seen in the UI to those for started collex

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ services:
     - redis-server
 
 install:
-  - pip install pipenv==8.3.2
+  - pip install pipenv
   - pipenv install --dev --deploy
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 sudo: required
-dist: trusty
 python: '3.6'
 
 # before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ script:
   - APP_SETTINGS=TestingConfig pipenv run pytest --cov=frontstage --cov-report xml --ignore=node_modules
   - pipenv run coverage report
 
+env:
+  global:
+    - PIPENV_IGNORE_VIRTUALENVS=1
+
 after_success:
   - pipenv run codecov
 

--- a/frontstage/controllers/party_controller.py
+++ b/frontstage/controllers/party_controller.py
@@ -234,7 +234,14 @@ def get_respondent_enrolments(party_id):
 
 
 def get_respondent_enrolments_for_known_collex(enrolment_data, cache_collex):
-    """remove any enrolments that are for surveys not in already started collex."""
+    """ Needed because enrolment_data includes not started enrolments ,
+    but cache_collex only contains started collex. Hence indexing collex by enrolment[survey] causes a 500
+
+    :param enrolment_data: A list of enrolments.
+    :param cache_collex: A list of not started collection exercises.
+    :return: list of enrolments corresponding to the known collection exercises
+    """
+
     enrolments = []
     for enrolment in enrolment_data:
         if enrolment['survey_id'] in cache_collex:
@@ -329,7 +336,6 @@ def get_survey_list_details_for_party(party_id, tag, business_party_id, survey_i
                   'instrument': dict()}
 
     # These two will call the services to get responses and cache the data for later use.
-
     caching_data_for_survey_list(cache_data, surveys_ids, business_ids, tag)
     caching_data_for_collection_instrument(cache_data)
 

--- a/frontstage/controllers/party_controller.py
+++ b/frontstage/controllers/party_controller.py
@@ -233,6 +233,17 @@ def get_respondent_enrolments(party_id):
                 }
 
 
+def get_respondent_enrolments_for_known_collex(enrolment_data, cache_collex):
+    """remove any enrolments that are for surveys not in collex
+    needed because a user may be enrolled on a not started collex
+    """
+    enrolments = []
+    for enrolment in enrolment_data:
+        if enrolment['survey_id'] in cache_collex:
+            enrolments.append(enrolment)
+    return enrolments
+
+
 def set_enrolment_data(enrolment_data):
     # In this function, we're getting all the unique set of partys and surveys, so that we don't get the data more
     # than once.
@@ -304,8 +315,7 @@ def get_survey_list_details_for_party(party_id, tag, business_party_id, survey_i
     :survey_id: This is the surveys uuid
 
     """
-    enrolment_data = get_respondent_enrolments(party_id)
-
+    enrolment_data = list(get_respondent_enrolments(party_id))
     # Gets the survey ids and business ids from the enrolment data that has been generated.
 
     surveys_ids, business_ids = set_enrolment_data(enrolment_data)
@@ -324,8 +334,7 @@ def get_survey_list_details_for_party(party_id, tag, business_party_id, survey_i
     caching_data_for_survey_list(cache_data, surveys_ids, business_ids, tag)
     caching_data_for_collection_instrument(cache_data)
 
-    for enrolment in get_respondent_enrolments(party_id):
-
+    for enrolment in get_respondent_enrolments_for_known_collex(enrolment_data, cache_data['collexes']):
         business_party = cache_data['businesses'][enrolment['business_id']]
         survey = cache_data['surveys'][enrolment['survey_id']]
         live_collection_exercises = cache_data['collexes'][survey['id']]

--- a/frontstage/controllers/party_controller.py
+++ b/frontstage/controllers/party_controller.py
@@ -234,9 +234,7 @@ def get_respondent_enrolments(party_id):
 
 
 def get_respondent_enrolments_for_known_collex(enrolment_data, cache_collex):
-    """remove any enrolments that are for surveys not in collex
-    needed because a user may be enrolled on a not started collex
-    """
+    """remove any enrolments that are for surveys not in already started collex."""
     enrolments = []
     for enrolment in enrolment_data:
         if enrolment['survey_id'] in cache_collex:
@@ -317,6 +315,7 @@ def get_survey_list_details_for_party(party_id, tag, business_party_id, survey_i
     """
     enrolment_data = list(get_respondent_enrolments(party_id))
     # Gets the survey ids and business ids from the enrolment data that has been generated.
+    # Converted to list to avoid multiple calls to party (and the list size is small).
 
     surveys_ids, business_ids = set_enrolment_data(enrolment_data)
 

--- a/tests/app/controllers/test_party_controller.py
+++ b/tests/app/controllers/test_party_controller.py
@@ -205,7 +205,7 @@ class TestPartyController(unittest.TestCase):
                           {"survey_id": "survey3", "enrolment_data": "enrolment3"}]
 
         result = get_respondent_enrolments_for_known_collex(enrolment_data, collex)
-        self.assertEquals(len(result), 2)
+        self.assertEqual(len(result), 2)
         self.assertDictEqual({"survey_id": "survey1", "enrolment_data": "enrolment1"}, result[0])
         self.assertDictEqual({"survey_id": "survey3", "enrolment_data": "enrolment3"}, result[1])
 

--- a/tests/app/controllers/test_party_controller.py
+++ b/tests/app/controllers/test_party_controller.py
@@ -198,11 +198,11 @@ class TestPartyController(unittest.TestCase):
         """test that get_respondent_enrolments_for_known_collex will only return enrolment data
         if we have a corresponding collex."""
 
-        collex={"survey1": "collex1", "survey3": "collex3"}
+        collex = {"survey1": "collex1", "survey3": "collex3"}
 
         enrolment_data = [{"survey_id": "survey1", "enrolment_data": "enrolment1"},
-                        {"survey_id": "survey2", "enrolment_data": "enrolment2"},
-                        {"survey_id": "survey3", "enrolment_data": "enrolment3"}]
+                          {"survey_id": "survey2", "enrolment_data": "enrolment2"},
+                          {"survey_id": "survey3", "enrolment_data": "enrolment3"}]
 
         result = get_respondent_enrolments_for_known_collex(enrolment_data, collex)
         self.assertEquals(len(result), 2)

--- a/tests/app/controllers/test_party_controller.py
+++ b/tests/app/controllers/test_party_controller.py
@@ -196,7 +196,7 @@ class TestPartyController(unittest.TestCase):
 
     def test_get_respondent_enrolments_for_known_collex(self):
         """test that get_respondent_enrolments_for_known_collex will only return enrolment data
-        if we have a corresponding collex."""
+        if we have a corresponding collex"""
 
         collex = {"survey1": "collex1", "survey3": "collex3"}
 

--- a/tests/app/controllers/test_party_controller.py
+++ b/tests/app/controllers/test_party_controller.py
@@ -8,7 +8,7 @@ from config import TestingConfig
 from frontstage import app
 from frontstage.controllers import party_controller
 from frontstage.controllers.collection_exercise_controller import convert_events_to_new_format
-from frontstage.controllers.party_controller import display_button
+from frontstage.controllers.party_controller import display_button, get_respondent_enrolments_for_known_collex
 from frontstage.exceptions.exceptions import ApiError
 from tests.app.mocked_services import (business_party, case, case_list, collection_exercise,
                                        collection_exercise_by_survey,
@@ -193,6 +193,21 @@ class TestPartyController(unittest.TestCase):
                     party_controller.notify_party_and_respondent_account_locked(respondent_party['id'],
                                                                                 respondent_party['emailAddress'],
                                                                                 status='ACTIVE')
+
+    def test_get_respondent_enrolments_for_known_collex(self):
+        """test that get_respondent_enrolments_for_known_collex will only return enrolment data
+        if we have a corresponding collex."""
+
+        collex={"survey1": "collex1", "survey3": "collex3"}
+
+        enrolment_data = [{"survey_id": "survey1", "enrolment_data": "enrolment1"},
+                        {"survey_id": "survey2", "enrolment_data": "enrolment2"},
+                        {"survey_id": "survey3", "enrolment_data": "enrolment3"}]
+
+        result = get_respondent_enrolments_for_known_collex(enrolment_data, collex)
+        self.assertEquals(len(result), 2)
+        self.assertDictEqual({"survey_id": "survey1", "enrolment_data": "enrolment1"}, result[0])
+        self.assertDictEqual({"survey_id": "survey3", "enrolment_data": "enrolment3"}, result[1])
 
     @patch('frontstage.controllers.party_controller.get_respondent_party_by_id')
     def test_get_respondent_enrolments(self, get_respondent_party):


### PR DESCRIPTION
# Motivation and Context
Ras frontstage was erroring in the case where a user was enrolled on a collection exercise but that collection exercise had not started .  

# What has changed
The error was due to using enrolment survey id as an index into collection exercises , but collection exercises were restricted to those that had started . 
Changed the generator to not consider enrolments where the collex had not yet started . 

# How to test?
Run unit tests . 

# Links
https://trello.com/c/W59SAyNd

