### PR TITLE
force https and allow http traffic at the loadbalancer

### DIFF
--- a/_infra/helm/frontstage/templates/deployment.yaml
+++ b/_infra/helm/frontstage/templates/deployment.yaml
@@ -217,10 +217,12 @@ spec:
             value: "http://$(ZIPKIN_SERVICE_HOST):$(ZIPKIN_SERVICE_PORT)/api/v1/spans"
           - name: ZIPKIN_SAMPLE_RATE
             value: "100"
+          - name: SECURE_APP
+            value: "{{- if .Values.security.enabled -}}True{{- else -}}False{{- end -}}"
           - name: WTF_CSRF_ENABLED
-            value: "{{ .Values.csrf.protected }}"
+            value: "{{- if .Values.security.csrf.protected -}}True{{- else -}}False{{- end -}}"
           - name: WTF_CSRF_TIME_LIMIT
-            value: "{{ .Values.csrf.timeLimit }}"
+            value: "{{ .Values.security.csrf.timeLimit }}"
           - name: SECRET_KEY
             valueFrom:
               secretKeyRef:

--- a/_infra/helm/frontstage/templates/ingress.yaml
+++ b/_infra/helm/frontstage/templates/ingress.yaml
@@ -7,7 +7,6 @@ metadata:
     kubernetes.io/ingress.global-static-ip-name: frontstage-ip
     kubernetes.io/ingress.class: gce
     networking.gke.io/managed-certificates: {{ .Values.ingress.certNameSurveys }}
-    kubernetes.io/ingress.allow-http: "false"
 spec:
   rules:
   - host: {{ .Values.ingress.host | quote }}

--- a/_infra/helm/frontstage/values.yaml
+++ b/_infra/helm/frontstage/values.yaml
@@ -42,9 +42,13 @@ email:
     key: ONS_DUMMY_KEY
 
 scheme: http
-csrf:
-  protected: True
-  timeLimit: 7200
+
+security:
+  enabled: true
+  csrf:
+    protected: true
+    timeLimit: 7200
+
 eq:
   url: "http://localhost/session?token="
 

--- a/config.py
+++ b/config.py
@@ -157,7 +157,6 @@ class DevelopmentConfig(Config):
     SURVEY_AUTH = (SURVEY_USERNAME, SURVEY_PASSWORD)
     WTF_CSRF_TIME_LIMIT = int(os.getenv('WTF_CSRF_TIME_LIMIT', '3200'))
     SECURE_APP = bool(strtobool(os.getenv('SECURE_APP', "False")))
-    WTF_CSRF_ENABLED = bool(strtobool(os.getenv('WTF_CSRF_ENABLED', "False")))
 
 
 class TestingConfig(DevelopmentConfig):
@@ -178,4 +177,3 @@ class TestingConfig(DevelopmentConfig):
     REQUESTS_POST_TIMEOUT = 99
     WTF_CSRF_TIME_LIMIT = int(os.getenv('WTF_CSRF_TIME_LIMIT', '3200'))
     SECURE_APP = bool(strtobool(os.getenv('SECURE_APP', "False")))
-    WTF_CSRF_ENABLED = bool(strtobool(os.getenv('WTF_CSRF_ENABLED', "False")))

--- a/config.py
+++ b/config.py
@@ -97,7 +97,8 @@ class Config(object):
     RAS_NOTIFY_ACCOUNT_LOCKED_TEMPLATE = os.getenv('RAS_NOTIFY_ACCOUNT_LOCKED_TEMPLATE', 'account_locked_id')
     SEND_EMAIL_TO_GOV_NOTIFY = os.getenv('SEND_EMAIL_TO_GOV_NOTIFY', False)
     REQUESTS_POST_TIMEOUT = os.getenv('REQUESTS_POST_TIMEOUT', 20)
-    WTF_CSRF_ENABLED = bool(strtobool(os.getenv('WTF_CSRF_ENABLED', "True")))
+    SECURE_APP = bool(strtobool(os.getenv('SECURE_APP', "True")))
+    WTF_CSRF_ENABLED = bool(strtobool(os.getenv('WTF_CSRF_ENABLED', str(SECURE_APP))))
     WTF_CSRF_TIME_LIMIT = int(os.getenv('WTF_CSRF_TIME_LIMIT', '7200'))
 
 

--- a/config.py
+++ b/config.py
@@ -156,6 +156,8 @@ class DevelopmentConfig(Config):
     SURVEY_PASSWORD = os.getenv('SURVEY_PASSWORD', 'secret')
     SURVEY_AUTH = (SURVEY_USERNAME, SURVEY_PASSWORD)
     WTF_CSRF_TIME_LIMIT = int(os.getenv('WTF_CSRF_TIME_LIMIT', '3200'))
+    SECURE_APP = bool(strtobool(os.getenv('SECURE_APP', "False")))
+    WTF_CSRF_ENABLED = bool(strtobool(os.getenv('WTF_CSRF_ENABLED', "False")))
 
 
 class TestingConfig(DevelopmentConfig):
@@ -175,3 +177,5 @@ class TestingConfig(DevelopmentConfig):
     SECURITY_USER_PASSWORD = 'password'
     REQUESTS_POST_TIMEOUT = 99
     WTF_CSRF_TIME_LIMIT = int(os.getenv('WTF_CSRF_TIME_LIMIT', '3200'))
+    SECURE_APP = bool(strtobool(os.getenv('SECURE_APP', "False")))
+    WTF_CSRF_ENABLED = bool(strtobool(os.getenv('WTF_CSRF_ENABLED', "False")))

--- a/frontstage/create_app.py
+++ b/frontstage/create_app.py
@@ -57,7 +57,7 @@ def create_app_object():
         app,
         content_security_policy=csp_policy,
         content_security_policy_nonce_in=['script-src'],
-        force_https=False,  # this is handled at the firewall
+        force_https=True,
         strict_transport_security=True,
         strict_transport_security_max_age=31536000,
         frame_options='DENY')

--- a/frontstage/create_app.py
+++ b/frontstage/create_app.py
@@ -57,7 +57,7 @@ def create_app_object():
         app,
         content_security_policy=csp_policy,
         content_security_policy_nonce_in=['script-src'],
-        force_https=True,
+        force_https=app.config['SECURE_APP'],
         strict_transport_security=True,
         strict_transport_security_max_age=31536000,
         frame_options='DENY')


### PR DESCRIPTION
http traffic will always give us the google 404 error, which will confuse external users.

By forcing https in talisman we can ensure that we are always redirected to https. Our HSTS headers will ensure all all subsequent redirects happen at the browser level preventing any man in the middle attacks.

The httpsOnly annotation needs to be removed in order to allow http traffic at the loadbalancer