### PR TITLE
Remove deprecated survey url

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -75,6 +75,7 @@
                 "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
                 "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==7.1.2"
         },
         "cryptography": {
@@ -99,6 +100,7 @@
                 "sha256:e993468c859d084d5579e2ebee101de8f5a27ce8e2159959b6673b418fd8c785",
                 "sha256:f118a95c7480f5be0df8afeb9a11bd199aa20afab7a96bcf20409b411a3a85f0"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==2.9.2"
         },
         "dateutils": {
@@ -113,6 +115,7 @@
                 "sha256:36c5e8e38d4369a08b6780b7f27d790a292b2b08eea01607865bf0936c558e01",
                 "sha256:f69c21288a962f4da86e56c4905b49d11aba7938d3d740e80d9e366ee4f1632d"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "ecdsa": {
@@ -120,6 +123,7 @@
                 "sha256:867ec9cf6df0b03addc8ef66b56359643cb5d0c1dc329df76ba7ecfe256c8061",
                 "sha256:8f12ac317f8a1318efa75757ef0a651abe12e51fc1af8838fb91079445227277"
             ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.15"
         },
         "email-validator": {
@@ -164,31 +168,31 @@
         },
         "gevent": {
             "hashes": [
-                "sha256:13ed2fa4a074c26fd60744a0757bf65004950554dfd9efd7c9deee1c241279af",
-                "sha256:1734f56ea545668780a4a283542a48d11298ab525c780a6001071f9d9d3c6880",
-                "sha256:1c2ad11663597d785e06daa8b65978a1536347a42bc840cf32823b54a0209d15",
-                "sha256:1cf6ed4f66ecc432939e4be9434a20dffcf3207fb0ab6bc0343e7a9ea76d233b",
-                "sha256:2504563f44bb188c1e48684e2ac7d2793f9f5b1e1cf119a8fdf8c36d2bf2eaf7",
-                "sha256:28a71ac05cf8a80897a8402f3193dab89bd225a3f0d27042d7352ec37156ba6a",
-                "sha256:29eefad2557138fb654ba5cedfb94055f959e6c9705f9983518195cbcf250cc6",
-                "sha256:3a1ec10c73fb70bd474cd778e4ab487c1375b7d93053c24db15acbda367e3734",
-                "sha256:42ff095288b1f335f7ea96a7812f378d843a034f4f0e604edc24a3dddb001106",
-                "sha256:52567bdc3769bc6df4693c1ea5ed1d82f825a6066835b405676ece437caf3fb9",
-                "sha256:5c07973cd9f5a73480a386d1805b6a6b94e69aa906ee42f84a0cba02619a19e3",
-                "sha256:653ad83784b872e78204c7e049b650c41c2e7ccb956142d8edc23a72e57ff80c",
-                "sha256:71438390acb6aea432d5f853d5dcb16fa2a6d3c1d2299a0ebe32eed03ac81547",
-                "sha256:765b39e502c76a1d77f743b821b7b1afe2a816848cf73a3606b1d5a91841cb9c",
-                "sha256:7cb2fedafb0a692a3f1a14ddb13cbb3283863a1dfc3b536452f5ac6dfb88317a",
-                "sha256:7f1e339b6d51c354fa904ec8233b994b53c7c339b81c0743e07f2921b299d787",
-                "sha256:867c77a6da601b2f4600b71b7f8663cadb8f11c31f294b3a49025cdbaf406110",
-                "sha256:8bea8dccb6ea671ecf00e1ba16d5275da8b78464082ac035e7391097513db777",
-                "sha256:ad01ef76f1d71cc7f2ce131cde6575ecc35d0a682a187a3229df3e977847f378",
-                "sha256:b53cf1a495c065df8b4b65d9f73a1cd7c5fa010955c0ed7bc5de196062099e41",
-                "sha256:f4a73e288fab042335b19f4b40407f8b44a40612626429943e37db23b40dd055",
-                "sha256:fe3ede0282c023b6ac1d0441402866488017b8f90f47691794441d0a18342a65"
+                "sha256:08de7d46923ab04529e70ff0601522bc7897b7bcef8ac40e8a9f906168518875",
+                "sha256:12276c30ce4d6da84eba674dade04b0cd80fb5808dbfdef01ba49b75d50b3816",
+                "sha256:1886197bcf8aea097c066e212c32a0aed9ad6a0ed245c124f3ff6b7dce7db354",
+                "sha256:1bb8330f1f86460b845b589eeea73b3e2dd52f84bee30178a8eaa0ddd61622a6",
+                "sha256:2436dfbc1f0cfa2c2fc8ec9e824dcc13f8501085c29605b4488c981456f12ed6",
+                "sha256:2756de36f56b33c46f6cc7146a74ba65afcd1471922c95b6771ce87b279d689c",
+                "sha256:2863c2899f0a379322cb07724c67eb608652e99ab5bdf5bfce936c9bf89f4a87",
+                "sha256:2f138b82527c520fff432e3aa9f606335d23eebfa1e8aeb0e36822e34a91afdd",
+                "sha256:4a3ee667456ccec0c1d215aeec8d150449d0a6da5d58ba2c6be741249af1f139",
+                "sha256:4a69373a07a0d4ff74401274d3b30aa47430e76d7e314f23bb9f399da1bbed6e",
+                "sha256:67820fd68ba14a38a1645261fc8f3530c4cfad6c45e29f40cc1dda8d5dcc17fb",
+                "sha256:899e1cdbfaa7aa0d53a430f2f4cb8d03c00db0ee94872ce2b4bb918817a719f0",
+                "sha256:9146860dd8ac0d0b675abc64025ea8dcd3d399de9290a8eec23bbed6d3993be4",
+                "sha256:91bfe6c3a2ec4d0027b30eb1aa678ab1f828c7d8961e64ac000d8c4a80fc8806",
+                "sha256:9c4601f67f26e534237d1cbaded3157b2a70a89e7760c819e8afb20e32878553",
+                "sha256:9cec7379b540cd7a8cdffec9ebe799943c07d0f575e6f222bf3515e7655544d7",
+                "sha256:a55ee5c388511362b1f886be57f06062334bc44b91ef215b997435d21901def7",
+                "sha256:ae6787acd68bd2f8d40e10fd8d031a5da2ac9dae6ddd35390cf4c18261a8bd38",
+                "sha256:bd261c12724e3e4be81ce4bd978c3ba47d31bd56444ba9f30332b8e7d4f09b81",
+                "sha256:c2c2e0e275b375941be80a174cd47b3ee20ccf457fbec31863808448ec4fcf59",
+                "sha256:de44cb7bf1f74043e7976f2dbf9780da7a99a2b58799675817d1df77ccfde519",
+                "sha256:f2932f05b8cfef3d7c285ddbd77008d642bd843c88625e1da4e96a643d4de885"
             ],
             "index": "pypi",
-            "version": "==20.5.1"
+            "version": "==20.5.2"
         },
         "greenlet": {
             "hashes": [
@@ -231,6 +235,7 @@
                 "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb",
                 "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.9"
         },
         "iso8601": {
@@ -247,6 +252,7 @@
                 "sha256:321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19",
                 "sha256:b12271b2047cb23eeb98c8b5622e2e5c5e9abd9784a153e9d8ef9cb4dd09d749"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.1.0"
         },
         "jinja2": {
@@ -254,6 +260,7 @@
                 "sha256:89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0",
                 "sha256:f0a4641d3cf955324a89c04f3d94663aa4d638abe8f733ecd3582848e1c37035"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==2.11.2"
         },
         "jwcrypto": {
@@ -299,6 +306,7 @@
                 "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7",
                 "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.1.1"
         },
         "phonenumbers": {
@@ -325,8 +333,19 @@
         },
         "pyasn1": {
             "hashes": [
+                "sha256:5c9414dcfede6e441f7e8f81b43b34e834731003427e5b09e4e00e3172a10f00",
                 "sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d",
-                "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba"
+                "sha256:99fcc3c8d804d1bc6d9a099921e39d827026409a58f2a720dcdb89374ea0c776",
+                "sha256:0458773cfe65b153891ac249bcf1b5f8f320b7c2ce462151f8fa74de8934becf",
+                "sha256:014c0e9976956a08139dc0712ae195324a75e142284d5f87f1a87ee1b068a359",
+                "sha256:fec3e9d8e36808a28efb59b489e4528c10ad0f480e57dcc32b4de5c9d8c9fdf3",
+                "sha256:08c3c53b75eaa48d71cf8c710312316392ed40899cb34710d092e96745a358b7",
+                "sha256:6e7545f1a61025a4e58bb336952c5061697da694db1cae97b116e9c46abcf7c8",
+                "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba",
+                "sha256:e89bf84b5437b532b0803ba5c9a5e054d21fec423a89952a74f87fa2c9b7bce2",
+                "sha256:03840c999ba71680a131cfaee6fab142e1ed9bbd9c693e285cc6aca0d555e576",
+                "sha256:7ab8a544af125fb704feadb008c99a88805126fb525280b2270bb25cc1d78a12",
+                "sha256:78fa6da68ed2727915c4767bb386ab32cdba863caa7dbe473eaae45f9959da86"
             ],
             "version": "==0.4.8"
         },
@@ -335,6 +354,7 @@
                 "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0",
                 "sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.20"
         },
         "pycryptodome": {
@@ -378,6 +398,7 @@
                 "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
                 "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.8.1"
         },
         "python-jose": {
@@ -454,6 +475,7 @@
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.15.0"
         },
         "structlog": {
@@ -468,6 +490,7 @@
             "hashes": [
                 "sha256:6516b4c55b656d6de92ec1f554a0f1ce758d42fc8d564385a26fb31e5842dc6e"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.4.11"
         },
         "urllib3": {
@@ -475,6 +498,7 @@
                 "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527",
                 "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.25.9"
         },
         "werkzeug": {
@@ -543,6 +567,7 @@
                 "sha256:f68bf937f113b88c866d090fea0bc52a098695173fc613b055a17ff0cf9683b6",
                 "sha256:fb55c182a3f7b84c1a2d6de5fa7b1a05d4660d866b91dbf8d74549c57a1499e8"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==5.1.0"
         }
     },
@@ -552,6 +577,7 @@
                 "sha256:4c17cea3e592c21b6e222f673868961bad77e1f985cb1694ed077475a89229c1",
                 "sha256:d8506842a3faf734b81599c8b98dcc423de863adcc1999248480b18bd31a0f38"
             ],
