### PR TITLE
Append the protocol and host to reset link

### DIFF
--- a/frontstage/views/passwords/reset_password.py
+++ b/frontstage/views/passwords/reset_password.py
@@ -96,7 +96,11 @@ def request_password_change(email):
     logger.info("Requesting password change", party_id=party_id)
 
     token = verification.generate_email_token(email)
-    verification_url = url_for('passwords_bp.post_reset_password', token=token)
+
+    # url_root comes with a trailing slash that we don't want.
+    url_root = request.url_root[:-1]
+    verification_url = url_root + url_for('passwords_bp.post_reset_password', token=token)
+
     personalisation = {
         'RESET_PASSWORD_URL': verification_url,
         'FIRST_NAME': respondent['firstName']

--- a/frontstage/views/passwords/reset_password.py
+++ b/frontstage/views/passwords/reset_password.py
@@ -97,8 +97,10 @@ def request_password_change(email):
 
     token = verification.generate_email_token(email)
 
-    # url_root comes with a trailing slash that we don't want.
-    url_root = request.url_root[:-1]
+    url_root = request.url_root
+    # url_for comes with a leading slash, so strip off the trailing slash in url_root if there is one
+    if url_root.endswith('/'):
+        url_root = url_root[:-1]
     verification_url = url_root + url_for('passwords_bp.post_reset_password', token=token)
 
     personalisation = {


### PR DESCRIPTION
# Motivation and Context
Before, the password reset link would be `/passwords/reset-password/<token>`
This PR fixes so that it becomes `http://localhost:8082/passwords/reset-password/<token>`

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):
