### PR TITLE
Remove html5 attribs from forms

### DIFF
--- a/frontstage/common/validators.py
+++ b/frontstage/common/validators.py
@@ -13,7 +13,7 @@ class InputRequired(IR):
     Example sage: element = StringField('name', [ FrontstageInputRequired(message="Error message to show") ]
     """
     def __init__(self, message=None):
-        super(IR, self).__init__()
+        super().__init__()
         self.field_flags = remove_required(self.field_flags)
 
 
@@ -22,7 +22,7 @@ class DataRequired(DR):
     WTForms validator replacement that requires data, but doesn't add 'required' attribute to rendered html
     """
     def __init__(self, message=None):
-        super(DR, self).__init__()
+        super().__init__()
         self.field_flags = remove_required(self.field_flags)
 
 

--- a/frontstage/common/validators.py
+++ b/frontstage/common/validators.py
@@ -1,0 +1,34 @@
+from wtforms.validators import InputRequired as IR
+from wtforms.validators import DataRequired as DR
+
+"""
+A collection of validators for use with WTForms forms
+"""
+
+
+class InputRequired(IR):
+    """
+    WTForms validator replacement that requires input, but doesn't add 'required' attribute to rendered html
+
+    Example sage: element = StringField('name', [ FrontstageInputRequired(message="Error message to show") ]
+    """
+    def __init__(self, message=None):
+        super(IR, self).__init__()
+        self.field_flags = remove_required(self.field_flags)
+
+
+class DataRequired(DR):
+    """
+    WTForms validator replacement that requires data, but doesn't add 'required' attribute to rendered html
+    """
+    def __init__(self, message=None):
+        super(DR, self).__init__()
+        self.field_flags = remove_required(self.field_flags)
+
+
+def remove_required(flags):
+    if 'required' in flags:
+        n = flags.index('required')
+        return flags[: n] + flags[n + 1:]
+
+    return flags

--- a/frontstage/common/validators.py
+++ b/frontstage/common/validators.py
@@ -13,7 +13,7 @@ class InputRequired(IR):
     Example sage: element = StringField('name', [ FrontstageInputRequired(message="Error message to show") ]
     """
     def __init__(self, message=None):
-        super().__init__()
+        super().__init__(message=message)
         self.field_flags = remove_required(self.field_flags)
 
 
@@ -22,7 +22,7 @@ class DataRequired(DR):
     WTForms validator replacement that requires data, but doesn't add 'required' attribute to rendered html
     """
     def __init__(self, message=None):
-        super().__init__()
+        super().__init__(message=message)
         self.field_flags = remove_required(self.field_flags)
 
 

--- a/frontstage/models.py
+++ b/frontstage/models.py
@@ -6,7 +6,8 @@ from flask_wtf import FlaskForm
 from phonenumbers.phonenumberutil import NumberParseException
 from structlog import wrap_logger
 from wtforms import HiddenField, PasswordField, StringField, SubmitField, TextAreaField
-from wtforms.validators import InputRequired, EqualTo, Length, DataRequired, Email, ValidationError
+from wtforms.validators import EqualTo, Length, Email, ValidationError
+from frontstage.common.validators import InputRequired, DataRequired
 
 from frontstage import app
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,22 @@
+import unittest
+
+from frontstage.common.validators import remove_required
+
+
+class TestRemoveRequiredFunction(unittest.TestCase):
+
+    """
+    remove_required function tests
+    """
+
+    def test_should_remove_a_required_member_if_there_is_one(self):
+        test_tuple = ('required', 'other', 'somethingelse')
+        output = remove_required(test_tuple)
+
+        self.assertFalse('required' in output)
+
+    def test_should_leave_tuple_unaffected_if_there_is_no_required_entry(self):
+        test_tuple = ('foo', 'other', 'somethingelse')
+        output = remove_required(test_tuple)
+
+        self.assertEqual(output, test_tuple)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -14,6 +14,24 @@ class TestRemoveRequiredFunction(unittest.TestCase):
 
         self.assertFalse('required' in output)
 
+    def test_should_remove_a_required_if_its_the_only_item_in_list(self):
+        test_tuple = ('required')
+        output = remove_required(test_tuple)
+
+        self.assertFalse('required' in output)
+
+    def test_should_remove_a_required_member_if_its_in_the_middle_of_the_list(self):
+        test_tuple = ('otheritem', 'required', 'other', 'somethingelse')
+        output = remove_required(test_tuple)
+
+        self.assertFalse('required' in output)
+    
+    def test_should_remove_a_required_member_if_its_the_last_item_in_the_list(self):
+        test_tuple = ('item', 'otheritem', 'required')
+        output = remove_required(test_tuple)
+
+        self.assertFalse('required' in output)
+
     def test_should_leave_tuple_unaffected_if_there_is_no_required_entry(self):
         test_tuple = ('foo', 'other', 'somethingelse')
         output = remove_required(test_tuple)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -25,7 +25,7 @@ class TestRemoveRequiredFunction(unittest.TestCase):
         output = remove_required(test_tuple)
 
         self.assertFalse('required' in output)
-    
+
     def test_should_remove_a_required_member_if_its_the_last_item_in_the_list(self):
         test_tuple = ('item', 'otheritem', 'required')
         output = remove_required(test_tuple)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,10 +1,9 @@
 import unittest
 
-from frontstage.common.validators import remove_required
+from frontstage.common.validators import remove_required, InputRequired, DataRequired
 
 
 class TestRemoveRequiredFunction(unittest.TestCase):
-
     """
     remove_required function tests
     """
@@ -20,3 +19,23 @@ class TestRemoveRequiredFunction(unittest.TestCase):
         output = remove_required(test_tuple)
 
         self.assertEqual(output, test_tuple)
+
+
+class TestInputRequired(unittest.TestCase):
+    """
+    Tests for the InputRequired class
+    """
+
+    def test_instantiated_field_should_have_no_required_attribute(self):
+        inputReq = InputRequired()
+        self.assertFalse('required' in inputReq.field_flags)
+
+
+class TestDataRequired(unittest.TestCase):
+    """
+    Tests for the DataRequired class
+    """
+
+    def test_instantiated_field_should_have_no_required_attribute(self):
+        inputReq = DataRequired()
+        self.assertFalse('required' in inputReq.field_flags)


### PR DESCRIPTION
# Motivation and Context
The use of HTML5 input attributes like `required` prevents the user experience being in line with that desired.

# What has changed
* Wrote custom validators that extend WTForm validators and removes html5 attribs
* Imported these validators in form models, instead of the WTForm validators
* Wrote tests

# How to test?
* Run through process of signing up as a respondent and confirm that in source code, no input has `required` attribute (can do this using inspect element)
* Run through other forms in frontstage, do the same check
* Acceptance tests

# Links
https://trello.com/c/lPtTcThh