+            "markers": "python_version >= '3.5'",
             "version": "==2.4.1"
         },
         "attrs": {
@@ -559,6 +585,7 @@
                 "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
                 "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==19.3.0"
         },
         "certifi": {
@@ -577,7 +604,8 @@
         },
         "codecov": {
             "hashes": [
-                "sha256:2ebd639d8f621aabcce399e475b0302e436cb7e00e7724d1b2224bbf3f215a0c"
+                "sha256:2ebd639d8f621aabcce399e475b0302e436cb7e00e7724d1b2224bbf3f215a0c",
+                "sha256:e20e9fd7e530da14a22245862beb43a9fce9a6b998d9bf196c44d0207817b236"
             ],
             "index": "pypi",
             "version": "==2.1.3"
@@ -632,6 +660,7 @@
                 "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb",
                 "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.9"
         },
         "isort": {
@@ -639,6 +668,7 @@
                 "sha256:54da7e92468955c4fceacd0c86bd0ec997b0e1ee80d97f67c35a78b719dccab1",
                 "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==4.3.21"
         },
         "lazy-object-proxy": {
@@ -665,6 +695,7 @@
                 "sha256:efa1909120ce98bbb3777e8b6f92237f5d5c8ea6758efea36a473e1d38f7d3e4",
                 "sha256:f3900e8a5de27447acbf900b4750b0ddfd7ec1ea7fbaf11dfa911141bc522af0"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.4.3"
         },
         "mccabe": {
@@ -679,6 +710,7 @@
                 "sha256:558bb897a2232f5e4f8e2399089e35aecb746e1f9191b6584a151647e89267be",
                 "sha256:7818f596b1e87be009031c7653d01acc46ed422e6656b394b0f765ce66ed4982"
             ],
