### PR TITLE
added no-js to hide show password if javascript disabled

### DIFF
--- a/frontstage/static/css/theme.css
+++ b/frontstage/static/css/theme.css
@@ -217,3 +217,7 @@ font-weight: 400;
   border-color: #555;
   border-bottom: 1px solid #fff;
 }
+
+.no-js .hide-if-no-js {
+  display: none;
+}

--- a/frontstage/templates/passwords/reset-password.html
+++ b/frontstage/templates/passwords/reset-password.html
@@ -63,7 +63,7 @@
         <div class="panel panel--simple panel--error">
             <p class="error-message">{{ errorType['password'][0] }}</p>
         {% endif %}
-            <div class="field--toggle">
+            <div class="hide-if-no-js field--toggle">
               <label class="label label--inline venus field__label" for="showPasswordToggle">Show password</label>
               <input id="showPasswordToggle" class="field__input input input--checkbox" type="checkbox">
             </div>

--- a/frontstage/templates/sign-in/sign-in.html
+++ b/frontstage/templates/sign-in/sign-in.html
@@ -97,7 +97,7 @@
                         <p class="error-message">{{ errorType['password'][0] }}</p>
                     {% endif %}
                         {{ form.password.label(class_='label') }}
-                        <div class="field--toggle">
+                        <div class="hide-if-no-js field--toggle">
                             <label class="label label--inline venus field__label" for="showPasswordToggle">Show password</label>
                             <input id="showPasswordToggle" class="field__input input input--checkbox" type="checkbox">
                           </div>


### PR DESCRIPTION
# Motivation and Context

The purpose of this push was to make sure the "show password" option on the sign-in page is hidden if javascript was disabled. Before now, the show password option would appear, but would be non-functional if javascript was disabled. This change makes the interface less misleading to users who don't use javascript.

# What has changed

- Added a .hide-if-no-js function to theme.css.
- Applied the .hide-if-no-js to the "show password" boxes in both sign-in.html and reset-password.html.

# How to test?

- Switch off javascript in your browser (in Chrome, click the three dots in the top-right, go into "settings", then "advanced" at the bottom, then "site settings", then "javascript", then disable javascript).
- Load the sign-in page in frontstage (port 8082) and see if the "show password" box appears above the password field. It shouldn't appear if javascript is disabled. You can also check if it appears after javascript is re-enabled.

# Links

[Trello card](https://trello.com/c/tvIiLLE5)