### PR TITLE
Remove upload_failed endpoint and update dates

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.0.18
+appVersion: 2.0.19

--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.0.20
+appVersion: 2.0.21

--- a/frontstage/routes.md
+++ b/frontstage/routes.md
@@ -141,11 +141,7 @@ To reset a password
 
 * POST request to this endpoint will upload a collection instrument to the collection instrument service.
 
-`surveys/upload_failed` - DEPRECATED. Will be removed in a future release.
-
-* GET request to this endpoint will render an error page if it fails to upload the collection instrument.
-
-`surveys/upload-failed` - Replaces upload_failed
+`surveys/upload-failed`
 
 * GET request to this endpoint will render an error page if it fails to upload the collection instrument.
 

--- a/frontstage/views/surveys/upload_survey_failed.py
+++ b/frontstage/views/surveys/upload_survey_failed.py
@@ -11,7 +11,6 @@ from frontstage.views.surveys import surveys_bp
 logger = wrap_logger(logging.getLogger(__name__))
 
 
-@surveys_bp.route('/upload_failed', methods=['GET'])  # Deprecated. Will be removed when nolonger used
 @surveys_bp.route('/upload-failed', methods=['GET'])
 @jwt_authorization(request)
 def upload_failed(session):

--- a/tests/integration/views/surveys/test_upload_survey_failed.py
+++ b/tests/integration/views/surveys/test_upload_survey_failed.py
@@ -29,67 +29,49 @@ class TestUploadSurveyFailed(unittest.TestCase):
     @patch('frontstage.controllers.case_controller.get_case_data')
     def test_upload_failed_no_error_info(self, get_case_data):
         get_case_data.return_value = self.case_data
-        urls = ['upload_failed', 'upload-failed']
-        for url in urls:
-            with self.subTest(url=url):
-                response = self.app.get(f'/surveys/{url}?case_id={case["id"]}&business_party_id={business_party["id"]}&survey_short_name={survey["shortName"]}')
+        response = self.app.get(f'/surveys/upload-failed?case_id={case["id"]}&business_party_id={business_party["id"]}&survey_short_name={survey["shortName"]}')
 
-                self.assertEqual(response.status_code, 200)
-                self.assertTrue("Something went wrong".encode() in response.data)
-                self.assertTrue("Please try uploading your spreadsheet again".encode() in response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue("Something went wrong".encode() in response.data)
+        self.assertTrue("Please try uploading your spreadsheet again".encode() in response.data)
 
     @patch('frontstage.controllers.case_controller.get_case_data')
     def test_upload_failed_type_error_info(self, get_case_data):
         get_case_data.return_value = self.case_data
-        urls = ['upload_failed', 'upload-failed']
-        for url in urls:
-            with self.subTest(url=url):
-                response = self.app.get(f'/surveys/{url}?case_id={case["id"]}&business_party_id={business_party["id"]}&survey_short_name={survey["shortName"]}'
-                                        f'&error_info=type')
+        response = self.app.get(f'/surveys/upload-failed?case_id={case["id"]}&business_party_id={business_party["id"]}&survey_short_name={survey["shortName"]}'
+                                f'&error_info=type')
 
-                self.assertEqual(response.status_code, 200)
-                self.assertTrue("Error uploading - incorrect file type".encode() in response.data)
-                self.assertTrue("The spreadsheet must be in .xls or .xlsx format".encode() in response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue("Error uploading - incorrect file type".encode() in response.data)
+        self.assertTrue("The spreadsheet must be in .xls or .xlsx format".encode() in response.data)
 
     @patch('frontstage.controllers.case_controller.get_case_data')
     def test_upload_failed_charLimit_error_info(self, get_case_data):
         get_case_data.return_value = self.case_data
-        urls = ['upload_failed', 'upload-failed']
-        for url in urls:
-            with self.subTest(url=url):
-                response = self.app.get(f'/surveys/{url}?case_id={case["id"]}&business_party_id={business_party["id"]}&survey_short_name={survey["shortName"]}'
-                                        f'&error_info=charLimit')
+        response = self.app.get(f'/surveys/upload-failed?case_id={case["id"]}&business_party_id={business_party["id"]}&survey_short_name={survey["shortName"]}'
+                                f'&error_info=charLimit')
 
-                self.assertEqual(response.status_code, 200)
-                self.assertTrue("Error uploading - file name too long".encode() in response.data)
-                self.assertTrue("The file name of your spreadsheet must be less than 50 characters long".encode() in response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue("Error uploading - file name too long".encode() in response.data)
+        self.assertTrue("The file name of your spreadsheet must be less than 50 characters long".encode() in response.data)
 
     @patch('frontstage.controllers.case_controller.get_case_data')
     def test_upload_failed_size_error_info(self, get_case_data):
         get_case_data.return_value = self.case_data
-        urls = ['upload_failed', 'upload-failed']
-        for url in urls:
-            with self.subTest(url=url):
-                response = self.app.get(f'/surveys/{url}?case_id={case["id"]}&business_party_id={business_party["id"]}&survey_short_name={survey["shortName"]}'
-                                        f'&error_info=size')
+        response = self.app.get(f'/surveys/upload-failed?case_id={case["id"]}&business_party_id={business_party["id"]}&survey_short_name={survey["shortName"]}'
+                                f'&error_info=size')
 
-                self.assertEqual(response.status_code, 200)
-                self.assertTrue("Error uploading - file size too large".encode() in response.data)
-                self.assertTrue("The spreadsheet must be smaller than 20MB in size".encode() in response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue("Error uploading - file size too large".encode() in response.data)
+        self.assertTrue("The spreadsheet must be smaller than 20MB in size".encode() in response.data)
 
     def test_upload_survey_failed_with_no_business_party_id_fails(self):
-        urls = ['upload_failed', 'upload-failed']
-        for url in urls:
-            with self.subTest(url=url):
-                response = self.app.get(f'/surveys/{url}?case_id={case["id"]}&survey_short_name={survey["shortName"]}&error_info=size')
+        response = self.app.get(f'/surveys/upload-failed?case_id={case["id"]}&survey_short_name={survey["shortName"]}&error_info=size')
 
-                self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 400)
 
     def test_upload_survey_failed_with_no_survey_short_name_fails(self):
-        urls = ['upload_failed', 'upload-failed']
-        for url in urls:
-            with self.subTest(url=url):
-                response = self.app.get(f'/surveys/{url}?case_id={case["id"]}&business_party_id={business_party["id"]}'
-                                        f'&error_info=size')
+        response = self.app.get(f'/surveys/upload-failed?case_id={case["id"]}&business_party_id={business_party["id"]}'
+                                f'&error_info=size')
 
-                self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 400)


### PR DESCRIPTION
# Motivation and Context
A while ago we moved a bunch of urls from having _ to -. To reduce the risk we allowed both versions for a while to make sure nothing was using the old version.

That was 10 months ago and after looking at preprod, everything uses '-' so we should start removing these extra urls and the extra test code to handle both cases.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):