+            "markers": "python_version >= '3.5'",
             "version": "==8.3.0"
         },
         "packaging": {
@@ -686,6 +718,7 @@
                 "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8",
                 "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==20.4"
         },
         "pep8": {
@@ -700,6 +733,7 @@
                 "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
                 "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.13.1"
         },
         "py": {
@@ -707,6 +741,7 @@
                 "sha256:5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa",
                 "sha256:c20fdd83a5dbc0af9efd622bee9a5564e278f6380fffcacc43ba6f43db2813b0"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.8.1"
         },
         "pycodestyle": {
@@ -714,6 +749,7 @@
                 "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367",
                 "sha256:c58a7d2815e0e8d7972bf1803331fb0152f867bd89adf8a01dfd55085434192e"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.6.0"
         },
         "pyflakes": {
@@ -721,6 +757,7 @@
                 "sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92",
                 "sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.2.0"
         },
         "pylint": {
@@ -743,6 +780,7 @@
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
                 "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.4.7"
         },
         "pytest": {
@@ -790,6 +828,7 @@
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.15.0"
         },
         "toml": {
@@ -804,14 +843,15 @@
                 "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527",
                 "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.25.9"
         },
         "wcwidth": {
             "hashes": [
-                "sha256:cafe2186b3c009a04067022ce1dcd79cb38d8d65ee4f4791b8888d6599d1bbe1",
-                "sha256:ee73862862a156bf77ff92b09034fc4825dd3af9cf81bc5b360668d425f3c5f1"
+                "sha256:3de2e41158cb650b91f9654cbf9a3e053cee0719c9df4ddc11e4b568669e9829",
+                "sha256:b651b6b081476420e4e9ae61239ac4c1b49d0c5ace42b2e81dc2ff49ed50c566"
             ],
-            "version": "==0.1.9"
+            "version": "==0.2.2"
         },
         "wrapt": {
             "hashes": [

--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.0.18
+appVersion: 2.0.19

--- a/frontstage/routes.md
+++ b/frontstage/routes.md
@@ -1,4 +1,4 @@
-# ras frontstage routes
+# ras-frontstage routes
 
 This page documents the ras frontstage routes that can be hit.
 
@@ -105,13 +105,10 @@ To reset a password
 
 ## Surveys endpoints
 
-`surveys/access_survey` - DEPRECATED. Will be removed in a future release
-
-* GET request to this endpoint will allow the respondent to upload and download a survey.
-
 `surveys/access-survey` - Replaces access_survey
 
-* GET request to this endpoint will allow the respondent to upload and download a survey.
+* GET request to this endpoint will allow the respondent to upload and download a survey if the ci_type is a SEFT.
+If the ci_type is EQ then it'll redirect the user to EQ to complete a questionnaire.
 
 `surveys/add-survey`
 
@@ -123,7 +120,8 @@ To reset a password
 
 `surveys/add-survey/add-survey-submit`
 
-* GET request to this endpoint will assign the new survey to the respondent.  Called by the `surveys/add-survey/confirm-organisation-survey` page.
+* GET request to this endpoint will assign the new survey to the respondent.
+Called by the `surveys/add-survey/confirm-organisation-survey` page.
 
 `surveys/download_survey` - DEPRECATED. Will be removed in a future release
 

--- a/frontstage/views/surveys/access_survey.py
+++ b/frontstage/views/surveys/access_survey.py
@@ -11,7 +11,6 @@ from frontstage.views.surveys import surveys_bp
 logger = wrap_logger(logging.getLogger(__name__))
 
 
-@surveys_bp.route('/access_survey', methods=['GET'])  # Deprecated , will be removed when no longer in use
 @surveys_bp.route('/access-survey', methods=['GET'])
 @jwt_authorization(request)
 def access_survey(session):

--- a/tests/integration/test_generate_eq.py
+++ b/tests/integration/test_generate_eq.py
@@ -52,15 +52,12 @@ class TestGenerateEqURL(unittest.TestCase):
         mock_request.get(url_get_respondent_party, status_code=200, json=respondent_party)
 
         # When the generate-eq-url is called
-        urls = ['access_survey', 'access-survey']
-        for url in urls:
-            with self.subTest(url=url):
-                response = self.app.get(f"/surveys/{url}?case_id={case['id']}&business_party_id={business_party['id']}"
-                                        f"&survey_short_name={survey_eq['shortName']}&ci_type=EQ", headers=self.headers)
+        response = self.app.get(f"/surveys/access-survey?case_id={case['id']}&business_party_id={business_party['id']}"
+                                f"&survey_short_name={survey_eq['shortName']}&ci_type=EQ", headers=self.headers)
 
-                # An eq url is generated
-                self.assertEqual(response.status_code, 302)
-                self.assertIn("https://eq-test/session?token=", response.location)
+        # An eq url is generated
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("https://eq-test/session?token=", response.location)
 
     @requests_mock.mock()
     @patch('frontstage.controllers.party_controller.is_respondent_enrolled')
@@ -70,14 +67,11 @@ class TestGenerateEqURL(unittest.TestCase):
         mock_request.get(url_get_case, json=completed_case)
 
         # When the generate-eq-url is called
-        urls = ['access_survey', 'access-survey']
-        for url in urls:
-            with self.subTest(url=url):
-                response = self.app.get(f"/surveys/{url}?case_id={completed_case['id']}&business_party_id={business_party['id']}"
-                                        f"&survey_short_name={survey_eq['shortName']}&ci_type=EQ", headers=self.headers, follow_redirects=True)
+        response = self.app.get(f"/surveys/access-survey?case_id={completed_case['id']}&business_party_id={business_party['id']}"
+                                f"&survey_short_name={survey_eq['shortName']}&ci_type=EQ", headers=self.headers, follow_redirects=True)
 
-                # A 403 is returned
-                self.assertEqual(response.status_code, 403)
+        # A 403 is returned
+        self.assertEqual(response.status_code, 403)
 
     @requests_mock.mock()
     def test_generate_eq_url_seft(self, mock_request):

--- a/tests/integration/views/surveys/test_access_survey.py
+++ b/tests/integration/views/surveys/test_access_survey.py
@@ -94,14 +94,12 @@ class TestAccessSurvey(unittest.TestCase):
             "business_party": business_party
         }
         get_case_data.return_value = case_data
-        urls = ['access_survey', 'access-survey']
-        for url in urls:
-            with self.subTest(url=url):
-                response = self.app.get(f'/surveys/{url}?case_id=8cdc01f9-656a-4715-a148-ffed0dbe1b04&business_party_id=0008279d-9425-4e28-897d-bfd876aa7f3f&'
-                                        'survey_short_name=Bricks&ci_type=SEFT', headers=self.headers, follow_redirects=True)
 
-                self.assertEqual(response.status_code, 500)
-                self.assertTrue('An error has occurred'.encode() in response.data)
+        response = self.app.get('/surveys/access-survey?case_id=8cdc01f9-656a-4715-a148-ffed0dbe1b04&business_party_id=0008279d-9425-4e28-897d-bfd876aa7f3f&'
+                                'survey_short_name=Bricks&ci_type=SEFT', headers=self.headers, follow_redirects=True)
+
+        self.assertEqual(response.status_code, 500)
+        self.assertTrue('An error has occurred'.encode() in response.data)
 
     @patch('frontstage.controllers.case_controller.get_case_data')
     def test_access_survey_missing_business_party_from_case_data(self, get_case_data):
@@ -112,51 +110,36 @@ class TestAccessSurvey(unittest.TestCase):
         }
         get_case_data.return_value = case_data
 
