### PR TITLE
separate talisman to allow health checking

### DIFF
--- a/frontstage/__init__.py
+++ b/frontstage/__init__.py
@@ -1,7 +1,27 @@
 import redis
 from frontstage.create_app import create_app_object
+from flask_talisman import Talisman
+
+# TODO: review https://content-security-policy.com/, remove this comment if we're covered.
+CSP_POLICY = {
+    'default-src': ["'self'", 'https://cdn.ons.gov.uk'],
+    'font-src': ["'self'", 'data:', 'https://fonts.gstatic.com', 'https://cdn.ons.gov.uk'],
+    'script-src': ["'self'", 'https://www.googletagmanager.com', 'https://cdn.ons.gov.uk'],
+    'connect-src': ["'self'", 'https://www.googletagmanager.com', 'https://tagmanager.google.com', 'https://cdn.ons.gov.uk'],
+    'img-src': ["'self'", 'data:', 'https://www.gstatic.com', 'https://www.google-analytics.com',
+                'https://www.googletagmanager.com', 'https://ssl.gstatic.com', 'https://cdn.ons.gov.uk'],
+    'style-src': ["'self'", 'https://cdn.ons.gov.uk', "'unsafe-inline'", 'https://tagmanager.google.com', 'https://fonts.googleapis.com'],
+}
 
 app = create_app_object()
+talisman = Talisman(
+    app,
+    content_security_policy=CSP_POLICY,
+    content_security_policy_nonce_in=['script-src'],
+    force_https=app.config['SECURE_APP'],
+    strict_transport_security=True,
+    strict_transport_security_max_age=31536000,
+    frame_options='DENY')
 redis = redis.StrictRedis(host=app.config['REDIS_HOST'],
                           port=app.config['REDIS_PORT'],
                           db=app.config['REDIS_DB'])

--- a/frontstage/create_app.py
+++ b/frontstage/create_app.py
@@ -6,7 +6,6 @@ import copy
 from flask import Flask, request
 from flask_zipkin import Zipkin
 from structlog import wrap_logger
-from flask_talisman import Talisman
 from flask_wtf.csrf import CSRFProtect
 
 from frontstage.cloud.cloudfoundry import ONSCloudFoundry
@@ -22,17 +21,6 @@ CACHE_HEADERS = {
     'Pragma': 'no-cache',
 }
 
-# TODO: review https://content-security-policy.com/, remove this comment if we're covered.
-CSP_POLICY = {
-    'default-src': ["'self'", 'https://cdn.ons.gov.uk'],
-    'font-src': ["'self'", 'data:', 'https://fonts.gstatic.com', 'https://cdn.ons.gov.uk'],
-    'script-src': ["'self'", 'https://www.googletagmanager.com', 'https://cdn.ons.gov.uk'],
-    'connect-src': ["'self'", 'https://www.googletagmanager.com', 'https://tagmanager.google.com', 'https://cdn.ons.gov.uk'],
-    'img-src': ["'self'", 'data:', 'https://www.gstatic.com', 'https://www.google-analytics.com',
-                'https://www.googletagmanager.com', 'https://ssl.gstatic.com', 'https://cdn.ons.gov.uk'],
-    'style-src': ["'self'", 'https://cdn.ons.gov.uk', "'unsafe-inline'", 'https://tagmanager.google.com', 'https://fonts.googleapis.com'],
-}
-
 
 class GCPLoadBalancer:
     def __init__(self, app):
@@ -46,21 +34,12 @@ class GCPLoadBalancer:
 
 
 def create_app_object():
-    csp_policy = copy.deepcopy(CSP_POLICY)
     app = Flask(__name__)
 
     # Load app config
     app_config = 'config.{}'.format(os.environ.get('APP_SETTINGS', 'Config'))
     app.config.from_object(app_config)
 
-    Talisman(
-        app,
-        content_security_policy=csp_policy,
-        content_security_policy_nonce_in=['script-src'],
-        force_https=app.config['SECURE_APP'],
-        strict_transport_security=True,
-        strict_transport_security_max_age=31536000,
-        frame_options='DENY')
     app.name = "ras-frontstage"
 
     if not app.config['DEBUG'] and not cf.detected:

--- a/frontstage/create_app.py
+++ b/frontstage/create_app.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import requestsdefaulter
-import copy
 
 from flask import Flask, request
 from flask_zipkin import Zipkin

--- a/frontstage/views/info.py
+++ b/frontstage/views/info.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from flask import Blueprint, jsonify, make_response
 from structlog import wrap_logger
 
