### PR TITLE
Change planet font classes to design system versions

### DIFF
--- a/frontstage/templates/contact-us.html
+++ b/frontstage/templates/contact-us.html
@@ -5,15 +5,15 @@
 
 {% block main %}
 
-    <h1 class="saturn">Contact us</h1>
+    <h1 class="u-fs-l">Contact us</h1>
     
     <h2 class="neptune">
         Telephone
     </h2>
-    <div class="mars">
+    <div class="u-fs-r">
         <p><a class="nowrap" href="tel:+44-300-1234-931">0300 1234 931</a></p>        
     </div>
-    <div class="mars">
+    <div class="u-fs-r">
         <p class="u-mb-l">Opening hours:<br />
             Monday to Thursday 8:30am – 5pm<br/>
             Friday 8:30am - 4:30pm</p>
@@ -21,7 +21,7 @@
     <h2 class="neptune">
         Post
     </h2>
-    <div class="mars">
+    <div class="u-fs-r">
         <p>Office for National Statistics<br />
             Government Buildings<br />
             Cardiff Road<br />

--- a/frontstage/templates/cookies-privacy.html
+++ b/frontstage/templates/cookies-privacy.html
@@ -5,7 +5,7 @@
 
 {% block main %}
 
-                <h1 class="saturn">
+                <h1 class="u-fs-l">
                     Cookies and Privacy
                 </h1>
 
@@ -330,7 +330,7 @@
 
                         <p>Surveys that are conducted on the Survey Data Collection platform may collect additional items of personal data.</p>
 
-                        <h3 class="venus">Business surveys that require personal data</h3>
+                        <h3 class="u-fs-r--b">Business surveys that require personal data</h3>
                         <p><a href="https://www.ons.gov.uk/surveys/informationforbusinesses/businesssurveys/annualsurveyofhoursandearningsashe">Annual Survey of Hours and Earnings</a><br>The legal basis for undertaking the Annual Survey of Hours and Earnings (ASHE) is the Statistics of Trade Act 1947.  This means the General Data Protection Regulation has not changed the fact that this is mandatory for the organisations selected to be part of the sample.  The personal data an organisation returns as part of this submission does not require the permission of the employees who form the data subjects and the subjects do not have any option to opt-out. The ASHE survey collects the following items of personal data:</p>
                         <ul>
                             <li>National insurance number</li>
@@ -338,7 +338,7 @@
                             <li>Postcode</li>
                         </ul>
 
-                        <h3 class="venus">Communication outside of the Survey Data Collection Platform</h3>
+                        <h3 class="u-fs-r--b">Communication outside of the Survey Data Collection Platform</h3>
                         <p>The Survey Data Collection platform contains both a telephone number and email address which can be used for both queries and issues with the platform and survey hosted on the platform.</p>
                         <p>If you contact us via email, we will process the following data items:</p>
                         <ul>
@@ -358,7 +358,7 @@
                     <h2 class="neptune u-mt-l">
                         Who we share your personal data with
                     </h2>
-                    <div class="mars">
+                    <div class="u-fs-r">
                         <p>We use several (1st and 3rd) parties to collect and process personal data. These include (but are not limited to) government departments and approved researchers. Further information can be found on the following articles: </p>
                         <p><a href="https://www.ons.gov.uk/aboutus/whatwedo/statistics/requestingstatistics/approvedresearcherscheme">Approved Researcher Scheme</a><br>
                         <p><a href="https://www.ons.gov.uk/aboutus/whatwedo/statistics/requestingstatistics/accesstounpublishedonsresearchdatabygovernmentorganisationsforstatisticalresearch">Access to unpublished ONS research data by government organisations for statistical research</a></p>
@@ -390,8 +390,8 @@
                     <h2 class="neptune u-mt-l">
                         How long we keep your data
                     </h2>
-                    <div class="mars">
-                        <h3 class="venus"><strong>Log Retention</strong></h3>
+                    <div class="u-fs-r">
+                        <h3 class="u-fs-r--b"><strong>Log Retention</strong></h3>
                         <p>Standard logs from the Survey Data Collection service are retained for a period of 30 days. Exceptional events may be retained for longer.</p>
                         <p>Our general retention period for data collected via annual surveys is 3 years.</p>
                         <p>Personal data used for account access will be retained as long as the account is active.</p>
@@ -400,7 +400,7 @@
                     <h2 class="neptune u-mt-l">
                         Your rights over your personal data
                     </h2>
-                    <div class="mars">
+                    <div class="u-fs-r">
                         <p>The General Data Protection Regulation (GDPR) details eight rights of individuals:</p>
                         <ol>
                             <li>The right to be informed</li>
@@ -418,7 +418,7 @@
                     <h2 class="neptune u-mt-l">
                         Contacting the Data Protection Office
                     </h2>
-                    <div class="mars">
+                    <div class="u-fs-r">
                         <p>The Data Protection Officer for the Office for National Statistics can be contacted as follows:</p>
                         <p>Office for National Statistics<br>Segensworth Road<br>Titchfield<br>Fareham<br>Hampshire<br>PO15 5RR</p>
                         <p>Telephone: 0845 601 3034<br>Email: <a href="mailto:dpo@statistics.gov.uk">dpo@statistics.gov.uk</a></p>
@@ -427,7 +427,7 @@
                     <h2 class="neptune u-mt-l">
                         Contacting the Information Commissioner's Office
                     </h2>
-                    <div class="mars">
+                    <div class="u-fs-r">
                         <p>We welcome the opportunity to be able to answer any questions or concerns you may have around the information provided here. If you are unhappy with our response to any of your requests or you have concerns around how your data has been handled, you have the right to lodge a complaint with the Information Commissioner's Office.</p>
                         <p>Information Commissioner’s Office<br>Wycliffe House<br>Water Lane<br>Wilmslow<br>Cheshire<br>SK9 5AF</p>
                         <p>Telephone: 0303 123 1113<br>Email: <a href="mailto:casework@ico.org.uk">casework@ico.org.uk</a></p>

--- a/frontstage/templates/errors/403-error.html
+++ b/frontstage/templates/errors/403-error.html
@@ -4,6 +4,6 @@
 {% block page_title %}Not signed in - ONS Business Surveys{% endblock %}
 
 {% block main %}
-    <h1 class="saturn">Not signed in</h1>
+    <h1 class="u-fs-l">Not signed in</h1>
     <p><a href="{{ url_for('sign_in_bp.login') }}">sign in </a> to see this page.</p>
 {% endblock main %}

--- a/frontstage/templates/errors/403-incorrect-account-error.html
+++ b/frontstage/templates/errors/403-incorrect-account-error.html
@@ -4,7 +4,7 @@
 {% block page_title %}ONS Business Surveys{% endblock %}
 
 {% block main %}
-    <h1 class="saturn">Access to this page is forbidden</h1>
+    <h1 class="u-fs-l">Access to this page is forbidden</h1>
     <p>The page you are trying to view is not for this account.</p>
 	<p>If you have another ONS Business Surveys account, check that you are signed in to the right one.</p>
 	<p>If the problem continues, <a href="/contact-us">contact the survey enquiries helpline</a> for further support</p>

--- a/frontstage/templates/errors/404-error.html
+++ b/frontstage/templates/errors/404-error.html
@@ -4,7 +4,7 @@
 {% block page_title %}Page not found - ONS Business Surveys{% endblock %}
 
 {% block main %}