-        urls = ['access_survey', 'access-survey']
-        for url in urls:
-            with self.subTest(url=url):
-                response = self.app.get(f'/surveys/{url}?case_id=8cdc01f9-656a-4715-a148-ffed0dbe1b04&business_party_id=0008279d-9425-4e28-897d-bfd876aa7f3f&'
-                                        'survey_short_name=Bricks&ci_type=SEFT', headers=self.headers, follow_redirects=True)
+        response = self.app.get('/surveys/access-survey?case_id=8cdc01f9-656a-4715-a148-ffed0dbe1b04&business_party_id=0008279d-9425-4e28-897d-bfd876aa7f3f&'
+                                'survey_short_name=Bricks&ci_type=SEFT', headers=self.headers, follow_redirects=True)
 
-                self.assertEqual(response.status_code, 500)
-                self.assertTrue('An error has occurred'.encode() in response.data)
+        self.assertEqual(response.status_code, 500)
+        self.assertTrue('An error has occurred'.encode() in response.data)
 
     def test_access_survey_without_request_arg_case_id(self):
-        urls = ['access_survey', 'access-survey']
-        for url in urls:
-            with self.subTest(url=url):
-                response = self.app.get(f'/surveys/{url}?business_party_id=0008279d-9425-4e28-897d-bfd876aa7f3f&'
-                                        'survey_short_name=Bricks&ci_type=SEFT', headers=self.headers, follow_redirects=True)
+        response = self.app.get('/surveys/access-survey?business_party_id=0008279d-9425-4e28-897d-bfd876aa7f3f&'
+                                'survey_short_name=Bricks&ci_type=SEFT', headers=self.headers, follow_redirects=True)
 