-from frontstage import app
+from frontstage import app, talisman
 
 
 logger = wrap_logger(logging.getLogger(__name__))
@@ -19,6 +19,7 @@ if Path('git_info').exists():
 
 
 @info_bp.route('/', methods=['GET'])
+@talisman(force_https=False)
 def get_info():
     info = {
         "name": 'ras-frontstage',

--- a/tests/app/views/surveys/test_download_survey.py
+++ b/tests/app/views/surveys/test_download_survey.py
@@ -41,34 +41,34 @@ class TestDownloadSurvey(unittest.TestCase):
                 self.assertEqual(response.status_code, 200)
 
     def test_enforces_secure_headers(self):
-        with app.test_client() as client:
-            headers = client.get(
-                '/',
-                headers={'X-Forwarded-Proto': 'https'}  # set protocol so that talisman sets HSTS headers
-            ).headers
+        with app as client:
+        headers = client.get(
+            '/',
+            headers={'X-Forwarded-Proto': 'https'}  # set protocol so that talisman sets HSTS headers
+        ).headers
 
-            self.assertEqual('no-cache, no-store, must-revalidate', headers['Cache-Control'])
-            self.assertEqual('no-cache', headers['Pragma'])
-            self.assertEqual('max-age=31536000; includeSubDomains', headers['Strict-Transport-Security'])
-            self.assertEqual('DENY', headers['X-Frame-Options'])
-            self.assertEqual('1; mode=block', headers['X-Xss-Protection'])
-            self.assertEqual('nosniff', headers['X-Content-Type-Options'])
+        self.assertEqual('no-cache, no-store, must-revalidate', headers['Cache-Control'])
+        self.assertEqual('no-cache', headers['Pragma'])
+        self.assertEqual('max-age=31536000; includeSubDomains', headers['Strict-Transport-Security'])
+        self.assertEqual('DENY', headers['X-Frame-Options'])
+        self.assertEqual('1; mode=block', headers['X-Xss-Protection'])
+        self.assertEqual('nosniff', headers['X-Content-Type-Options'])
 
-            csp_policy_parts = headers['Content-Security-Policy'].split('; ')
-            self.assertIn("default-src 'self' https://cdn.ons.gov.uk", csp_policy_parts)
-            self.assertIn(
-                "font-src 'self' data: https://fonts.gstatic.com https://cdn.ons.gov.uk", csp_policy_parts)
-            self.assertIn(
-                "script-src 'self' https://www.googletagmanager.com https://cdn.ons.gov.uk 'nonce-{}'".format(
-                    request.csp_nonce),
-                csp_policy_parts
-            )
-            # TODO: fix assertion error
-            # self.assertIn(
-            #     "connect-src 'self' https://www.googletagmanager.com https://tagmanager.google.com https://cdn.ons.gov.uk "
-            #     'http://localhost:8082 ws://localhost:8082', csp_policy_parts)
-            self.assertIn(
-                "img-src 'self' data: https://www.gstatic.com https://www.google-analytics.com "
-                'https://www.googletagmanager.com https://ssl.gstatic.com https://cdn.ons.gov.uk', csp_policy_parts)
-            self.assertIn(
-                "style-src 'self' https://cdn.ons.gov.uk 'unsafe-inline' https://tagmanager.google.com https://fonts.googleapis.com", csp_policy_parts)
+        csp_policy_parts = headers['Content-Security-Policy'].split('; ')
+        self.assertIn("default-src 'self' https://cdn.ons.gov.uk", csp_policy_parts)
+        self.assertIn(
+            "font-src 'self' data: https://fonts.gstatic.com https://cdn.ons.gov.uk", csp_policy_parts)
+        self.assertIn(
+            "script-src 'self' https://www.googletagmanager.com https://cdn.ons.gov.uk 'nonce-{}'".format(
+                request.csp_nonce),
+            csp_policy_parts
+        )
+        # TODO: fix assertion error
+        # self.assertIn(
+        #     "connect-src 'self' https://www.googletagmanager.com https://tagmanager.google.com https://cdn.ons.gov.uk "
+        #     'http://localhost:8082 ws://localhost:8082', csp_policy_parts)
+        self.assertIn(
+            "img-src 'self' data: https://www.gstatic.com https://www.google-analytics.com "
+            'https://www.googletagmanager.com https://ssl.gstatic.com https://cdn.ons.gov.uk', csp_policy_parts)
+        self.assertIn(
+            "style-src 'self' https://cdn.ons.gov.uk 'unsafe-inline' https://tagmanager.google.com https://fonts.googleapis.com", csp_policy_parts)

--- a/tests/app/views/surveys/test_download_survey.py
+++ b/tests/app/views/surveys/test_download_survey.py
@@ -42,33 +42,33 @@ class TestDownloadSurvey(unittest.TestCase):
 
     def test_enforces_secure_headers(self):
         with app as client:
-        headers = client.get(
-            '/',
-            headers={'X-Forwarded-Proto': 'https'}  # set protocol so that talisman sets HSTS headers
-        ).headers
+            headers = client.get(
+                '/',
+                headers={'X-Forwarded-Proto': 'https'}  # set protocol so that talisman sets HSTS headers
+            ).headers
 
-        self.assertEqual('no-cache, no-store, must-revalidate', headers['Cache-Control'])
-        self.assertEqual('no-cache', headers['Pragma'])
-        self.assertEqual('max-age=31536000; includeSubDomains', headers['Strict-Transport-Security'])
-        self.assertEqual('DENY', headers['X-Frame-Options'])
-        self.assertEqual('1; mode=block', headers['X-Xss-Protection'])
-        self.assertEqual('nosniff', headers['X-Content-Type-Options'])
+            self.assertEqual('no-cache, no-store, must-revalidate', headers['Cache-Control'])
+            self.assertEqual('no-cache', headers['Pragma'])
+            self.assertEqual('max-age=31536000; includeSubDomains', headers['Strict-Transport-Security'])
+            self.assertEqual('DENY', headers['X-Frame-Options'])
+            self.assertEqual('1; mode=block', headers['X-Xss-Protection'])
+            self.assertEqual('nosniff', headers['X-Content-Type-Options'])
 
-        csp_policy_parts = headers['Content-Security-Policy'].split('; ')
-        self.assertIn("default-src 'self' https://cdn.ons.gov.uk", csp_policy_parts)
-        self.assertIn(
-            "font-src 'self' data: https://fonts.gstatic.com https://cdn.ons.gov.uk", csp_policy_parts)
-        self.assertIn(
-            "script-src 'self' https://www.googletagmanager.com https://cdn.ons.gov.uk 'nonce-{}'".format(
-                request.csp_nonce),
-            csp_policy_parts
-        )
-        # TODO: fix assertion error
-        # self.assertIn(
-        #     "connect-src 'self' https://www.googletagmanager.com https://tagmanager.google.com https://cdn.ons.gov.uk "
-        #     'http://localhost:8082 ws://localhost:8082', csp_policy_parts)
-        self.assertIn(
-            "img-src 'self' data: https://www.gstatic.com https://www.google-analytics.com "
-            'https://www.googletagmanager.com https://ssl.gstatic.com https://cdn.ons.gov.uk', csp_policy_parts)
-        self.assertIn(
-            "style-src 'self' https://cdn.ons.gov.uk 'unsafe-inline' https://tagmanager.google.com https://fonts.googleapis.com", csp_policy_parts)
+            csp_policy_parts = headers['Content-Security-Policy'].split('; ')
+            self.assertIn("default-src 'self' https://cdn.ons.gov.uk", csp_policy_parts)
+            self.assertIn(
+                "font-src 'self' data: https://fonts.gstatic.com https://cdn.ons.gov.uk", csp_policy_parts)
+            self.assertIn(
+                "script-src 'self' https://www.googletagmanager.com https://cdn.ons.gov.uk 'nonce-{}'".format(
+                    request.csp_nonce),
+                csp_policy_parts
+            )
+            # TODO: fix assertion error
+            # self.assertIn(
+            #     "connect-src 'self' https://www.googletagmanager.com https://tagmanager.google.com https://cdn.ons.gov.uk "
+            #     'http://localhost:8082 ws://localhost:8082', csp_policy_parts)
+            self.assertIn(
+                "img-src 'self' data: https://www.gstatic.com https://www.google-analytics.com "
+                'https://www.googletagmanager.com https://ssl.gstatic.com https://cdn.ons.gov.uk', csp_policy_parts)
+            self.assertIn(
+                "style-src 'self' https://cdn.ons.gov.uk 'unsafe-inline' https://tagmanager.google.com https://fonts.googleapis.com", csp_policy_parts)

--- a/tests/app/views/surveys/test_download_survey.py
+++ b/tests/app/views/surveys/test_download_survey.py
@@ -41,34 +41,33 @@ class TestDownloadSurvey(unittest.TestCase):
                 self.assertEqual(response.status_code, 200)
 
     def test_enforces_secure_headers(self):
-        with app as client:
-            headers = client.get(
-                '/',
-                headers={'X-Forwarded-Proto': 'https'}  # set protocol so that talisman sets HSTS headers
-            ).headers
+        headers = self.app.get(
+            '/',
+            headers={'X-Forwarded-Proto': 'https'}  # set protocol so that talisman sets HSTS headers
+        ).headers
 
-            self.assertEqual('no-cache, no-store, must-revalidate', headers['Cache-Control'])
-            self.assertEqual('no-cache', headers['Pragma'])
-            self.assertEqual('max-age=31536000; includeSubDomains', headers['Strict-Transport-Security'])
-            self.assertEqual('DENY', headers['X-Frame-Options'])
-            self.assertEqual('1; mode=block', headers['X-Xss-Protection'])
-            self.assertEqual('nosniff', headers['X-Content-Type-Options'])
+        self.assertEqual('no-cache, no-store, must-revalidate', headers['Cache-Control'])
+        self.assertEqual('no-cache', headers['Pragma'])
+        self.assertEqual('max-age=31536000; includeSubDomains', headers['Strict-Transport-Security'])
+        self.assertEqual('DENY', headers['X-Frame-Options'])
+        self.assertEqual('1; mode=block', headers['X-Xss-Protection'])
+        self.assertEqual('nosniff', headers['X-Content-Type-Options'])
 
-            csp_policy_parts = headers['Content-Security-Policy'].split('; ')
-            self.assertIn("default-src 'self' https://cdn.ons.gov.uk", csp_policy_parts)
-            self.assertIn(
-                "font-src 'self' data: https://fonts.gstatic.com https://cdn.ons.gov.uk", csp_policy_parts)
-            self.assertIn(
-                "script-src 'self' https://www.googletagmanager.com https://cdn.ons.gov.uk 'nonce-{}'".format(
-                    request.csp_nonce),
-                csp_policy_parts
-            )
-            # TODO: fix assertion error
-            # self.assertIn(
-            #     "connect-src 'self' https://www.googletagmanager.com https://tagmanager.google.com https://cdn.ons.gov.uk "
-            #     'http://localhost:8082 ws://localhost:8082', csp_policy_parts)
-            self.assertIn(
-                "img-src 'self' data: https://www.gstatic.com https://www.google-analytics.com "
-                'https://www.googletagmanager.com https://ssl.gstatic.com https://cdn.ons.gov.uk', csp_policy_parts)
-            self.assertIn(
-                "style-src 'self' https://cdn.ons.gov.uk 'unsafe-inline' https://tagmanager.google.com https://fonts.googleapis.com", csp_policy_parts)
+        csp_policy_parts = headers['Content-Security-Policy'].split('; ')
+        self.assertIn("default-src 'self' https://cdn.ons.gov.uk", csp_policy_parts)
+        self.assertIn(
+            "font-src 'self' data: https://fonts.gstatic.com https://cdn.ons.gov.uk", csp_policy_parts)
+        self.assertIn(
+            "script-src 'self' https://www.googletagmanager.com https://cdn.ons.gov.uk 'nonce-{}'".format(
+                request.csp_nonce),
+            csp_policy_parts
+        )
+        # TODO: fix assertion error
+        # self.assertIn(
+        #     "connect-src 'self' https://www.googletagmanager.com https://tagmanager.google.com https://cdn.ons.gov.uk "
+        #     'http://localhost:8082 ws://localhost:8082', csp_policy_parts)
+        self.assertIn(
+            "img-src 'self' data: https://www.gstatic.com https://www.google-analytics.com "
+            'https://www.googletagmanager.com https://ssl.gstatic.com https://cdn.ons.gov.uk', csp_policy_parts)
+        self.assertIn(
+            "style-src 'self' https://cdn.ons.gov.uk 'unsafe-inline' https://tagmanager.google.com https://fonts.googleapis.com", csp_policy_parts)

--- a/tests/app/views/surveys/test_download_survey.py
+++ b/tests/app/views/surveys/test_download_survey.py
@@ -41,7 +41,7 @@ class TestDownloadSurvey(unittest.TestCase):
                 self.assertEqual(response.status_code, 200)
 
     def test_enforces_secure_headers(self):
-        with create_app_object().test_client() as client:
+        with app.test_client() as client:
             headers = client.get(
                 '/',
                 headers={'X-Forwarded-Proto': 'https'}  # set protocol so that talisman sets HSTS headers

--- a/tests/app/views/surveys/test_download_survey.py
+++ b/tests/app/views/surveys/test_download_survey.py
@@ -41,33 +41,34 @@ class TestDownloadSurvey(unittest.TestCase):
                 self.assertEqual(response.status_code, 200)
 
     def test_enforces_secure_headers(self):
-        headers = self.app.get(
-            '/',
-            headers={'X-Forwarded-Proto': 'https'}  # set protocol so that talisman sets HSTS headers
-        ).headers
+        with app.test_client() as client:
+            headers = client.get(
+                '/',
+                headers={'X-Forwarded-Proto': 'https'}  # set protocol so that talisman sets HSTS headers
+            ).headers
 
-        self.assertEqual('no-cache, no-store, must-revalidate', headers['Cache-Control'])
-        self.assertEqual('no-cache', headers['Pragma'])
-        self.assertEqual('max-age=31536000; includeSubDomains', headers['Strict-Transport-Security'])
-        self.assertEqual('DENY', headers['X-Frame-Options'])
-        self.assertEqual('1; mode=block', headers['X-Xss-Protection'])
-        self.assertEqual('nosniff', headers['X-Content-Type-Options'])
+            self.assertEqual('no-cache, no-store, must-revalidate', headers['Cache-Control'])
+            self.assertEqual('no-cache', headers['Pragma'])
+            self.assertEqual('max-age=31536000; includeSubDomains', headers['Strict-Transport-Security'])
+            self.assertEqual('DENY', headers['X-Frame-Options'])
+            self.assertEqual('1; mode=block', headers['X-Xss-Protection'])
+            self.assertEqual('nosniff', headers['X-Content-Type-Options'])
 
-        csp_policy_parts = headers['Content-Security-Policy'].split('; ')
-        self.assertIn("default-src 'self' https://cdn.ons.gov.uk", csp_policy_parts)
-        self.assertIn(
-            "font-src 'self' data: https://fonts.gstatic.com https://cdn.ons.gov.uk", csp_policy_parts)
-        self.assertIn(
-            "script-src 'self' https://www.googletagmanager.com https://cdn.ons.gov.uk 'nonce-{}'".format(
-                request.csp_nonce),
-            csp_policy_parts
-        )
-        # TODO: fix assertion error
-        # self.assertIn(
-        #     "connect-src 'self' https://www.googletagmanager.com https://tagmanager.google.com https://cdn.ons.gov.uk "
-        #     'http://localhost:8082 ws://localhost:8082', csp_policy_parts)
-        self.assertIn(
-            "img-src 'self' data: https://www.gstatic.com https://www.google-analytics.com "
-            'https://www.googletagmanager.com https://ssl.gstatic.com https://cdn.ons.gov.uk', csp_policy_parts)
-        self.assertIn(
-            "style-src 'self' https://cdn.ons.gov.uk 'unsafe-inline' https://tagmanager.google.com https://fonts.googleapis.com", csp_policy_parts)
+            csp_policy_parts = headers['Content-Security-Policy'].split('; ')
+            self.assertIn("default-src 'self' https://cdn.ons.gov.uk", csp_policy_parts)
+            self.assertIn(
+                "font-src 'self' data: https://fonts.gstatic.com https://cdn.ons.gov.uk", csp_policy_parts)
+            self.assertIn(
+                "script-src 'self' https://www.googletagmanager.com https://cdn.ons.gov.uk 'nonce-{}'".format(
+                    request.csp_nonce),
+                csp_policy_parts
+            )
+            # TODO: fix assertion error
+            # self.assertIn(
+            #     "connect-src 'self' https://www.googletagmanager.com https://tagmanager.google.com https://cdn.ons.gov.uk "
+            #     'http://localhost:8082 ws://localhost:8082', csp_policy_parts)
+            self.assertIn(
+                "img-src 'self' data: https://www.gstatic.com https://www.google-analytics.com "
+                'https://www.googletagmanager.com https://ssl.gstatic.com https://cdn.ons.gov.uk', csp_policy_parts)
+            self.assertIn(
+                "style-src 'self' https://cdn.ons.gov.uk 'unsafe-inline' https://tagmanager.google.com https://fonts.googleapis.com", csp_policy_parts)

--- a/tests/app/views/surveys/test_download_survey.py
+++ b/tests/app/views/surveys/test_download_survey.py
@@ -3,7 +3,7 @@ import unittest
 from unittest.mock import patch
 from flask import request
 
-from frontstage import app, create_app_object
+from frontstage import app
 from tests.app.mocked_services import business_party, case, collection_instrument_seft, encoded_jwt_token, survey
 
 


### PR DESCRIPTION
recent change to fronstage allowed http traffic but a redirect is necessary for http traffic.
This failed the kubernetes health checks as every /info hit was being redirected to https.