-    <h1 class="saturn">Page not found</h1>
+    <h1 class="u-fs-l">Page not found</h1>
     <p>If you entered a web address, check it is correct.</p>
     <p>If you pasted the web address, check you copied the entire address.</p>
     <p>If the web address is correct or you selected a link or button, <a href="https://www.ons.gov.uk/aboutus/contactus/surveyenquiries">contact the survey enquiries helpline</a> for further support.</p>

--- a/frontstage/templates/errors/500-error.html
+++ b/frontstage/templates/errors/500-error.html
@@ -4,7 +4,7 @@
 {% block page_title %}An error has occurred - ONS Business Surveys - 500{% endblock %}
 
 {% block main %}
-    <h1 class="saturn">An error has occurred</h1>
+    <h1 class="u-fs-l">An error has occurred</h1>
     <p>Sorry, something has gone wrong.</p>
     <p>If the problem continues, <a href="https://www.ons.gov.uk/aboutus/contactus/surveyenquiries">contact the survey enquiries helpline</a>.</p>
 {% endblock main %}

--- a/frontstage/templates/errors/validation_error.html
+++ b/frontstage/templates/errors/validation_error.html
@@ -2,10 +2,10 @@
 
 <div class="panel panel--error">
     <div class="panel__header">
-        <h1 class="panel__title venus">{{ panel_title }}</h1>
+        <h1 class="panel__title u-fs-r--b">{{ panel_title }}</h1>
     </div>
     <div class="panel__body" data-qa="error-body">
-        <p class="mars"><a onclick="focusOn({{ focus_on }});" href="{{ context }}">{{ error_message }}</a></p>
+        <p class="u-fs-r"><a onclick="focusOn({{ focus_on }});" href="{{ context }}">{{ error_message }}</a></p>
     </div>
 </div>
 <br/>

--- a/frontstage/templates/layouts/_base.html
+++ b/frontstage/templates/layouts/_base.html
@@ -1,5 +1,5 @@
 <!doctype html>
-{% set cdn_hash = "v1.5.6" %}
+{%- set cdn_hash = "v2.0.0" -%}
 
 {% set cdn_url_prefix = "https://cdn.ons.gov.uk/sdc/"~cdn_hash %}
 

--- a/frontstage/templates/partials/footer.html
+++ b/frontstage/templates/partials/footer.html
@@ -2,7 +2,7 @@
     <div class="container">
         <div class="grid">
             <div class="grid__col col-4@m">
-                <p class="venus footer__heading"><strong>Legal information</strong></p>
+                <p class="u-fs-r--b footer__heading"><strong>Legal information</strong></p>
                 <ul class="list list--bare">
                     <li>
                         <a href="/cookies-privacy"
@@ -12,7 +12,7 @@
             </div>
 
             <div class="grid__col col-4@m">
-                <p class="venus footer__heading"><strong>About ONS</strong></p>
+                <p class="u-fs-r--b footer__heading"><strong>About ONS</strong></p>
                 <ul class="list list--bare">
                     <li>
                         <a href="https://www.ons.gov.uk/aboutus/whatwedo"
@@ -30,7 +30,7 @@
             </div>
 
             <div class="grid__col col-4@m">
-                <p class="venus footer__heading"><strong>Statistics</strong></p>
+                <p class="u-fs-r--b footer__heading"><strong>Statistics</strong></p>
                 <ul class="list list--bare">
                     <li>
                         <a href="https://www.statisticsauthority.gov.uk/about-the-authority/"

--- a/frontstage/templates/partials/section.html
+++ b/frontstage/templates/partials/section.html
@@ -1,7 +1,7 @@
 {% macro section_default(title, description) -%}
     <div class="section">
-        <h2 class="section__title saturn">{{ title }}</h2>
-        <p class="section__description mars">{{ description }}</p>
+        <h2 class="section__title u-fs-l">{{ title }}</h2>
+        <p class="section__description u-fs-r">{{ description }}</p>
         {{ caller() }}
     </div>
 {% endmacro %}

--- a/frontstage/templates/passwords/forgot-password.check-email.html
+++ b/frontstage/templates/passwords/forgot-password.check-email.html
@@ -5,7 +5,7 @@
 
 {% block main %}
 
-    <h1 class="saturn">Password reset request sent</h1>
+    <h1 class="u-fs-l">Password reset request sent</h1>
 
     <p>If {{ email }} is registered to an account, you'll receive an email with instructions to reset your password</p>
 
@@ -15,7 +15,7 @@
      data-hide-label="Hide help with email"
      data-show-label="Show help with email">
 
-        <a class="guidance__link js-details-trigger js-details-label icon--details mars"
+        <a class="guidance__link js-details-trigger js-details-label icon--details u-fs-r"
         id="guidance-help-with-email"
         data-guidance-trigger="true"
         aria-expanded="false"
@@ -23,7 +23,7 @@
         aria-controls="guidance-help-with-email">Help with email</a>
 
         <div class="guidance__main js-details-body" id="guidance-help-with-email" aria-hidden="true">
-            <div class="guidance__content mars">
+            <div class="guidance__content u-fs-r">
                 <div>
                 <p>Email not arrived? It might be in your spam folder.</p>
                 <p>If it doesn’t arrive in the next 15 minutes, please call <a href="tel:03001234931">0300 1234 931</a> or send an email to <a href="mailto:surveys@ons.gov.uk">surveys@ons.gov.uk</a>.</p>

--- a/frontstage/templates/passwords/forgot-password.html
+++ b/frontstage/templates/passwords/forgot-password.html
@@ -8,10 +8,10 @@
 {% if form.errors %}
 <div class="panel panel--error">
     <div class="panel__header">
-        <h1 class="panel__title venus">Invalid email address</h1>
+        <h1 class="panel__title u-fs-r--b">Invalid email address</h1>
     </div>
     <div class="panel__body" data-qa="error-body">
-        <p class="mars"><a href="#forgot-details" class="js-inpagelink">Please enter a valid email address</a></p>
+        <p class="u-fs-r"><a href="#forgot-details" class="js-inpagelink">Please enter a valid email address</a></p>
     </div>
 </div>
 <br />
@@ -23,7 +23,7 @@
     class="form"
     role="form">
 
-    <h1 class="saturn">Forgot password</h1>
+    <h1 class="u-fs-l">Forgot password</h1>
     <legend>No problem. We'll send you a link to reset your password.</legend>
     <br />
     {{ form.csrf_token }}
@@ -37,7 +37,7 @@
 
                 {{ form.email_address.label(class_='label') }}
 
-                <span class="label__description label__inner pluto">Please type the email address you were registered with</span>
+                <span class="label__description label__inner u-fs-s">Please type the email address you were registered with</span>
 
                 {{ form.email_address(class_='input input--text input-type__input') }}
 
@@ -46,7 +46,7 @@
     </fieldset>
     <br />
 
-    <button class="btn venus u-mb-s" id="reset-password-btn" type="submit">Send reset link</button>
+    <button class="btn u-fs-r--b u-mb-s" id="reset-password-btn" type="submit">Send reset link</button>
 
     <p><a href="/sign-in">Cancel</a></p>
 

--- a/frontstage/templates/passwords/password-expired.html
+++ b/frontstage/templates/passwords/password-expired.html
@@ -5,7 +5,7 @@
 
 {% block main %}
 
