### PR TITLE
remove the redendant dns

### DIFF
--- a/_infra/helm/frontstage/templates/ManagedCertificate.yaml
+++ b/_infra/helm/frontstage/templates/ManagedCertificate.yaml
@@ -2,14 +2,6 @@
 apiVersion: networking.gke.io/v1beta1
 kind: ManagedCertificate
 metadata:
-  name: {{ .Values.ingress.certNameFrontstage }}
-spec:
-  domains:
-    - {{ .Values.ingress.frontstageHost }}
----
-apiVersion: networking.gke.io/v1beta1
-kind: ManagedCertificate
-metadata:
   name: {{ .Values.ingress.certNameSurveys }}
 spec:
   domains:

--- a/_infra/helm/frontstage/templates/ingress.yaml
+++ b/_infra/helm/frontstage/templates/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.global-static-ip-name: frontstage-ip
     kubernetes.io/ingress.class: gce
-    networking.gke.io/managed-certificates: {{ .Values.ingress.certNameFrontstage }},{{ .Values.ingress.certNameSurveys }}
+    networking.gke.io/managed-certificates: {{ .Values.ingress.certNameSurveys }}
     kubernetes.io/ingress.allow-http: "false"
 spec:
   rules:

--- a/_infra/helm/frontstage/values.yaml
+++ b/_infra/helm/frontstage/values.yaml
@@ -27,8 +27,6 @@ database:
 
 ingress:
   enabled: false
-  frontstageHost: frontstage.example.com
-  certNameFrontstage: frontstage-cert
   surveysHost: surveys.example.com
   certNameSurveys: surveys-cert
 


### PR DESCRIPTION
The gcp dns is no longer required. we use the aws dns surveys.onsdigital.uk