-                self.assertEqual(response.status_code, 400)
-                self.assertTrue('An error has occurred'.encode() in response.data)
+        self.assertEqual(response.status_code, 400)
+        self.assertTrue('An error has occurred'.encode() in response.data)
 
     def test_access_survey_missing_request_arg_business_party_id(self):
-        urls = ['access_survey', 'access-survey']
-        for url in urls:
-            with self.subTest(url=url):
-                response = self.app.get(f'/surveys/{url}?case_id=8cdc01f9-656a-4715-a148-ffed0dbe1b04&'
-                                        'survey_short_name=Bricks&ci_type=SEFT', headers=self.headers)
+        response = self.app.get('/surveys/access-survey?case_id=8cdc01f9-656a-4715-a148-ffed0dbe1b04&'
+                                'survey_short_name=Bricks&ci_type=SEFT', headers=self.headers)
 
-                self.assertEqual(response.status_code, 400)
-                self.assertTrue('An error has occurred'.encode() in response.data)
+        self.assertEqual(response.status_code, 400)
+        self.assertTrue('An error has occurred'.encode() in response.data)
 
     def test_access_survey_missing_request_arg_survey_short_name(self):
-        urls = ['access_survey', 'access-survey']
-        for url in urls:
-            with self.subTest(url=url):
-                response = self.app.get(f'/surveys/{url}?case_id=8cdc01f9-656a-4715-a148-ffed0dbe1b04&business_party_id=0008279d-9425-4e28-897d-bfd876aa7f3f&'
-                                        'ci_type=SEFT', headers=self.headers, follow_redirects=True)
+        response = self.app.get('/surveys/access-survey?case_id=8cdc01f9-656a-4715-a148-ffed0dbe1b04&business_party_id=0008279d-9425-4e28-897d-bfd876aa7f3f&'
+                                'ci_type=SEFT', headers=self.headers, follow_redirects=True)
 
