### PR TITLE
Filter ended collection exercises out of lists

### DIFF
--- a/tests/app/controllers/test_party_controller.py
+++ b/tests/app/controllers/test_party_controller.py
@@ -2,6 +2,7 @@
 import json
 import unittest
 from collections import namedtuple
+from datetime import datetime, timedelta
 from unittest.mock import patch
 
 import responses
@@ -284,7 +285,11 @@ class TestPartyController(unittest.TestCase):
         with open('tests/test_data/party/collection_exercises.json') as business_json_data:
             data = json.load(business_json_data)
 
-        # Data has 2 collection exercises in the far future, nothing should be removed
+        # Enddates set for tomorrow. Millseconds are set up this way because datetime generates 6 digits
+        # where we receive 3 digits.
+        date = datetime.now() + timedelta(days=1)
+        data[0]['scheduledEndDateTime'] = date.strftime("%Y-%m-%dT%H:%M:%S") + ".000Z"
+        data[1]['scheduledEndDateTime'] = date.strftime("%Y-%m-%dT%H:%M:%S") + ".111Z"
         self.assertEqual(len(data), 2)
         filter_ended_collection_exercises(data)
         self.assertEqual(len(data), 2)

--- a/tests/test_data/party/collection_exercises.json
+++ b/tests/test_data/party/collection_exercises.json
@@ -1,0 +1,128 @@
+[
+    {
+        "id": "06e7df7a-f95e-4411-bc46-234e0235badb",
+        "surveyId": "cb8accda-6118-4d3b-85a3-149e28960c54",
+        "name": null,
+        "actualExecutionDateTime": "2019-11-27T13:36:53.520Z",
+        "scheduledExecutionDateTime": "2018-12-07T00:00:00.000Z",
+        "scheduledStartDateTime": "2018-12-07T00:00:00.000Z",
+        "actualPublishDateTime": null,
+        "periodStartDateTime": "2018-12-07T00:00:00.000Z",
+        "periodEndDateTime": "2021-01-31T00:00:00.000Z",
+        "scheduledReturnDateTime": "2019-01-09T00:00:00.000Z",
+        "scheduledEndDateTime": "2021-01-31T00:00:00.000Z",
+        "executedBy": null,
+        "state": "LIVE",
+        "caseTypes": [
+            {
+                "actionPlanId": "2eda862b-e070-4836-b539-2f7339fb8910",
+                "sampleUnitType": "B"
+            },
+            {
+                "actionPlanId": "b2a00973-1f13-4de0-b05a-1762fe169bf2",
+                "sampleUnitType": "BI"
+            }
+        ],
+        "exerciseRef": "201812",
+        "userDescription": "December 2018",
+        "created": "2019-11-27T13:36:04.924Z",
+        "updated": "2019-11-27T13:36:53.633Z",
+        "deleted": null,
+        "validationErrors": null,
+        "events": {
+            "exercise_end": {
+                "date": "31 Jan 2021",
+                "month": "01",
+                "is_in_future": true
+            },
+            "go_live": {
+                "date": "14 Dec 2018",
+                "month": "12",
+                "is_in_future": false
+            },
+            "mps": {
+                "date": "07 Dec 2018",
+                "month": "12",
+                "is_in_future": false
+            },
+            "ref_period_end": {
+                "date": "31 Dec 2018",
+                "month": "12",
+                "is_in_future": false
+            },
+            "ref_period_start": {
+                "date": "01 Dec 2018",
+                "month": "12",
+                "is_in_future": false
+            },
+            "return_by": {
+                "date": "09 Jan 2019",
+                "month": "01",
+                "is_in_future": false
+            }
+        }
+    },
+    {
+        "id": "5cafede2-b0b1-4162-aef2-bffee136ddf4",
+        "surveyId": "cb8accda-6118-4d3b-85a3-149e28960c54",
+        "name": null,
+        "actualExecutionDateTime": "2019-11-27T13:36:51.273Z",
+        "scheduledExecutionDateTime": "2018-01-16T00:00:00.000Z",
+        "scheduledStartDateTime": "2018-01-16T00:00:00.000Z",
+        "actualPublishDateTime": null,
+        "periodStartDateTime": "2018-01-16T00:00:00.000Z",
+        "periodEndDateTime": "2020-02-28T00:00:00.000Z",
+        "scheduledReturnDateTime": "2018-02-09T00:00:00.000Z",
+        "scheduledEndDateTime": "2020-02-28T00:00:00.000Z",
+        "executedBy": null,
+        "state": "LIVE",
+        "caseTypes": [
+            {
+                "actionPlanId": "675a6dac-2c2a-4db5-b052-2ace821825de",
+                "sampleUnitType": "B"
+            },
+            {
+                "actionPlanId": "a7e27c14-304b-48f8-86fb-3ffa101a3264",
+                "sampleUnitType": "BI"
+            }
+        ],
+        "exerciseRef": "201801",
+        "userDescription": "January 2018",
+        "created": "2019-11-27T13:36:04.539Z",
+        "updated": "2019-11-27T13:36:51.496Z",
+        "deleted": null,
+        "validationErrors": null,
+        "events": {
+            "exercise_end": {
+                "date": "28 Feb 2020",
+                "month": "02",
+                "is_in_future": true
+            },
+            "go_live": {
+                "date": "21 Jan 2018",
+                "month": "01",
+                "is_in_future": false
+            },
+            "mps": {
+                "date": "16 Jan 2018",
+                "month": "01",
+                "is_in_future": false
+            },
+            "ref_period_end": {
+                "date": "28 Jan 2018",
+                "month": "01",
+                "is_in_future": false
+            },
+            "ref_period_start": {
+                "date": "01 Jan 2018",
+                "month": "01",
+                "is_in_future": false
+            },
+            "return_by": {
+                "date": "09 Feb 2018",
+                "month": "02",
+                "is_in_future": false
+            }
+        }
+    }
+]


### PR DESCRIPTION
# Motivation and Context
Currently we get the live collection exercises for the user for the todo and history lists.  These never go away so the list gets longer and longer.  This PR filters the surveys from the live surveys list if the end date (which is a date far in the future from the return by date) to make the list be full of relevant surveys.

Note:  The collection exercise service has the concept of not-started and live surveys only.  In the future, if it ever becomes a list of 3 (not-started, live-but-not-ended and ended) then the filter done here can be removed and we can change the call to collection exercise with the data we care about.

# What has changed
- Added code to filter out the ended surveys from the list.

# How to test?
- Unit and acceptance tests pass.
- Spin the service up (with seeded data from accecptance tests), change the >= to <= in the filter function to see the lists change.  You can also comment the check out to see everything instead of the filtered lists.

# Links
https://trello.com/c/vfbt44rn
https://trello.com/c/OWir1kSL

# Screenshots (if appropriate):
