### PR TITLE
Add fix for load balancer ssl termination in GCP

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.0.0
+appVersion: 2.0.1

--- a/_infra/helm/frontstage/templates/backendconfig.yaml
+++ b/_infra/helm/frontstage/templates/backendconfig.yaml
@@ -6,4 +6,6 @@ metadata:
 spec:
   securityPolicy:
     name: "ras-cloud-armor-policy"
+  customRequestHeaders:
+    X-Forwarded-Proto: https
 {{- end }}

--- a/config.py
+++ b/config.py
@@ -10,6 +10,7 @@ class Config(object):
     DEBUG = False
     TESTING = False
     VERSION = '1.21.0'
+    PREFERRED_URL_SCHEME = 'https'
     PORT = os.getenv('PORT', 8082)
     MAX_UPLOAD_LENGTH = os.getenv('MAX_UPLOAD_LENGTH', 20 * 1024 * 1024)
 
@@ -102,6 +103,7 @@ class DevelopmentConfig(Config):
     DEVELOPMENT = True
     DEBUG = True
     TEMPLATES_AUTO_RELOAD = True
+    PREFERRED_URL_SCHEME = 'http'
     SECRET_KEY = os.getenv('SECRET_KEY', 'ONS_DUMMY_KEY')
     JWT_SECRET = os.getenv('JWT_SECRET', 'testsecret')
 


### PR DESCRIPTION
When running behind a GCP load balancer with SSL termination use the HTTP_X_FORWARDED_PROTO header to set the protocol scheme on the WSGI middleware.

If this is not set then flask will redirect all requests back to http.