### PR TITLE
Move redis to port 6379

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ start:
 
 TEST_TARGET=tests
 
-docker-test: REDIS_PORT=7379
+docker-test: REDIS_PORT=6379
 docker-test: test
 
 check:

--- a/config.py
+++ b/config.py
@@ -36,7 +36,7 @@ class Config(object):
     JSON_SECRET_KEYS = os.getenv('JSON_SECRET_KEYS')
 
     REDIS_HOST = os.getenv('REDIS_HOST', 'localhost')
-    REDIS_PORT = os.getenv('REDIS_PORT', 6379)
+    REDIS_PORT = os.getenv('REDIS_PORT', 7379)
     REDIS_DB = os.getenv('REDIS_DB', 1)
 
     PASSWORD_MATCH_ERROR_TEXT = 'Your passwords do not match'

--- a/config.py
+++ b/config.py
@@ -36,7 +36,7 @@ class Config(object):
     JSON_SECRET_KEYS = os.getenv('JSON_SECRET_KEYS')
 
     REDIS_HOST = os.getenv('REDIS_HOST', 'localhost')
-    REDIS_PORT = os.getenv('REDIS_PORT', 7379)
+    REDIS_PORT = os.getenv('REDIS_PORT', 6379)
     REDIS_DB = os.getenv('REDIS_DB', 1)
 
     PASSWORD_MATCH_ERROR_TEXT = 'Your passwords do not match'

--- a/frontstage/__init__.py
+++ b/frontstage/__init__.py
@@ -18,6 +18,7 @@ def inject_availability_message():
             }
     return {}
 
+
 # Bind routes to app
 import frontstage.views  # NOQA  # pylint: disable=wrong-import-position
 import frontstage.error_handlers  # NOQA  # pylint: disable=wrong-import-position


### PR DESCRIPTION
# Motivation and Context
It used to map to 7379 , docker was moved to 6379 to ease testing , this is following 

# What has changed
changed testing config

# How to test?
run acceptance tests 
 
 
