### PR TITLE
All done

### DIFF
--- a/frontstage/__init__.py
+++ b/frontstage/__init__.py
@@ -1,6 +1,5 @@
 import redis
 from flask_wtf.csrf import CSRFProtect
-
 from frontstage.create_app import create_app_object
 
 
@@ -9,6 +8,12 @@ redis = redis.StrictRedis(host=app.config['REDIS_HOST'],
                           port=app.config['REDIS_PORT'],
                           db=app.config['REDIS_DB'])
 csrf = CSRFProtect(app)
+
+
+@app.context_processor
+def inject_availability_message():
+    msg = str(redis.get('AVAILABILITY_MESSAGE').decode('utf-8'))
+    return dict(availability_message=msg)
 
 # Bind routes to app
 import frontstage.views  # NOQA  # pylint: disable=wrong-import-position

--- a/frontstage/__init__.py
+++ b/frontstage/__init__.py
@@ -12,8 +12,10 @@ csrf = CSRFProtect(app)
 
 @app.context_processor
 def inject_availability_message():
-    msg = str(redis.get('AVAILABILITY_MESSAGE').decode('utf-8'))
-    return dict(availability_message=msg)
+    msg = redis.get('AVAILABILITY_MESSAGE')
+    if msg:
+        return dict(availability_message=msg)
+    return dict()
 
 # Bind routes to app
 import frontstage.views  # NOQA  # pylint: disable=wrong-import-position

--- a/frontstage/__init__.py
+++ b/frontstage/__init__.py
@@ -13,8 +13,10 @@ csrf = CSRFProtect(app)
 @app.context_processor
 def inject_availability_message():
     if len(redis.keys('AVAILABILITY_MESSAGE')) == 1:
-        return dict(availability_message=redis.get('AVAILABILITY_MESSAGE').decode('utf-8'))
-    return dict()
+        return {
+            "availability_message": redis.get('AVAILABILITY_MESSAGE').decode('utf-8')
+            }
+    return {}
 
 # Bind routes to app
 import frontstage.views  # NOQA  # pylint: disable=wrong-import-position

--- a/frontstage/__init__.py
+++ b/frontstage/__init__.py
@@ -12,9 +12,8 @@ csrf = CSRFProtect(app)
 
 @app.context_processor
 def inject_availability_message():
-    msg = redis.get('AVAILABILITY_MESSAGE')
-    if msg:
-        return dict(availability_message=msg)
+    if len(redis.keys('AVAILABILITY_MESSAGE')) == 1:
+        return dict(availability_message=redis.get('AVAILABILITY_MESSAGE').decode('utf-8'))
     return dict()
 
 # Bind routes to app

--- a/frontstage/templates/partials/header.html
+++ b/frontstage/templates/partials/header.html
@@ -54,3 +54,6 @@
         </div>
     </div>
 </header>
+{% if availability_message %}
+<div class="panel panel--simple panel--warn u-mb-l container">{{ availability_message }}</div>
+{% endif %}

--- a/tests/app/test_availability_message.py
+++ b/tests/app/test_availability_message.py
@@ -1,0 +1,29 @@
+from unittest import TestCase
+from unittest.mock import patch
+from frontstage import app
+
+TESTMSG = b'THIS IS A TEST MESSAGE'
+
+
+class TestAvailabilityMessage(TestCase):
+
+    def setUp(self):
+        app.testing = True
+        self.app = app.test_client()
+
+    @patch('redis.StrictRedis.get')
+    def test_message_does_not_show_if_redis_flag_not_set(self, mock_redis_get):
+        mock_redis_get.return_value = b''
+        response = self.app.get('/', follow_redirects=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(TESTMSG in response.data)
+
+    @patch('redis.StrictRedis.get')
+    def test_message_shows_correct_message_if_redis_flag_set(self, mock_redis_get):
+        mock_redis_get.return_value = TESTMSG
+
+        response = self.app.get('/', follow_redirects=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(TESTMSG in response.data)

--- a/tests/app/test_availability_message.py
+++ b/tests/app/test_availability_message.py
@@ -11,17 +11,21 @@ class TestAvailabilityMessage(TestCase):
         app.testing = True
         self.app = app.test_client()
 
+    @patch('redis.StrictRedis.keys')
     @patch('redis.StrictRedis.get')
-    def test_message_does_not_show_if_redis_flag_not_set(self, mock_redis_get):
+    def test_message_does_not_show_if_redis_flag_not_set(self, mock_redis_get, mock_redis_keys):
         mock_redis_get.return_value = b''
+        mock_redis_keys.return_value = []
         response = self.app.get('/', follow_redirects=True)
 
         self.assertEqual(response.status_code, 200)
         self.assertFalse(TESTMSG in response.data)
 
+    @patch('redis.StrictRedis.keys')
     @patch('redis.StrictRedis.get')
-    def test_message_shows_correct_message_if_redis_flag_set(self, mock_redis_get):
+    def test_message_shows_correct_message_if_redis_flag_set(self, mock_redis_get, mock_redis_keys):
         mock_redis_get.return_value = TESTMSG
+        mock_redis_keys.return_value = ['AVAILABILITY_MESSAGE']
 
         response = self.app.get('/', follow_redirects=True)
 


### PR DESCRIPTION
# Motivation and Context
Make it possible to display a customise message on all pages to advise users of system issues that may effect them

# What has changed
- System now checks for a Redis value to set a message
- If value present, passed as global variable to all layouts
- If passed to layout, shown as a warning panel at the top of page

# How to test?
- Confirm tests run
- Review code content
- Run frontstage and confirm that you can set a key `AVAILABILITY_MESSAGE` that will show a message on pages on the site (ensure you set on the database in use)

# Links
- https://trello.com/c/LrZe68zI
