### PR TITLE
Local test fix

### DIFF
--- a/frontstage/views/sign_in/sign_in.py
+++ b/frontstage/views/sign_in/sign_in.py
@@ -13,7 +13,6 @@ from frontstage.exceptions.exceptions import OAuth2Error
 from frontstage.jwt import encode, timestamp_token
 from frontstage.models import LoginForm
 from frontstage.views.sign_in import sign_in_bp
-from config import Config
 
 
 logger = wrap_logger(logging.getLogger(__name__))
@@ -35,7 +34,7 @@ def login():
     form.username.data = form.username.data.strip()
     account_activated = request.args.get('account_activated', None)
 
-    secure = Config.WTF_CSRF_ENABLED
+    secure = app.config['WTF_CSRF_ENABLED']
 
     if request.method == 'POST' and (form.validate() or not secure):
         username = form.username.data

--- a/frontstage/views/sign_in/sign_in.py
+++ b/frontstage/views/sign_in/sign_in.py
@@ -13,6 +13,7 @@ from frontstage.exceptions.exceptions import OAuth2Error
 from frontstage.jwt import encode, timestamp_token
 from frontstage.models import LoginForm
 from frontstage.views.sign_in import sign_in_bp
+from config import Config
 
 
 logger = wrap_logger(logging.getLogger(__name__))
@@ -34,7 +35,7 @@ def login():
     form.username.data = form.username.data.strip()
     account_activated = request.args.get('account_activated', None)
 
-    if request.method == 'POST' and form.validate():
+    if request.method == 'POST' and (form.validate() or not Config.WTF_CSRF_ENABLED):
         username = form.username.data
         password = request.form.get('password')
         bound_logger = logger.bind(email=obfuscate_email(username))

--- a/frontstage/views/sign_in/sign_in.py
+++ b/frontstage/views/sign_in/sign_in.py
@@ -35,7 +35,9 @@ def login():
     form.username.data = form.username.data.strip()
     account_activated = request.args.get('account_activated', None)
 
-    if request.method == 'POST' and (form.validate() or not Config.WTF_CSRF_ENABLED):
+    secure = Config.WTF_CSRF_ENABLED
+
+    if request.method == 'POST' and (form.validate() or not secure):
         username = form.username.data
         password = request.form.get('password')
         bound_logger = logger.bind(email=obfuscate_email(username))
@@ -94,8 +96,8 @@ def login():
         response.set_cookie('authorization',
                             value=session.session_key,
                             expires=data_dict_for_jwt_token['expires_at'],
-                            secure=True,
-                            httponly=True)
+                            secure=secure,
+                            httponly=secure)
         bound_logger.info('Successfully created session', session_key=session.session_key)
         return response
 

--- a/frontstage/views/sign_in/sign_in.py
+++ b/frontstage/views/sign_in/sign_in.py
@@ -36,7 +36,7 @@ def login():
 
     secure = app.config['WTF_CSRF_ENABLED']
 
-    if request.method == 'POST' and (form.validate() or not secure):
+    if request.method == 'POST' and form.validate():
         username = form.username.data
         password = request.form.get('password')
         bound_logger = logger.bind(email=obfuscate_email(username))


### PR DESCRIPTION
CSRF and Secure cookies break chrome tests, firefox doesnt have the same issues. This is due to chrome following their own standards and not RFC. By controlling secure cookies and csrf by the WTF_CSRF_ENABLED flag we can test the basic functionality of the frontend with acceptance tests