-<h1 class="saturn">Your link has expired</h1>
+<h1 class="u-fs-l">Your link has expired</h1>
 
 <div>
     <p>

--- a/frontstage/templates/passwords/reset-password.check-email.html
+++ b/frontstage/templates/passwords/reset-password.check-email.html
@@ -5,7 +5,7 @@
 
 {% block main %}
 
-    <h1 class="saturn">Check your email</h1>
+    <h1 class="u-fs-l">Check your email</h1>
 
     <p>Please follow the link in the email we've sent you to reset your password and sign in to your account.</p>
 
@@ -15,7 +15,7 @@
      data-hide-label="Hide help with email"
      data-show-label="Show help with email">
 
-    <a class="guidance__link js-details-trigger js-details-label icon--details mars"
+    <a class="guidance__link js-details-trigger js-details-label icon--details u-fs-r"
        id="guidance-help-with-email"
        data-guidance-trigger="true"
        aria-expanded="false"
@@ -23,7 +23,7 @@
        aria-controls="guidance-help-with-email">Help with email</a>
 
     <div class="guidance__main js-details-body" id="guidance-help-with-email" aria-hidden="true">
-        <div class="guidance__content mars">
+        <div class="guidance__content u-fs-r">
             <div>
               <p>If you don't receive this within 15 minutes, try checking your spam folder.</p>
               <p>If you're still having problems, call us on <a href="tel:03001234931">0300 1234 931</a>.</p>

--- a/frontstage/templates/passwords/reset-password.confirmation.html
+++ b/frontstage/templates/passwords/reset-password.confirmation.html
@@ -4,6 +4,6 @@
 {% block page_title %}You've changed your password - ONS Business Surveys{% endblock %}
 
 {% block main %}
-<h1 class="saturn">Your password has been changed</h1>
+<h1 class="u-fs-l">Your password has been changed</h1>
 <p>You can now <a href="/sign-in">sign in to your Business Surveys Account</a>.</p>
 {% endblock main %}

--- a/frontstage/templates/passwords/reset-password.html
+++ b/frontstage/templates/passwords/reset-password.html
@@ -20,14 +20,14 @@
 
 <div class="panel panel--error">
     <div class="panel__header">
-        <h1 class="panel__title venus">
+        <h1 class="panel__title u-fs-r--b">
             {{ errorNotEnteredTitle if errorType.password[0] == errorNotEnteredTitle }}
             {{ errorNoMatchTitle if errorType.password[0] == errorNoMatchTitle }}
             {{ errorStrongerPasswordTitle if errorType.password[0] == errorStrongerPasswordTitle }}
         </h1>
     </div>
     <div class="panel__body" data-qa="error-body">
-        <p class="mars">
+        <p class="u-fs-r">
             <a href="#reset-details" class="js-inpagelink">
             {{ errorNotEnteredDescription if errorType.password[0] == errorNotEnteredTitle }}
             {{ errorNoMatchDescription if errorType.password[0] == errorNoMatchTitle }}
@@ -46,7 +46,7 @@
     role="form">
     {{ form.csrf_token }}
 
-    <h1 class="saturn">Reset your password</h1>
+    <h1 class="u-fs-l">Reset your password</h1>
     <p>Your password must have:</p>
     <ul>
         <li>at least 8 characters</li>
@@ -64,7 +64,7 @@
             <p class="error-message">{{ errorType['password'][0] }}</p>
         {% endif %}
             <div class="hide-if-no-js field--toggle">
-              <label class="label label--inline venus field__label" for="showPasswordToggle">Show password</label>
+              <label class="label label--inline u-fs-r--b field__label" for="showPasswordToggle">Show password</label>
               <input id="showPasswordToggle" class="field__input input input--checkbox" type="checkbox">
             </div>
             <div class="field" id="password_field">
@@ -83,7 +83,7 @@
     </fieldset>
     <br/>
 
-    <button class="btn u-mb-s venus" id="confirm_password_button" type="submit">Confirm</button>
+    <button class="btn u-mb-s u-fs-r--b" id="confirm_password_button" type="submit">Confirm</button>
 
     <p><a href="{{ url_for('sign_in_bp.login') }}">Cancel</a></p>
 

--- a/frontstage/templates/passwords/reset-password.trouble.html
+++ b/frontstage/templates/passwords/reset-password.trouble.html
@@ -4,11 +4,11 @@
 {% block page_title %}Something went wrong - ONS Business Surveys{% endblock %}
 
 {% block main %}
-    <h1 class="saturn">Something went wrong</h1>
+    <h1 class="u-fs-l">Something went wrong</h1>
 
     <p class="u-mb-l">Please call us on <a href="tel:03001234931">0300 1234 931</a></p>
 
-    <div class="mars">
+    <div class="u-fs-r">
         <p class="u-mb-l">Opening hours:<br />
             Monday to Thursday 8:30am – 5pm<br/>
             Friday 8:30am - 4:30pm</p>

--- a/frontstage/templates/register/register.activate-account.html
+++ b/frontstage/templates/register/register.activate-account.html
@@ -9,19 +9,19 @@
             action="{{ url_for('register_bp.register_activate_account') }}"
             class="form"
             role="form">
-        <h1 class="saturn">Activate your account</h1>
+        <h1 class="u-fs-l">Activate your account</h1>
         {{ form.csrf_token }}
 
-        <div class="label__description label__inner pluto">Thanks for confirming your email address</div>
+        <div class="label__description label__inner u-fs-s">Thanks for confirming your email address</div>
 
         <br />
 
-        <div class="label__description label__inner pluto">Please now activate your account</div>
+        <div class="label__description label__inner u-fs-s">Please now activate your account</div>
 
         <br />
         <br />
 
-        <button class="btn btn--secondary venus" id="activate_account_button" type="submit">Activate account</button>
+        <button class="btn btn--secondary u-fs-r--b" id="activate_account_button" type="submit">Activate account</button>
 
     </form>
 {% endblock main %}

--- a/frontstage/templates/register/register.almost-done.html
+++ b/frontstage/templates/register/register.almost-done.html
@@ -4,7 +4,7 @@
 {% block page_title %}Check your email - ONS Business Surveys{% endblock %}
 
 {% block main %}
-    <h1 class="saturn">Almost done...</h1>
+    <h1 class="u-fs-l">Almost done...</h1>
     <p id="email_confirmation_sent">We've sent an email to {{ email }}</p>
     <p>Please follow the link in the email to confirm your email address and finish setting up your account.</p>
     <div class="guidance js-details u-mb-m"
@@ -13,7 +13,7 @@
         data-hide-label="Hide help with email"
         data-show-label="Show help with email">
 
-        <a class="guidance__link js-details-trigger js-details-label icon--details mars"
+        <a class="guidance__link js-details-trigger js-details-label icon--details u-fs-r"
         id="guidance-help-with-email"
         data-guidance-trigger="true"
         aria-expanded="false"
@@ -21,7 +21,7 @@
         aria-controls="guidance-help-with-email">Help with email</a>
 
         <div class="guidance__main js-details-body" id="guidance-help-with-email-body" aria-hidden="true">
-            <div class="guidance__content mars">
+            <div class="guidance__content u-fs-r">
                 <div>
                     <p>Email not arrived? It might be in your spam folder.</p>
                     <p>If it doesn’t arrive in the next 15 minutes, please call <a href="tel:03001234931">0300 1234 931</a></p>

