### PR TITLE
temporarily disabled pipenv check, pending pipenv bug resolution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,9 @@ docker-test: REDIS_PORT=6379
 docker-test: test
 
 check:
-	pipenv check
+# TEMPORARILY disable pipenv check, pending resolution of pipenv bugs 2412 and 4147
+# TODO: re-enable as soon as possible.
+#	pipenv check
 
 test: check lint
 	APP_SETTINGS=TestingConfig pipenv run pytest $(TEST_TARGET) --cov frontstage --cov-report term-missing	
-
-


### PR DESCRIPTION
# Motivation and Context
Disabled 'pipenv check' in Makefile, pending resolution of blocking pipenv bugs 2412 (plus duplicates) and 4147

# What has changed
Commented the line 'pipenv check' in the Makefile, with a note to uncomment as soon as possible.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
https://trello.com/c/3ZxIpfsX
