### PR TITLE
Newest first survey list

### DIFF
--- a/frontstage/views/surveys/surveys_list.py
+++ b/frontstage/views/surveys/surveys_list.py
@@ -24,7 +24,7 @@ def get_survey_list(session, tag):
     survey_list = party_controller.get_survey_list_details_for_party(party_id, tag, business_party_id=business_id,
                                                                      survey_id=survey_id)
 
-    sorted_survey_list = sorted(survey_list, key=lambda k: datetime.strptime(k['submit_by'], '%d %b %Y'))
+    sorted_survey_list = sorted(survey_list, key=lambda k: datetime.strptime(k['submit_by'], '%d %b %Y'), reverse=True)
 
     if tag == 'todo':
         added_survey = True if business_id and survey_id and not already_enrolled else None

--- a/frontstage/views/surveys/surveys_list.py
+++ b/frontstage/views/surveys/surveys_list.py
@@ -15,6 +15,10 @@ logger = wrap_logger(logging.getLogger(__name__))
 @surveys_bp.route('/<tag>', methods=['GET'])
 @jwt_authorization(request)
 def get_survey_list(session, tag):
+    """
+    Displays the list of surveys for the respondent by tag.  A tag represents the state the
+    survey is in (e.g., todo, history, etc)
+    """
     logger.info("Retrieving survey todo list")
     party_id = session.get('party_id')
     business_id = request.args.get('business_party_id')


### PR DESCRIPTION
# Motivation and Context
Currently the todo and history list sort the list of surveys with the oldest first.  This isn't a big deal when there are a handful of surveys, but with a long list, you'll have to scroll down quite a far way to see your latest surveys. 

# What has changed
The todo and history are sorted with newest first, as opposed to oldest first.

# How to test?
- Run the acceptance tests to put in some example data.  Then sign in as a respondent.  The newest surveys should be at the top.  For extra checking, you can enrol on another survey and see that it's added to the right place in the list

# Links
https://trello.com/c/VRjWyzVd
https://trello.com/c/63o99Lx6


# Screenshots (if appropriate):