--- a/frontstage/templates/register/register.confirm-organisation-survey.html
+++ b/frontstage/templates/register/register.confirm-organisation-survey.html
@@ -5,7 +5,7 @@
 
 {% block main %}
 
-<h1 class="saturn">Confirm organisation and survey details</h1>
+<h1 class="u-fs-l">Confirm organisation and survey details</h1>
 
  {% include('partials/business_survey_credentials.html') %}
 

--- a/frontstage/templates/register/register.email-resent.html
+++ b/frontstage/templates/register/register.email-resent.html
@@ -5,7 +5,7 @@
 
 {% block main %}
 
-<h1 class="saturn">We've sent you another email</h1>
+<h1 class="u-fs-l">We've sent you another email</h1>
 
 {% include "register/register.help-with-email.html" %}
 

--- a/frontstage/templates/register/register.enter-enrolment-code.html
+++ b/frontstage/templates/register/register.enter-enrolment-code.html
@@ -29,7 +29,7 @@
             role="form">
         {{ form.csrf_token }}
 
-        <h1 class="saturn">Create an account</h1>
+        <h1 class="u-fs-l">Create an account</h1>
 
         {% if errorType == "failed" or errors|length > 0 %}
         <div class="panel panel--simple panel--error panel--spacious">
@@ -40,7 +40,7 @@
 
                 {{ form.enrolment_code.label(class_='label') }}
 
-                <span class="label__description label__inner pluto">You'll find this in the letter we sent you</span>
+                <span class="label__description label__inner u-fs-s">You'll find this in the letter we sent you</span>
                 {{ form.enrolment_code(class_='input input--text input-type__input') }}
             </div>
 
@@ -50,7 +50,7 @@
 
         <br/>
 
-        <button class="btn venus" type="submit" id="continue_button">Continue</button>
+        <button class="btn u-fs-r--b" type="submit" id="continue_button">Continue</button>
 
     </form>
 

--- a/frontstage/templates/register/register.enter-your-details.html
+++ b/frontstage/templates/register/register.enter-your-details.html
@@ -10,16 +10,16 @@
             <div class="panel__header">
                 {% if errors|length == 1 %}
                 {% for error in errors %}
-                <h1 class="panel__title venus">{{ errors[error][0] }}</h1>
+                <h1 class="panel__title u-fs-r--b">{{ errors[error][0] }}</h1>
                 {% endfor %}
                 {% elif errors|length > 1 %}
-                <h1 class="panel__title venus">There are {{ errors|length }} errors on this page</h1>
+                <h1 class="panel__title u-fs-r--b">There are {{ errors|length }} errors on this page</h1>
                 {% endif %}
             </div>
             <div class="panel__body" data-qa="error-body">
                 {% for error in errors %}
                     {% set error_text = 'passwords' if error == 'password' else error %}
-                    <p class="mars"><a class="js-inpagelink" href="#{{error}}_field">Please check the {{error_text.replace('_', ' ')}} and try again</a></p>
+                    <p class="u-fs-r"><a class="js-inpagelink" href="#{{error}}_field">Please check the {{error_text.replace('_', ' ')}} and try again</a></p>
                 {% endfor %}
             </div>
         </div>
@@ -34,7 +34,7 @@
             onsubmit="formSubmitted(event);">
             {{ form.csrf_token }}
 
-        <h1 class="saturn">Enter your account details</h1>
+        <h1 class="u-fs-l">Enter your account details</h1>
         {{ form.enrolment_code }}
 
         <div class="section">
@@ -66,7 +66,7 @@
 
         <div class="section">
             <h2 class="section__title neptune u-mt-m">Email address</h2>
-            <p class="section__description mars">We'll send you an email so you can activate your account</p>
+            <p class="section__description u-fs-r">We'll send you an email so you can activate your account</p>
             {% if errors.email_address %}
             <div class="panel panel--simple panel--error">
                 <p class="error-message">{{ errors['email_address'][0] }}</p>
@@ -87,7 +87,7 @@
 
         <div class="section">
             <h2 class="section__title neptune u-mt-m">Create a password</h2>
-            <p class="section__description mars">Your password must have:</p>
+            <p class="section__description u-fs-r">Your password must have:</p>
             <ul>
                 <li>at least 8 characters </li>
                 <li>at least one symbol (eg ?!£%) </li>
@@ -117,7 +117,7 @@
 
         <div class="section">
             <h2 class="section__title neptune u-mt-m">Phone number</h2>
-            <p class="section__description mars">We may sometimes need to call you to discuss information you have provided</p>
+            <p class="section__description u-fs-r">We may sometimes need to call you to discuss information you have provided</p>
             {% if errors.phone_number %}
             <div class="panel panel--simple panel--error">
                 <p class="error-message">{{ errors['phone_number'][0] }}</p>
@@ -133,7 +133,7 @@
 
         <br />
 
-        <button class="btn venus" id="continue_button" type="submit">Continue</button>
+        <button class="btn u-fs-r--b" id="continue_button" type="submit">Continue</button>
 
     </form>
 

--- a/frontstage/templates/register/register.help-with-email.html
+++ b/frontstage/templates/register/register.help-with-email.html
@@ -6,7 +6,7 @@
     data-hide-label="Hide help with email"
     data-show-label="Show help with email">
 
-    <a class="guidance__link js-details-trigger js-details-label icon--details mars"
+    <a class="guidance__link js-details-trigger js-details-label icon--details u-fs-r"
     id="guidance-help-with-email"
     data-guidance-trigger="true"
     aria-expanded="false"
@@ -14,7 +14,7 @@
     aria-controls="guidance-help-with-email">Help with email</a>
 
     <div class="guidance__main js-details-body" id="guidance-help-with-email-body" aria-hidden="true">
-        <div class="guidance__content mars">
+        <div class="guidance__content u-fs-r">
             <div>
                 <p>Email not arrived? It might be in your spam folder.</p>
                 <p>If it doesn’t arrive in the next 15 minutes, please call us on <a href="tel:03001234931">0300 1234 931</a></p>

--- a/frontstage/templates/register/register.link-expired.html
+++ b/frontstage/templates/register/register.link-expired.html
@@ -5,7 +5,7 @@
 
 {% block main %}
 
-<h1 class="saturn">Your link has expired</h1>
+<h1 class="u-fs-l">Your link has expired</h1>
 
 <div>
     <p>

--- a/frontstage/templates/secure-messages/conversation-list.html
+++ b/frontstage/templates/secure-messages/conversation-list.html
@@ -12,7 +12,7 @@
       <div class="panel panel--simple panel--success col-6@m">
           <div class="panel__body" data-qa="success-body">
             {% for message in messages %}
-            <p class="mars" id="flashed-message-{{ loop.index }}">{{ message }}</p>
+            <p class="u-fs-r" id="flashed-message-{{ loop.index }}">{{ message }}</p>
             {% endfor %}
           </div>
       </div>
@@ -23,10 +23,10 @@
     <nav class="nav nav--horizontal nav--sub nav--dark u-mb-l u-pt-s" role="menu">
         <div class="container">
             <ul class="nav__list" aria-label="Section navigation menu">
-                <li class="nav__item pluto {% if not is_closed %}nav__item--current{% endif %}">
+                <li class="nav__item u-fs-s {% if not is_closed %}nav__item--current{% endif %}">
                     <a class="nav__link" href="{{ url_for('secure_message_bp.view_conversation_list') }}" aria-current="{% if not is_closed %}location{% endif %}" role="menuitem">Open</a>
                 </li>
