### PR TITLE
Fix 400 error page title

### DIFF
--- a/frontstage/templates/errors/400-error.html
+++ b/frontstage/templates/errors/400-error.html
@@ -1,7 +1,7 @@
 {% import 'partials/section.html' as section %}
 {% extends "layouts/_twocol.html" %}
 
-{% block page_title %}Page not found (Error 404) - ONS Business Surveys{% endblock %}
+{% block page_title %}An error has occurred - ONS Business Surveys{% endblock %}
 
 {% block main %}
         <div class="grid__col col-8@m">


### PR DESCRIPTION
# Motivation and Context
Fixed a small error in the title of https://github.com/ONSdigital/ras-frontstage/pull/443

# What has changed
Page title is now correct for a status code 400 page (previous one referenced 404)

# How to test?
Get to an error page.  Check the title is sensible.

# Links
https://trello.com/c/k1M7FJAy/844-csrf-returning-as-500-on-frontstage

# Screenshots (if appropriate):