-                self.assertEqual(response.status_code, 400)
-                self.assertTrue('An error has occurred'.encode() in response.data)
+        self.assertEqual(response.status_code, 400)
+        self.assertTrue('An error has occurred'.encode() in response.data)
 
     def test_access_survey_missing_request_arg_ci_type(self):
-        urls = ['access_survey', 'access-survey']
-        for url in urls:
-            with self.subTest(url=url):
-                response = self.app.get(f'/surveys/{url}?case_id=8cdc01f9-656a-4715-a148-ffed0dbe1b04&business_party_id=0008279d-9425-4e28-897d-bfd876aa7f3f&'
-                                        'survey_short_name=Bricks', headers=self.headers, follow_redirects=True)
+        response = self.app.get('/surveys/access-survey?case_id=8cdc01f9-656a-4715-a148-ffed0dbe1b04&business_party_id=0008279d-9425-4e28-897d-bfd876aa7f3f&'
+                                'survey_short_name=Bricks', headers=self.headers, follow_redirects=True)
 
-                self.assertEqual(response.status_code, 400)
-                self.assertTrue('An error has occurred'.encode() in response.data)
+        self.assertEqual(response.status_code, 400)
+        self.assertTrue('An error has occurred'.encode() in response.data)

--- a/tests/integration/views/surveys/test_access_survey.py
+++ b/tests/integration/views/surveys/test_access_survey.py
@@ -6,6 +6,9 @@ from frontstage import app
 from tests.integration.mocked_services import (collection_exercise, collection_instrument_seft, survey, business_party,
                                                encoded_jwt_token, encrypted_enrolment_code)
 