-                <li class="nav__item pluto {% if is_closed %}nav__item--current{% endif %}">
+                <li class="nav__item u-fs-s {% if is_closed %}nav__item--current{% endif %}">
                     <a class="nav__link" href="{{ url_for('secure_message_bp.view_conversation_list', is_closed='true') }}" aria-current="{% if is_closed %}location{% endif %}" role="menuitem">Closed</a>
                 </li>
             </ul>
@@ -44,31 +44,31 @@
       <ul class="message-list">
         {% for message in messages %}
           {% if message['unread'] %}
-            <li id="message-list-unread" class="message-list__item venus">
+            <li id="message-list-unread" class="message-list__item u-fs-r--b">
               <a href="{{ url_for('secure_message_bp.view_conversation', thread_id=message.thread_id) }}#latest-message" id="message-link-{{ loop.index }}">{{ message.subject }}</a>
-              <span class="secure-message-conversation-meta__label mercury" style="color: #666;"> (New) </span>
+              <span class="secure-message-conversation-meta__label u-fs-s--b" style="color: #666;"> (New) </span>
           {% else %}
-            <li id="message-list" class="message-list__item mars">
+            <li id="message-list" class="message-list__item u-fs-r">
             <a href="{{ url_for('secure_message_bp.view_conversation', thread_id=message.thread_id) }}#latest-message" class="message-read" id="message-link-{{ loop.index }}">{{ message.subject }}</a>
           {% endif %}
 
           <div class="message-details">
-            <div class="secure-message-sent-message-meta-from mars">
+            <div class="secure-message-sent-message-meta-from u-fs-r">
               <span class="u-vh">From: </span>
               {{ message.from or 'Unavailable' }}
             </div>
 
-            <div class="secure-message-sent-message-meta-datetime mars u-mb-s" style="display: block; color: #666;">
+            <div class="secure-message-sent-message-meta-datetime u-fs-r u-mb-s" style="display: block; color: #666;">
               <span class="u-vh">Sent: </span>
               {{ message.sent_date or 'Unavailable' }}
             </div>
           </div>
 
-          <p class="message-list__item-preview mars" id="message-summary-{{ loop.index }}">{{ message['body']|truncate(80, False, '...', 0) }}</p>
+          <p class="message-list__item-preview u-fs-r" id="message-summary-{{ loop.index }}">{{ message['body']|truncate(80, False, '...', 0) }}</p>
 
           {% if message['unread'] %}
             <p class="message-list__item-preview--link">
-              <a href="{{ url_for('secure_message_bp.view_conversation', thread_id=message.thread_id) }}#latest-message" class="venus" id="open-conversation-link-{{ loop.index }}">Read full message</a>
+              <a href="{{ url_for('secure_message_bp.view_conversation', thread_id=message.thread_id) }}#latest-message" class="u-fs-r--b" id="open-conversation-link-{{ loop.index }}">Read full message</a>
             </p>
           {% else %}
             <p class="message-list__item-preview--link">

--- a/frontstage/templates/secure-messages/conversation-view.html
+++ b/frontstage/templates/secure-messages/conversation-view.html
@@ -7,7 +7,7 @@
 {% if conversation_data.is_closed %}
 <div class="panel panel--simple panel--info u-mb-s">
     <div class="panel__body">
-        <p class="mars u-mb-xs">This conversation has now been closed. <br>
+        <p class="u-fs-r u-mb-xs">This conversation has now been closed. <br>
           You can still send a message from your
           <a href="/surveys/todo">to do list</a> or
           <a href="/surveys/history">history</a>
@@ -20,16 +20,16 @@
     <div class="panel panel--error col-7@m">
         <div class="panel__header">
             {% if form.errors|length > 1 %}
-                <h1 class="panel__title venus">This page has {{ form.errors|length }} errors</h1>
+                <h1 class="panel__title u-fs-r--b">This page has {{ form.errors|length }} errors</h1>
             {% elif form.errors %}
-                <h1 class="panel__title venus">This page has {{ form.errors|length }} error</h1>
+                <h1 class="panel__title u-fs-r--b">This page has {{ form.errors|length }} error</h1>
             {% endif %}
         </div>
         <div class="panel__body">
             <ol>
               {% if form.body.errors %}
                 {% for error in form.body.errors %}
-                  <li class="panel__title venus"><a href='#secure-message-body'>{{ error }}</a></li>
+                  <li class="panel__title u-fs-r--b"><a href='#secure-message-body'>{{ error }}</a></li>
                 {% endfor %}
               {% endif %}
             </ol>
@@ -38,15 +38,15 @@
 <br />
 {% endif %}
 
-<h1 class="saturn" name="page-messages-title">{{ subject }}</h1>
+<h1 class="u-fs-l" name="page-messages-title">{{ subject }}</h1>
 <div class="secure-message-view-component">
     {% for message in conversation %}
       <div class="secure-message-sent-message" id="conversation-message-{{ loop.index }}" name="conversation-message">
         {% if loop.last %}<div name="latest-message" id="latest-message"></div>{% endif %}
-        <span class="secure-message-sent-message-meta-from venus">
+        <span class="secure-message-sent-message-meta-from u-fs-r--b">
             <span name="sm-sender" id="sm-sender-{{ loop.index }}">{{ message.get('from') }}</span>
         </span>
-        <span class="secure-message-sent-message-meta-datetime u-mb-s mars">
+        <span class="secure-message-sent-message-meta-datetime u-mb-s u-fs-r">
             <span name="sm-sent-date" id="sm-sent-date-{{ loop.index }}">{{ message.get('sent_date') }}</span>
         </span>
         <span class="secure-message-sent-message-body" id="conversation-message-body-{{ loop.index }}" name="conversation-message-body">{{ message.get('body') }}</span>
@@ -59,7 +59,7 @@
 {% if not conversation_data.is_closed %}
 <div class="secure-message-reply">
     <form action="{{ url_for('secure_message_bp.view_conversation', thread_id=conversation[0].thread_id) }}" method="post" id="create-message-form">
-        <label class="venus" for="message-text">Reply</label>
+        <label class="u-fs-r--b" for="message-text">Reply</label>
         {{ form.csrf_token }}
         {{ form.body(id='secure-message-body', class_='input input--textarea input--textarea-message', rows='10', maxlength='10000') }}
         <br>

--- a/frontstage/templates/secure-messages/message-error-summary.html
+++ b/frontstage/templates/secure-messages/message-error-summary.html
@@ -2,9 +2,9 @@
     <div class="panel panel--error">
         <div class="panel__header">
         {% if errors|length == 1 %}
-            <h1 class="panel__title venus">This page has 1 error</h1>
+            <h1 class="panel__title u-fs-r--b">This page has 1 error</h1>
         {% elif errors|length > 1 %}
-            <h1 class="panel__title venus">This page has {{ errors|length }} errors</h1>
+            <h1 class="panel__title u-fs-r--b">This page has {{ errors|length }} errors</h1>
         {% endif %}
         </div>
         <div class="panel__body" data-qa="error-body">
@@ -15,7 +15,7 @@
         {% endif %}
 
         {% for error in errors %}
