### PR TITLE
Access Control Origin Header

### DIFF
--- a/_infra/helm/frontstage/templates/deployment.yaml
+++ b/_infra/helm/frontstage/templates/deployment.yaml
@@ -114,6 +114,12 @@ spec:
           - name: GOOGLE_TAG_MANAGER_PROP
             value: "{{ .Values.analytics.tagManagerProp }}"
           {{- end }}
+          - name: ACCESS_CONTROL_ALLOW_ORIGIN
+            {{- if .Values.ingress.enabled }}
+            value: "https://{{ .Values.ingress.surveysHost }}"
+            {{- else }}
+            value: "*"
+            {{- end }}
           - name: IAC_URL
             {{- if .Values.dns.enabled }}
             value: "http://iac.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.dns.wellKnownPort }}"

--- a/_infra/helm/frontstage/values.yaml
+++ b/_infra/helm/frontstage/values.yaml
@@ -14,10 +14,10 @@ image:
   pullPolicy: Always
 
 container:
-  port: 8080
+  port: 9000
 service:
   type: ClusterIP
-  port: 80
+  port: 9000
 
 resources:
   requests:

--- a/config.py
+++ b/config.py
@@ -34,6 +34,7 @@ class Config(object):
     ZIPKIN_DSN = os.getenv("ZIPKIN_DSN", None)
     ZIPKIN_SAMPLE_RATE = int(os.getenv("ZIPKIN_SAMPLE_RATE", 0))
 
+    ACCESS_CONTROL_ALLOW_ORIGIN = os.getenv("ACCESS_CONTROL_ALLOW_ORIGIN", "*")
     ACCOUNT_SERVICE_URL = os.getenv('ACCOUNT_SERVICE_URL')
     ACCOUNT_SERVICE_LOG_OUT_URL = os.getenv('ACCOUNT_SERVICE_LOG_OUT_URL')
     EQ_URL = os.getenv('EQ_URL')
@@ -177,3 +178,4 @@ class TestingConfig(DevelopmentConfig):
     REQUESTS_POST_TIMEOUT = 99
     WTF_CSRF_TIME_LIMIT = int(os.getenv('WTF_CSRF_TIME_LIMIT', '3200'))
     SECURE_APP = bool(strtobool(os.getenv('SECURE_APP', "False")))
+    ACCESS_CONTROL_ALLOW_ORIGIN = os.getenv("ACCESS_CONTROL_ALLOW_ORIGIN", "http://localhost")

--- a/frontstage/controllers/collection_instrument_controller.py
+++ b/frontstage/controllers/collection_instrument_controller.py
@@ -37,7 +37,12 @@ def download_collection_instrument(collection_instrument_id, case_id, party_id):
     logger.info('Successfully downloaded collection instrument',
                 collection_instrument_id=collection_instrument_id,
                 party_id=party_id)
-    return response.content, response.headers.items()
+
+    headers = response.headers
+    acao = app.config['ACCESS_CONTROL_ALLOW_ORIGIN']
+    logger.debug(f"Setting Access-Control-Allow-Origin header to {acao}")
+    headers['Access-Control-Allow-Origin'] = acao
+    return response.content, headers.items()
 
 
 def get_collection_instrument(collection_instrument_id, collection_instrument_url, collection_instrument_auth):

--- a/tests/app/controllers/test_collection_instrument_controller.py
+++ b/tests/app/controllers/test_collection_instrument_controller.py
@@ -33,6 +33,16 @@ class TestCollectionInstrumentController(unittest.TestCase):
                 self.assertEqual(downloaded_ci['id'], collection_instrument_seft['id'])
 
     @patch('frontstage.controllers.case_controller.post_case_event')
+    def test_download_collection_instrument_access_control_header_set(self, _):
+        with responses.RequestsMock() as rsps:
+            rsps.add(rsps.GET, url_download_ci, json=collection_instrument_seft, status=200)
+            with app.app_context():
+                _, headers = collection_instrument_controller.download_collection_instrument(collection_instrument_seft['id'], case['id'], business_party['id'])
+
+                acao = dict(headers)['Access-Control-Allow-Origin']
+                self.assertEqual("http://localhost", acao)
+
+    @patch('frontstage.controllers.case_controller.post_case_event')
     def test_download_collection_instrument_fail(self, _):
         with responses.RequestsMock() as rsps:
             rsps.add(rsps.GET, url_download_ci, status=400)


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The final part of the security review suggested setting the access control origin header to our domain during SEFT downloads. 

I've matched the header to the ingress host when deployed in kubernetes and to * when run locally.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Additional header has been set. 

Test added to check error

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
1. Run the application
1. Ensure you have a respondent that is able to download a SEFT survey
1. Download a seft survey and check that the access control header is correct. (NB. I found this easier to check in firefox)


# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/STxexCYI/1834-s7-access-control-allow-origin-header-3
# Screenshots (if appropriate):
