### PR TITLE
Fix broken /thread links in emails

### DIFF
--- a/frontstage/views/secure_messaging/message_get.py
+++ b/frontstage/views/secure_messaging/message_get.py
@@ -15,9 +15,16 @@ from frontstage.views.secure_messaging import secure_message_bp
 logger = wrap_logger(logging.getLogger(__name__))
 
 
+@secure_message_bp.route('/thread/<thread_id>', methods=['GET', 'POST'])
 @secure_message_bp.route('/threads/<thread_id>', methods=['GET', 'POST'])
 @jwt_authorization(request)
 def view_conversation(session, thread_id):
+    """Endpoint to view conversations by thread_id
+
+    NOTE: /thread/<thread_id> endpoint is there for compatability reasons.  All new emails use /threads/<thread_id>.
+    From September 2019 onwards, it should be safe to remove the /thread endpoint (just check the analytics to make
+    sure that it's a very small number of people trying to hit it first!).
+    """
     party_id = session.get('party_id')
     logger.info("Getting conversation", thread_id=thread_id, party_id=party_id)
     # TODO, do we really want to do a GET every time, even if we're POSTing? Rops does it this

--- a/tests/app/mocked_services.py
+++ b/tests/app/mocked_services.py
@@ -122,6 +122,7 @@ url_get_survey_by_short_name_eq = f"{app.config['SURVEY_URL']}/surveys/shortname
 url_get_survey_by_short_name_rsi = f"{app.config['SURVEY_URL']}/surveys/shortname/{survey_rsi['shortName']}"
 url_get_token = f"{app.config['OAUTH_URL']}/api/v1/tokens/"
 url_get_thread = app.config['SECURE_MESSAGE_URL'] + '/threads/9e3465c0-9172-4974-a7d1-3a01592d1594'
+url_get_thread_old = app.config['SECURE_MESSAGE_URL'] + '/thread/9e3465c0-9172-4974-a7d1-3a01592d1594'
 url_get_threads = app.config['SECURE_MESSAGE_URL'] + '/threads'
 url_oauth_token = f"{app.config['OAUTH_URL']}/api/v1/tokens/"
 url_password_change = f"{app.config['PARTY_URL']}/party-api/v1/respondents/change_password/{token}"


### PR DESCRIPTION
# Motivation and Context
The remove v2 endpoint change for secure message had a side effect that old emails stopped working correctly as /thread was changed to /threads

# What has changed
/thread/<thread_id> and /threads/<thread_id> now hit the same endpoint, whereas before hitting /thread/<thread_id> would cause an error as that endpoint doesn't exist anymore.

# How to test?
- Unit tests pass
- Ensure that thread in fronstage can be accessed using both /thread and /threads urls (just change it manually after accessing it the first time)

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):