-            <p class=“mars”>{{ loop.index0 + 1 }}) <a class="js-inpagelink" href="#{{error}}-error">{{ errors[error][0] }}</a></p>
+            <p class=“u-fs-r”>{{ loop.index0 + 1 }}) <a class="js-inpagelink" href="#{{error}}-error">{{ errors[error][0] }}</a></p>
         {% endfor %}
         </div>
     </div>

--- a/frontstage/templates/secure-messages/secure-messages-view.html
+++ b/frontstage/templates/secure-messages/secure-messages-view.html
@@ -18,7 +18,7 @@
         {% if label != 'SENT' %}
             {% set message = {} if not message else message %}
 
-            {% if not message %}<h1 class="saturn">Create message</h1>{% endif %}
+            {% if not message %}<h1 class="u-fs-l">Create message</h1>{% endif %}
 
             <div class="secure-message-form" id="secure-message-form">
                 <form action="{{ url_for('secure_message_bp.create_message', ru_ref=ru_ref, survey=survey) }}" method="post">
@@ -34,7 +34,7 @@
                             <div class="panel panel--simple panel--error panel--spacious" id="subject-error">
                                 <p class="error-message">{{ errors['subject'][0] }}</p>
                         {% endif %}
-                            <label class="venus" for="subject">Subject</label>
+                            <label class="u-fs-r--b" for="subject">Subject</label>
                             {{ form.subject(id='secure-message-subject', class_='secure-message-form__subject input input--text') }}
                         {% if "subject" in errors %}
                             </div>
@@ -47,9 +47,9 @@
                             <p class="error-message">{{ errors['body'][0] }}</p>
                     {% endif %}
                     {% if message %}
-                        <label class="venus" for="body">Reply</label>
+                        <label class="u-fs-r--b" for="body">Reply</label>
                     {% else %}
-                        <label class="venus" for="body">Message</label>
+                        <label class="u-fs-r--b" for="body">Message</label>
                     {% endif %}
                     {{ form.body(id='secure-message-body', class_='input input--textarea input--textarea-message', rows='10', maxlength='10000') }}
                     {% if "body" in errors %}

--- a/frontstage/templates/secure-messages/thread-message.html
+++ b/frontstage/templates/secure-messages/thread-message.html
@@ -1,9 +1,9 @@
 {% if message %}
     <div>
     {% if message['subject'].startswith('Re: ') %}
-        <h1 class="saturn">Subject: {{ message['subject'][4:] }}</h1>
+        <h1 class="u-fs-l">Subject: {{ message['subject'][4:] }}</h1>
     {% else %}
-        <h1 class="saturn">Subject: {{ message['subject'] }}</h1>
+        <h1 class="u-fs-l">Subject: {{ message['subject'] }}</h1>
     {% endif %}
 
         <div class="grid">

--- a/frontstage/templates/sign-in/sign-in.account-locked.html
+++ b/frontstage/templates/sign-in/sign-in.account-locked.html
@@ -4,7 +4,7 @@
 {% block page_title %}Trouble signing in? - ONS Business Surveys{% endblock %}
 
 {% block main %}
-    <h1 class="saturn">Check your email</h1>
+    <h1 class="u-fs-l">Check your email</h1>
 
     <p>You've tried to sign in a few times with the wrong details.</p>
     <p>If {{ form.data['username'] }} is registered to an account, we'll send an email explaining how to sign in.</p>
@@ -15,7 +15,7 @@
      data-hide-label="Help with email"
      data-show-label="Help with email">
 
-    <a class="guidance__link js-details-trigger js-details-label icon--details mars"
+    <a class="guidance__link js-details-trigger js-details-label icon--details u-fs-r"
        id="guidance-help-with-email"
        data-guidance-trigger="true"
        aria-expanded="false"
@@ -23,7 +23,7 @@
        aria-controls="guidance-help-with-email">Help with email</a>
 
       <div class="details__main js-details-body" id="guidance-help-with-email-body">
-        <div class="details__content mars">
+        <div class="details__content u-fs-r">
           <div>
             <p>If you do not receive this email in 15 minutes, you can try the following: </p>
               <li>Check your spam folder</li>

--- a/frontstage/templates/sign-in/sign-in.account-not-verified.html
+++ b/frontstage/templates/sign-in/sign-in.account-not-verified.html
@@ -4,7 +4,7 @@
 {% block page_title %}Verify your email - ONS Business Surveys{% endblock %}
 
 {% block main %}
-    <h1 class="saturn">Verify your email</h1>
+    <h1 class="u-fs-l">Verify your email</h1>
 
     <p>When you created your account we sent you an email to verify your email address.</p>
     <p>Please follow the link the email to confirm your email address and sign in.</p>

--- a/frontstage/templates/sign-in/sign-in.html
+++ b/frontstage/templates/sign-in/sign-in.html
@@ -17,17 +17,17 @@
     <div class="panel panel--error">
         <div class="panel__header">
             {% if errorType == "failed" %}
-            <h1 class="panel__title venus">Incorrect email or password</h1>
+            <h1 class="panel__title u-fs-r--b">Incorrect email or password</h1>
             {% elif errorType|length > 1 %}
-            <h1 class="panel__title venus">There are {{ errorType|length }} errors on this page</h1>
+            <h1 class="panel__title u-fs-r--b">There are {{ errorType|length }} errors on this page</h1>
             {% else %}
             {% for error in errorType %}
-            <h1 class="panel__title venus">{{ errorType[error][0] }}</h1>
+            <h1 class="panel__title u-fs-r--b">{{ errorType[error][0] }}</h1>
             {% endfor %}
             {% endif %}
         </div>
         <div class="panel__body" data-qa="error-body">
-            <p class="mars"><a href="#sign-in-details" id="try-again-link" class="js-inpagelink">Please try again</a></p>
+            <p class="u-fs-r"><a href="#sign-in-details" id="try-again-link" class="js-inpagelink">Please try again</a></p>
         </div>
     </div>
     <br />
@@ -52,7 +52,7 @@
         {{ form.csrf_token }}
 
         {% if data['account_activated'] %}
-        <h1 class="saturn">You've activated your account</h1>
+        <h1 class="u-fs-l">You've activated your account</h1>
         <p>You may now sign in.</p>
         {% else %}
 
@@ -61,7 +61,7 @@
             <div class="panel__body">
                 <strong class="u-d-b">Service Availability</strong>
             </div>
-            <p class="mars u-mt-xs">Thank you for visiting the Office for National Statistics Secure Data Collection website.</p>
+            <p class="u-fs-r u-mt-xs">Thank you for visiting the Office for National Statistics Secure Data Collection website.</p>
 	    <p>We are carrying out essential maintenance on our internal systems.</p>
 	    <p>You are able to use the system and submit data during this period however your response status may not display as completed until after the maintenance has been completed.</p>
         </div>
@@ -71,7 +71,7 @@
         <p>New to this service?
            <a id="create-account" href="/register/create-account/">Create an account</a>
         </p>
-        <h1 class="saturn">Sign in</h1>
+        <h1 class="u-fs-l">Sign in</h1>
         {% endif %}
 
         <fieldset id="sign-in-details">
@@ -98,7 +98,7 @@
                     {% endif %}
                         {{ form.password.label(class_='label') }}
                         <div class="hide-if-no-js field--toggle">