+party_id = '0008279d-9425-4e28-897d-bfd876aa7f3f'
+case_id = '8cdc01f9-656a-4715-a148-ffed0dbe1b04'
+
 
 class TestAccessSurvey(unittest.TestCase):
 
@@ -42,32 +45,25 @@ class TestAccessSurvey(unittest.TestCase):
         }
         get_case_data.return_value = case_data
 
-        urls = ['access_survey', 'access-survey']
-        for url in urls:
-            with self.subTest(url=url):
+        response = self.app.get(f'/surveys/access-survey?case_id={case_id}&business_party_id={party_id}&'
+                                'survey_short_name=Bricks&ci_type=SEFT', headers=self.headers)
 
-                response = self.app.get(f'/surveys/{url}?case_id=8cdc01f9-656a-4715-a148-ffed0dbe1b04&business_party_id=0008279d-9425-4e28-897d-bfd876aa7f3f&'
-                                        'survey_short_name=Bricks&ci_type=SEFT', headers=self.headers)
-
-                self.assertEqual(response.status_code, 200)
-                self.assertIn(survey['shortName'].encode(), response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(survey['shortName'].encode(), response.data)
 
     @patch('frontstage.controllers.case_controller.get_case_data')
-    def test_access_survey_missing_collection_intrument_from_case_data(self, get_case_data):
+    def test_access_survey_missing_collection_instrument_from_case_data(self, get_case_data):
         case_data = {
             "collection_exercise": collection_exercise,
             "survey": survey,
             "business_party": business_party
         }
         get_case_data.return_value = case_data
-        urls = ['access_survey', 'access-survey']
-        for url in urls:
-            with self.subTest(url=url):
-                response = self.app.get(f'/surveys/{url}?case_id=8cdc01f9-656a-4715-a148-ffed0dbe1b04&business_party_id=0008279d-9425-4e28-897d-bfd876aa7f3f&'
-                                        'survey_short_name=Bricks&ci_type=SEFT', headers=self.headers, follow_redirects=True)
+        response = self.app.get(f'/surveys/access-survey?case_id={case_id}&business_party_id={party_id}&'
+                                'survey_short_name=Bricks&ci_type=SEFT', headers=self.headers, follow_redirects=True)
 
-                self.assertEqual(response.status_code, 500)
-                self.assertTrue('An error has occurred'.encode() in response.data)
+        self.assertEqual(response.status_code, 500)
+        self.assertTrue('An error has occurred'.encode() in response.data)
 
     @patch('frontstage.controllers.case_controller.get_case_data')
     def test_access_survey_missing_collection_exercise_from_case_data(self, get_case_data):
@@ -77,14 +73,11 @@ class TestAccessSurvey(unittest.TestCase):
             "business_party": business_party
         }
         get_case_data.return_value = case_data
-        urls = ['access_survey', 'access-survey']
-        for url in urls:
-            with self.subTest(url=url):
-                response = self.app.get(f'/surveys/{url}?case_id=8cdc01f9-656a-4715-a148-ffed0dbe1b04&business_party_id=0008279d-9425-4e28-897d-bfd876aa7f3f&'
-                                        'survey_short_name=Bricks&ci_type=SEFT', headers=self.headers, follow_redirects=True)
+        response = self.app.get(f'/surveys/access-survey?case_id={case_id}&business_party_id={party_id}&'
+                                'survey_short_name=Bricks&ci_type=SEFT', headers=self.headers, follow_redirects=True)
 
