### PR TITLE
Add docker target to make file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,6 @@ check:
 test: check lint
 	APP_SETTINGS=TestingConfig pipenv run pytest $(TEST_TARGET) --cov frontstage --cov-report term-missing	
 
+docker: test
+	docker build -t sdcplatform/ras-frontstage:latest .
+


### PR DESCRIPTION
# Motivation and Context
Adding `make docker` to Makefile similar to the response-operations-ui. 

# What has changed
Makefile

# How to test?
1. Run `make docker`

# Links


# Screenshots (if appropriate):