-                            <label class="label label--inline venus field__label" for="showPasswordToggle">Show password</label>
+                            <label class="label label--inline u-fs-r--b field__label" for="showPasswordToggle">Show password</label>
                             <input id="showPasswordToggle" class="field__input input input--checkbox" type="checkbox">
                           </div>
                         {{ form.password(id='inputPassword', class_='input input--text input-type__input', autocomplete="off", **{'aria-describedby':'inputPasswordLabel'}) }}
@@ -110,7 +110,7 @@
                 </div>
                 <br />
 
-                <button class="btn venus" type="submit" id="sign_in_button">Sign in</button>
+                <button class="btn u-fs-r--b" type="submit" id="sign_in_button">Sign in</button>
             {% if errorType == "failed" %}
             </div>
             {% endif %}

--- a/frontstage/templates/sign-in/sign-in.verification-email-sent.html
+++ b/frontstage/templates/sign-in/sign-in.verification-email-sent.html
@@ -4,12 +4,12 @@
 {% block page_title %}Check your email - ONS Business Surveys{% endblock %}
 
 {% block main %}
-    <h1 class="saturn">Check your email</h1>
+    <h1 class="u-fs-l">Check your email</h1>
     <p id="email_confirmation_sent">Please follow the link in the email we've sent you to verify your email address and sign in to your account.</p>
 
     <div class="details js-details" data-guidance-label="Help with email" data-guidance="Help with email" data-hide-label="Help with email" data-show-label="Help with email">
 
-        <a class="details__link js-details-trigger js-details-label mars"
+        <a class="details__link js-details-trigger js-details-label u-fs-r"
         data-guidance-trigger="true"
         aria-expanded="false"
         href="#guidance-help-with-email"
@@ -17,7 +17,7 @@
         aria-controls="guidance-help-with-email-body">Help with email</a>
 
         <div class="details__main js-details-body" id="guidance-help-with-email-body" aria-hidden="true">
-            <div class="details__content mars">
+            <div class="details__content u-fs-r">
                 <div>
                     <p>If you don't receive this within 15 minutes, try checking your spam folder.</p>
                     <br>

--- a/frontstage/templates/surveys/surveys-access.html
+++ b/frontstage/templates/surveys/surveys-access.html
@@ -20,7 +20,6 @@
 
 <h2 class="neptune">Download</h2>
 
-
 <p>
     {{ survey_info.shortName }} spreadsheet for <strong>{{ business_info.name }}</strong>
     for the period {{ collection_exercise_info.userDescription }}
@@ -48,37 +47,24 @@
 <p>Please upload by <strong>{{ collection_exercise_info.scheduledReturnDateTimeFormatted }}</strong></p>
 {% endif %}
 
-<div class="guidance js-details upload-guidance"
-     data-guidance-label="Guidance for uploading"
-     data-guidance="Guidance for uploading"
-     data-hide-label="Hide guidance for uploading"
-     data-show-label="Show guidance for uploading">
-
-    <a class="guidance__link js-details-trigger js-details-label icon--details u-fs-r"
-       id="guidance-for-uploading"
-       data-guidance-trigger="true"
-       aria-expanded="false"
-       href="#guidance-for-uploading"
-       aria-controls="guidance-for-uploading-body">Show guidance for uploading</a>
-
-    <div class="guidance__main js-details-body" id="guidance-for-uploading-body" aria-hidden="true">
-        <div class="guidance__content u-fs-r">
-            <div>
-                <p>Your file needs to be:</p>
-                <ul>
-                    <li>.xls or .xlsx format</li>
-                    <li>smaller than 20MB</li>
-                </ul>
-            </div>
+<div class="collapsible collapsible--simple js-collapsible js-collapsible-simple">
+    <div class="js-collapsible-content">
+        <h3 class="collapsible__title js-collapsible-title icon--collapsible-simple u-fs-r--b" data-ga="click" data-ga-category="definition" data-ga-action="Open panel" data-ga-label="Guidance for uploading">Guidance for uploading</h3>
+        <div class="collapsible__body js-collapsible-body">
+            <h4 class="u-mb-s">Your file needs to be:</h4>
+            <ul>
+                <li>.xls or .xlsx format</li>
+                <li>smaller than 20MB</li>
+            </ul>
+            <button class="btn--secondary btn--small js-collapsible-close u-no-js-hide" data-ga="click" data-ga-category="definition" data-ga-action="Close panel" data-ga-label="Guidance for uploading">Hide this</button>
         </div>
     </div>
-
 </div>
+
 <br/>
 
 <p class="u-fs-r--b icon--lock">We will treat your data securely and confidentially</p>
 
 {% include "surveys/surveys-upload-file-picker.html" %}
-
 
 {% endblock main %}

--- a/frontstage/templates/surveys/surveys-access.html
+++ b/frontstage/templates/surveys/surveys-access.html
@@ -16,7 +16,7 @@
 
 <br/>
 
-<h1 class="saturn">{{ survey_info.longName }}</h1>
+<h1 class="u-fs-l">{{ survey_info.longName }}</h1>
 
 <h2 class="neptune">Download</h2>
 
@@ -37,7 +37,7 @@
         <span class="download__text">Download spreadsheet&nbsp;&nbsp;&nbsp;</span>
         <span class="download__text"><i class="fa fa-download fa-lg" aria-hidden="true"></i></span>
     </div>
-    <div class="download__text pluto">({{ collection_instrument_size | file_size_filter }} kb XLS)</div>
+    <div class="download__text u-fs-s">({{ collection_instrument_size | file_size_filter }} kb XLS)</div>
 </a>
 
 <br/>
@@ -54,7 +54,7 @@
      data-hide-label="Hide guidance for uploading"
      data-show-label="Show guidance for uploading">
 
-    <a class="guidance__link js-details-trigger js-details-label icon--details mars"
+    <a class="guidance__link js-details-trigger js-details-label icon--details u-fs-r"
        id="guidance-for-uploading"
        data-guidance-trigger="true"
        aria-expanded="false"
@@ -62,7 +62,7 @@
        aria-controls="guidance-for-uploading-body">Show guidance for uploading</a>
 
     <div class="guidance__main js-details-body" id="guidance-for-uploading-body" aria-hidden="true">
-        <div class="guidance__content mars">
+        <div class="guidance__content u-fs-r">
             <div>
                 <p>Your file needs to be:</p>
                 <ul>
@@ -76,7 +76,7 @@
 </div>
 <br/>
 
-<p class="venus icon--lock">We will treat your data securely and confidentially</p>
+<p class="u-fs-r--b icon--lock">We will treat your data securely and confidentially</p>
 
 {% include "surveys/surveys-upload-file-picker.html" %}
 

--- a/frontstage/templates/surveys/surveys-add.html
+++ b/frontstage/templates/surveys/surveys-add.html
@@ -10,10 +10,10 @@
 {% if errorType == "failed" %}
 <div class="panel panel--error">
     <div class="panel__header">
-        <h1 id="error_notification" class="panel__title venus">Enrolment code not valid</h1>
+        <h1 id="error_notification" class="panel__title u-fs-r--b">Enrolment code not valid</h1>
     </div>
     <div class="panel__body" data-qa="error-body">
-        <p class="mars"><a onclick="focusOn('enrolment_code');" href="#enrolment_code">Please re-enter the code and try again</a></p>
+        <p class="u-fs-r"><a onclick="focusOn('enrolment_code');" href="#enrolment_code">Please re-enter the code and try again</a></p>
     </div>
 </div>
 <br/>
