### PR TITLE
added session affinity for Client IP to backendconfig.yaml file

### DIFF
--- a/_infra/helm/frontstage/templates/backendconfig.yaml
+++ b/_infra/helm/frontstage/templates/backendconfig.yaml
@@ -8,4 +8,5 @@ spec:
     name: "ras-cloud-armor-policy"
   customRequestHeaders:
     X-Forwarded-Proto: https
+  sessionAffinity: ClientIP
 {{- end }}


### PR DESCRIPTION
# Motivation and Context
allows for session affinity based on client ip

# What has changed
added a tag within the backendconfig for session affinity

# How to test?
i can't test it but when it is merged and deployed it will show up in advanced config for backend services
