### PR TITLE
Render template on POST

### DIFF
--- a/frontstage/routes.md
+++ b/frontstage/routes.md
@@ -55,14 +55,6 @@ To reset a password
 * GET request to this endpoint will display a form to enter in account details.
 * POST request to this endpoint will attempt to create an account for this respondent.
 
-`register/create-account/check-your-email`
-
-* GET request to this endpoint will render a page that will tell the user to verify their account via e-mail.
-
-`register/create-account/check-email`
-
-* GET request to this endpoint will display to the user that they've almost created their account.
-
 ---
 
 ## Secure messaging endpoints

--- a/frontstage/views/register/enter_account_details.py
+++ b/frontstage/views/register/enter_account_details.py
@@ -1,6 +1,6 @@
 import logging
 
-from flask import render_template, request, redirect, url_for
+from flask import render_template, request
 from structlog import wrap_logger
 
 from frontstage.common.cryptographer import Cryptographer
@@ -12,14 +12,6 @@ from frontstage.views.register import register_bp
 
 logger = wrap_logger(logging.getLogger(__name__))
 cryptographer = Cryptographer()
-
-
-@register_bp.route('/create-account/check-your-email', methods=['GET'])
-def confirm_enter_your_details():
-    email_address = request.args.get('email_address')
-    if not email_address:
-        raise Exception('Attempted to render check-your-email view without passing an email address')
-    return render_template('register/register.almost-done.html', email=email_address)
 
 
 @register_bp.route('/create-account/enter-account-details', methods=['GET', 'POST'])
@@ -57,7 +49,7 @@ def register_enter_your_details():
                 raise exc
 
         logger.info('Successfully created account')
-        return redirect(url_for('register_bp.confirm_enter_your_details', email_address=email_address))
+        return render_template('register/register.almost-done.html', email=email_address)
 
     else:
         return render_template('register/register.enter-your-details.html', form=form, errors=form.errors)

--- a/tests/app/test_registration.py
+++ b/tests/app/test_registration.py
@@ -14,7 +14,6 @@ from tests.app.mocked_services import (business_party, case, categories, collect
 class TestRegistration(unittest.TestCase):
 
     def setUp(self):
-
         self.app = app.test_client()
         self.headers = {
             "Authorization": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoicmluZ3JhbUBub3d3aGVyZS5jb20iLCJ1c2VyX3Njb3BlcyI6WyJjaS5yZWFkIiwiY2kud3JpdGUiXX0.se0BJtNksVtk14aqjp7SvnXzRbEKoqXb8Q5U9VVdy54"  # NOQA
@@ -466,18 +465,3 @@ class TestRegistration(unittest.TestCase):
 
         self.assertEqual(response.status_code, 500)
         self.assertTrue('An error has occurred'.encode() in response.data)
-
-    def test_can_access_email_confirmation_when_email_param_passed(self):
-        response = self.app.get('/register/create-account/check-your-email', query_string='email_address=steve')
-
-        self.assertEqual(response.status_code, 200)
-
-    def test_contains_email_confirmation_when_email_param_passed(self):
-        response = self.app.get('/register/create-account/check-your-email', query_string='email_address=steve')
-
-        self.assertTrue(b'steve' in response.data)
-
-    def test_cant_access_email_confirmation_when_email_param_passed(self):
-        response = self.app.get('/register/create-account/check-your-email')
-
-        self.assertEqual(response.status_code, 500)


### PR DESCRIPTION
# Motivation and Context
When creating an account, the enter account details page will redirect via a GET request a confirm email route. This redirection includes the email as a url parameter. This needs to be remove, so we're going to render the template immediately in the enter account details page instead, as it has all the information anyway.

# What has changed
Modified enter_account_details.py to stop it redirecting when you create an account, instead we immediately render the template.

# How to test?
1. Find an unused enrolment code
1. Create a new account
1. Account should be created successfully and the Almost done page should be rendered with the email from the step above.

# Links
https://trello.com/c/sx7LBxf8/1422-stop-email-address-being-passed-as-a-url-parameter-in-frontstage-3

# Screenshots (if appropriate):