@@ -26,7 +26,7 @@
           class="form">
         {{ form.csrf_token }}
 
-        <h1 class="saturn">Add a survey</h1>
+        <h1 class="u-fs-l">Add a survey</h1>
 
         {% if errorType == "failed" %}
         <div class="panel panel--simple panel--error panel--spacious">
@@ -37,7 +37,7 @@
 
                 {{ form.enrolment_code.label(class_='label') }}
 
-                <span class="label__description label__inner pluto">You'll find this in the letter we sent you</span>
+                <span class="label__description label__inner u-fs-s">You'll find this in the letter we sent you</span>
                 {{ form.enrolment_code(id="ENROLEMENT_CODE_FIELD", class='input input--text input-type__input') }}
             </div>
 
@@ -45,7 +45,7 @@
         </div>
         {% endif %}
 
-        <button id="continue_button" class="btn venus u-mt-s u-mb-s" type="submit">Continue</button>
+        <button id="continue_button" class="btn u-fs-r--b u-mt-s u-mb-s" type="submit">Continue</button>
 
         <p>
             <a id="cancel_button" href="{{ url_for('surveys_bp.get_survey_list', tag='todo') }}">Cancel</a>

--- a/frontstage/templates/surveys/surveys-confirm-organisation.html
+++ b/frontstage/templates/surveys/surveys-confirm-organisation.html
@@ -5,7 +5,7 @@
 
 {% block main %}
 
-<h1 id="confirm-org-title" class="saturn">Confirm organisation and survey details</h1>
+<h1 id="confirm-org-title" class="u-fs-l">Confirm organisation and survey details</h1>
 
  {% include('partials/business_survey_credentials.html') %}
 

--- a/frontstage/templates/surveys/surveys-download-failure.html
+++ b/frontstage/templates/surveys/surveys-download-failure.html
@@ -10,7 +10,7 @@
     <div class="grid__col col-6@m">
         <div class="panel panel--simple panel--warn">
             <div class="panel__body">
-                <h1 class="venus">Something went wrong</h1>
+                <h1 class="u-fs-r--b">Something went wrong</h1>
                 <p>Please call us on <a href="tel:03001234931">0300 1234 931</a></p>
             </div>
         </div>

--- a/frontstage/templates/surveys/surveys-upload-failure.html
+++ b/frontstage/templates/surveys/surveys-upload-failure.html
@@ -11,7 +11,7 @@
 
         <div class="panel panel--error u-mb-s" data-qa="error">
             <div class="panel__header">
-                <h1 class="panel__title venus">{{ error_info.header }}</h1>
+                <h1 class="panel__title u-fs-r--b">{{ error_info.header }}</h1>
             </div>
             <div class="panel__body" data-qa="error-body">
 
@@ -28,7 +28,7 @@
         <br/>
 
         <div class="lock u-mb-s u-mb-m@s">
-            <p class="venus"><i class="fa fa-lock" aria-hidden="true"></i>&nbsp;&nbsp;&nbsp;We will treat your data securely and confidentially</p>
+            <p class="u-fs-r--b"><i class="fa fa-lock" aria-hidden="true"></i>&nbsp;&nbsp;&nbsp;We will treat your data securely and confidentially</p>
         </div>
 
     </div>

--- a/frontstage/templates/surveys/surveys-upload-success.html
+++ b/frontstage/templates/surveys/surveys-upload-success.html
@@ -10,7 +10,7 @@
     <div class="grid__col col-12@m">
         <div class="panel panel--simple panel--success upload--success">
             <div class="panel__body">
-                <h1 class="venus">File uploaded successfully</h1>
+                <h1 class="u-fs-r--b">File uploaded successfully</h1>
                 <p>{{ upload_filename }} has been uploaded.</p>
                 <p>This survey has now moved into your <a href="{{ url_for('surveys_bp.get_survey_list', tag='history') }}">history</a>.</p>
                 <p><a id='return-survey-list' href="{{ url_for('surveys_bp.get_survey_list', tag='todo') }}">Return to my 'To do' list</a></p>

--- a/frontstage/templates/surveys/surveys.html
+++ b/frontstage/templates/surveys/surveys.html
@@ -21,9 +21,9 @@
     <li class="grid card" name="survey-card">
     {% endif %}
         <div class="grid__col col-4@m u-pl-xs">
-            <span class="survey-list-item__label mercury">SURVEY: </span>
+            <span class="survey-list-item__label u-fs-s--b">SURVEY: </span>
             <span id="SURVEY_NAME" >{{ survey.survey_long_name }}</span><br/>
-            <span id="REPORTING_UNIT_DETAILS_{{ survey.business_ref }}" name="reporting-unit-details" class="survey-list-item pluto">
+            <span id="REPORTING_UNIT_DETAILS_{{ survey.business_ref }}" name="reporting-unit-details" class="survey-list-item u-fs-s">
                 Business: {{ survey.business_name }}<br/>
                 {% if survey.trading_as %}
                 Trading as: {{ survey.trading_as }}<br/>
@@ -33,19 +33,19 @@
         </div>
 
         <div class="grid__col col-2@m">
-            <span class="survey-list-item__label mercury">PERIOD COVERED: </span>
+            <span class="survey-list-item__label u-fs-s--b">PERIOD COVERED: </span>
             <span id="period-{{ loop.index }}" name="period">{{ survey.period}}</span>
         </div>
 
         <div class="grid__col col-2@m">
             {% if not history %}
-            <span class="survey-list-item__label mercury">SUBMIT BY: </span>
+            <span class="survey-list-item__label u-fs-s--b">SUBMIT BY: </span>
             <span id="SUBMIT_BY_{{ loop.index }}" name="submit-by">{{ survey.submit_by}}</span>
             {% endif %}
         </div>
 
         <div class="grid__col col-2@m">
-            <span class="survey-list-item__label mercury">STATUS: </span>
+            <span class="survey-list-item__label u-fs-s--b">STATUS: </span>
             <span id="status-{{ loop.index }}" name="status">{{ survey.status }}</span>
         </div>
         <div class="grid__col col-2@m">
@@ -59,7 +59,7 @@
                 </button>
             </a>
             {% endif %}
-            <a id="create-message-link-{{loop.index}}" href="/secure-message/create-message/?survey={{survey.survey_id}}&ru_ref={{survey.business_party_id}}" class="pluto survey-message history__message">Send a message </span></a>
+            <a id="create-message-link-{{loop.index}}" href="/secure-message/create-message/?survey={{survey.survey_id}}&ru_ref={{survey.business_party_id}}" class="u-fs-s survey-message history__message">Send a message </span></a>
         </div>
     </li>
     {% endfor %}


### PR DESCRIPTION
# Motivation and Context
The pattern library use of planets to determine text size is deprecated in favour of utility font size classes.  Updates the version of the pattern library to the most recent, updates the font classes and fixes some javascript that broke as a result.

# What has changed
- Updated the version of the pattern library used to 2.0.0.
- Updated the planet classes to utility font sizes.  
- Fixed the guidance section that broke as part of the update.

# How to test?
Look at as many pages as possible and ensure it looks the same as the current ras-frontstage.  Also ensure no functionality is broken as a result.

# Links
https://trello.com/c/C74y7xaL/1074-change-frontstage-to-use-the-utility-classes-in-the-html-instead-of-the-planets-8