### PR TITLE
appended '- 400' to the 400 error page title for distinction from 500 in analytics

### DIFF
--- a/frontstage/templates/errors/400-error.html
+++ b/frontstage/templates/errors/400-error.html
@@ -1,7 +1,7 @@
 {% import 'partials/section.html' as section %}
 {% extends "layouts/_twocol.html" %}
 
-{% block page_title %}An error has occurred - ONS Business Surveys{% endblock %}
+{% block page_title %}An error has occurred - ONS Business Surveys - 400){% endblock %}
 
 {% block main %}
         <div class="grid__col col-8@m">

--- a/frontstage/templates/errors/500-error.html
+++ b/frontstage/templates/errors/500-error.html
@@ -1,7 +1,7 @@
 {% import 'partials/section.html' as section %}
 {% extends "layouts/_twocol.html" %}
 
-{% block page_title %}An error has occurred - ONS Business Surveys{% endblock %}
+{% block page_title %}An error has occurred - ONS Business Surveys - 500{% endblock %}
 
 {% block main %}
     <h1 class="saturn">An error has occurred</h1>


### PR DESCRIPTION

# Motivation and Context
So that we can track 400 and 500 errors independently in google analytics

# What has changed
added - 400 to the 400 template title, this is what our user researcher deemed most appropriate.

# How to test?
hit the error and look at the title

# Links
https://trello.com/c/JllhbBP2/1069-400-and-500-page-both-using-the-same-title-1