-                self.assertEqual(response.status_code, 500)
-                self.assertTrue('An error has occurred'.encode() in response.data)
+        self.assertEqual(response.status_code, 500)
+        self.assertTrue('An error has occurred'.encode() in response.data)
 
     @patch('frontstage.controllers.case_controller.get_case_data')
     def test_access_survey_missing_survey_from_case_data(self, get_case_data):
@@ -95,7 +88,7 @@ class TestAccessSurvey(unittest.TestCase):
         }
         get_case_data.return_value = case_data
 
-        response = self.app.get('/surveys/access-survey?case_id=8cdc01f9-656a-4715-a148-ffed0dbe1b04&business_party_id=0008279d-9425-4e28-897d-bfd876aa7f3f&'
+        response = self.app.get(f'/surveys/access-survey?case_id={case_id}&business_party_id={party_id}&'
                                 'survey_short_name=Bricks&ci_type=SEFT', headers=self.headers, follow_redirects=True)
 
         self.assertEqual(response.status_code, 500)
@@ -110,35 +103,35 @@ class TestAccessSurvey(unittest.TestCase):
         }
         get_case_data.return_value = case_data
 
-        response = self.app.get('/surveys/access-survey?case_id=8cdc01f9-656a-4715-a148-ffed0dbe1b04&business_party_id=0008279d-9425-4e28-897d-bfd876aa7f3f&'
+        response = self.app.get(f'/surveys/access-survey?case_id={case_id}&business_party_id={party_id}&'
                                 'survey_short_name=Bricks&ci_type=SEFT', headers=self.headers, follow_redirects=True)
 
         self.assertEqual(response.status_code, 500)
         self.assertTrue('An error has occurred'.encode() in response.data)
 
     def test_access_survey_without_request_arg_case_id(self):
-        response = self.app.get('/surveys/access-survey?business_party_id=0008279d-9425-4e28-897d-bfd876aa7f3f&'
+        response = self.app.get(f'/surveys/access-survey?business_party_id={party_id}&'
                                 'survey_short_name=Bricks&ci_type=SEFT', headers=self.headers, follow_redirects=True)
 
         self.assertEqual(response.status_code, 400)
         self.assertTrue('An error has occurred'.encode() in response.data)
 
     def test_access_survey_missing_request_arg_business_party_id(self):
-        response = self.app.get('/surveys/access-survey?case_id=8cdc01f9-656a-4715-a148-ffed0dbe1b04&'
+        response = self.app.get(f'/surveys/access-survey?case_id={case_id}&'
                                 'survey_short_name=Bricks&ci_type=SEFT', headers=self.headers)
 
         self.assertEqual(response.status_code, 400)
         self.assertTrue('An error has occurred'.encode() in response.data)
 
     def test_access_survey_missing_request_arg_survey_short_name(self):
-        response = self.app.get('/surveys/access-survey?case_id=8cdc01f9-656a-4715-a148-ffed0dbe1b04&business_party_id=0008279d-9425-4e28-897d-bfd876aa7f3f&'
+        response = self.app.get(f'/surveys/access-survey?case_id={case_id}&business_party_id={party_id}&'
                                 'ci_type=SEFT', headers=self.headers, follow_redirects=True)
 
         self.assertEqual(response.status_code, 400)
         self.assertTrue('An error has occurred'.encode() in response.data)
 
     def test_access_survey_missing_request_arg_ci_type(self):
-        response = self.app.get('/surveys/access-survey?case_id=8cdc01f9-656a-4715-a148-ffed0dbe1b04&business_party_id=0008279d-9425-4e28-897d-bfd876aa7f3f&'
+        response = self.app.get(f'/surveys/access-survey?case_id={case_id}&business_party_id={party_id}&'
                                 'survey_short_name=Bricks', headers=self.headers, follow_redirects=True)
 
         self.assertEqual(response.status_code, 400)


### PR DESCRIPTION
# Motivation and Context
A while ago we moved a bunch of urls from having _ to -.  To reduce the risk we allowed both versions for a while to make sure nothing was using the old version.

That was 10 months ago and after looking at preprod, everything uses '-' so we should start removing these extra urls and the extra test code to handle both cases.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):
