### PR TITLE
Change url for confirm email

### DIFF
--- a/frontstage/views/register/enter_account_details.py
+++ b/frontstage/views/register/enter_account_details.py
@@ -1,6 +1,6 @@
 import logging
 
-from flask import render_template, request
+from flask import render_template, request, redirect, url_for
 from structlog import wrap_logger
 
 from frontstage.common.cryptographer import Cryptographer
@@ -12,6 +12,14 @@ from frontstage.views.register import register_bp
 
 logger = wrap_logger(logging.getLogger(__name__))
 cryptographer = Cryptographer()
+
+
+@register_bp.route('/create-account/check-your-email', methods=['GET'])
+def confirm_enter_your_details():
+    email_address = request.args.get('email_address')
+    if not email_address:
+        raise Exception('Attempted to render check-your-email view without passing an email address')
+    return render_template('register/register.almost-done.html', email=email_address)
 
 
 @register_bp.route('/create-account/enter-account-details', methods=['GET', 'POST'])
@@ -49,7 +57,7 @@ def register_enter_your_details():
                 raise exc
 
         logger.info('Successfully created account')
-        return render_template('register/register.almost-done.html', email=email_address)
+        return redirect(url_for('register_bp.confirm_enter_your_details', email_address=email_address))
 
     else:
         return render_template('register/register.enter-your-details.html', form=form, errors=form.errors)

--- a/tests/app/test_registration.py
+++ b/tests/app/test_registration.py
@@ -451,3 +451,18 @@ class TestRegistration(unittest.TestCase):
 
         self.assertEqual(response.status_code, 500)
         self.assertTrue('Server error'.encode() in response.data)
+
+    def test_can_access_email_confirmation_when_email_param_passed(self):
+        response = self.app.get('/register/create-account/check-your-email', query_string='email_address=steve')
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_contains_email_confirmation_when_email_param_passed(self):
+        response = self.app.get('/register/create-account/check-your-email', query_string='email_address=steve')
+
+        self.assertTrue(b'steve' in response.data)
+
+    def test_cant_access_email_confirmation_when_email_param_passed(self):
+        response = self.app.get('/register/create-account/check-your-email')
+
+        self.assertEqual(response.status_code, 500)


### PR DESCRIPTION
# Motivation and Context
When signing up an account on RAS Frontstage, the user arrives at the same URL before and after entering their email address, with different content on the page.

For best URL practice, and for ease of analytics, make the confirmation page appear at a separare URL

# What has changed
Email confirmation page now appears at a different URL

# How to test?
* Sign up a respondent account
* Confirm that the 'check your email' page appears at a separate page URL
* Check that acceptance tests pass
