### PR TITLE
Added JS to disable form after first submit

### DIFF
--- a/frontstage/templates/register/register.enter-your-details.html
+++ b/frontstage/templates/register/register.enter-your-details.html
@@ -30,7 +30,8 @@
         <form
             method="post"
             class="form"
-            role="form">
+            role="form"
+            onsubmit="formSubmitted(event);">
             {{ form.csrf_token }}
 
         <h1 class="saturn">Enter your account details</h1>
@@ -130,4 +131,15 @@
         <button class="btn venus" id="continue_button" type="submit">Continue</button>
 
     </form>
+
+    <script>
+    var submitted = false;
+    function formSubmitted(event) {
+        if (submitted) {
+            event.preventDefault();
+            return false;
+        }
+        submitted = true;
+    }
+    </script>
 {% endblock main %}


### PR DESCRIPTION
# Motivation and Context
Very occasionally, a user double clicks the submit button on the frontstage sign up form, which creates two accounts for them on the system.

Whilst this shouldn't be possible in party, it was agreed in planning that this was a good mitigation, whilst a ticket would be raised to prevent this in party or the schema later.

# What has changed
* Form onsubmit event is bound to a function that will only allow submission once.

# How to test?
Click the button twice, and note whether the form submits twice in logs.
Run acceptance tests.

# Links
https://trello.com/c/J4xky7nK
