### PR TITLE
Fixed typo in email on password reset page

### DIFF
--- a/frontstage/templates/passwords/forgot-password.check-email.html
+++ b/frontstage/templates/passwords/forgot-password.check-email.html
@@ -26,7 +26,7 @@
             <div class="guidance__content mars">
                 <div>
                 <p>Email not arrived? It might be in your spam folder.</p>
-                <p>If it doesn’t arrive in the next 15 minutes, please call <a href="tel:03001234931">0300 1234 931</a> or send an email to <a href="mailto:surveys.ons@gov.uk">surveys.ons@gov.uk</a>.</p>
+                <p>If it doesn’t arrive in the next 15 minutes, please call <a href="tel:03001234931">0300 1234 931</a> or send an email to <a href="mailto:surveys@ons.gov.uk">surveys@ons.gov.uk</a>.</p>
                 </div>
             </div>
         </div>

--- a/frontstage/templates/passwords/forgot-password.check-email.html
+++ b/frontstage/templates/passwords/forgot-password.check-email.html
@@ -15,22 +15,22 @@
      data-hide-label="Hide help with email"
      data-show-label="Show help with email">
 
-    <a class="guidance__link js-details-trigger js-details-label icon--details mars"
-       id="guidance-help-with-email"
-       data-guidance-trigger="true"
-       aria-expanded="false"
-       href="#guidance-help-with-email"
-       aria-controls="guidance-help-with-email">Help with email</a>
+        <a class="guidance__link js-details-trigger js-details-label icon--details mars"
+        id="guidance-help-with-email"
+        data-guidance-trigger="true"
+        aria-expanded="false"
+        href="#guidance-help-with-email"
+        aria-controls="guidance-help-with-email">Help with email</a>
 
-    <div class="guidance__main js-details-body" id="guidance-help-with-email" aria-hidden="true">
-        <div class="guidance__content mars">
-            <div>
-              <p>Email not arrived? It might be in your spam folder.</p>
-              <p>If it doesn’t arrive in the next 15 minutes, please call <a href="tel:03001234931">0300 1234 931</a> or send an email to <a href="mailto:surveys.ons@gov.uk">surveys.ons@gov.uk</a>.</p>
+        <div class="guidance__main js-details-body" id="guidance-help-with-email" aria-hidden="true">
+            <div class="guidance__content mars">
+                <div>
+                <p>Email not arrived? It might be in your spam folder.</p>
+                <p>If it doesn’t arrive in the next 15 minutes, please call <a href="tel:03001234931">0300 1234 931</a> or send an email to <a href="mailto:surveys.ons@gov.uk">surveys.ons@gov.uk</a>.</p>
+                </div>
             </div>
         </div>
-    </div>
 
-</div>
+    </div>
 
 {% endblock main %}


### PR DESCRIPTION
# Motivation and Context
There is a typo on frontstage which shows the email address 'surveys.ons@gov.uk' - this has been altered to read 'surveys@ons.gov.uk'.

# What has changed
Email address changed in both href and content of markup.

# How to test?
Confirm change in code, run solution, confirm change shows up.  Make sensible checks that nothing is adversely affected.

# Links
https://trello.com/c/F51uuYXO

**NB: This is actually Adam Wilkie's first PR, I'm just submitting it for him because his machine is out of battery**