### PR TITLE
Using multi-stage build in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,18 @@
-FROM python:3.8-slim
-
+FROM python:3.8-slim AS build
 RUN apt update && apt install -y build-essential curl
-RUN pip install 'pipenv==2018.11.26'
+RUN pip install pipenv
 
+WORKDIR /build
+COPY Pipfile Pipfile.lock /build/
+RUN bash -c 'PIPENV_VENV_IN_PROJECT=1 pipenv install --deploy --system'
+
+FROM python:3.8-slim AS application
 WORKDIR /app
+COPY --from=build /build /app/
+COPY . /app
+
 EXPOSE 8082
 CMD ["python", "run.py"]
 
 HEALTHCHECK --interval=1m30s --timeout=10s --retries=3 \
   CMD curl -f http://localhost:8082/info || exit 1
-
-COPY . /app
-RUN pipenv install --deploy --system

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,19 @@
 FROM python:3.8-slim AS build
 RUN apt update && apt install -y build-essential curl
-RUN pip install pipenv
+ENV PYROOT /pyroot
+ENV PYTHONUSERBASE $PYROOT
 
-WORKDIR /build
-COPY Pipfile Pipfile.lock /build/
-RUN bash -c 'PIPENV_VENV_IN_PROJECT=1 pipenv install --deploy --system'
+COPY Pipfile Pipfile.lock ./
+RUN pip install pipenv
+RUN PIP_USER=1 PIP_IGNORE_INSTALLED=1 pipenv install --deploy --system
 
 FROM python:3.8-slim AS application
+ENV PYROOT /pyroot
+ENV PYTHONUSERBASE $PYROOT
+ENV PYTHONPATH $PYTHONPATH:/app
+
 WORKDIR /app
-COPY --from=build /build /app/
+COPY --from=build $PYROOT/lib/ $PYROOT/lib/
 COPY . /app
 
 EXPOSE 8082

--- a/_infra/docker/Dockerfile
+++ b/_infra/docker/Dockerfile
@@ -1,13 +1,16 @@
 # Dockerfile specifically for kubernetes
-FROM python:3.8-slim
-
+FROM python:3.8-slim AS build
 RUN apt update && apt install -y build-essential curl gunicorn
 RUN pip install pipenv
 
-WORKDIR /app
+WORKDIR /build
+COPY Pipfile Pipfile.lock /build/
+RUN bash -c 'PIPENV_VENV_IN_PROJECT=1 pipenv install --deploy --system'
 
+FROM python:3.8-slim AS application
+WORKDIR /app
+COPY --from=build /build /app/
 COPY . /app
-RUN pipenv install --deploy --system
 
 EXPOSE 8082
 CMD ["gunicorn", "-c", "gunicorn.py", "frontstage:app"]

--- a/_infra/docker/Dockerfile
+++ b/_infra/docker/Dockerfile
@@ -1,15 +1,20 @@
 # Dockerfile specifically for kubernetes
 FROM python:3.8-slim AS build
 RUN apt update && apt install -y build-essential curl gunicorn
-RUN pip install pipenv
+ENV PYROOT /pyroot
+ENV PYTHONUSERBASE $PYROOT
 
-WORKDIR /build
-COPY Pipfile Pipfile.lock /build/
-RUN bash -c 'PIPENV_VENV_IN_PROJECT=1 pipenv install --deploy --system'
+COPY Pipfile Pipfile.lock ./
+RUN pip install pipenv
+RUN PIP_USER=1 PIP_IGNORE_INSTALLED=1 pipenv install --deploy --system
 
 FROM python:3.8-slim AS application
+ENV PYROOT /pyroot
+ENV PYTHONUSERBASE $PYROOT
+ENV PYTHONPATH $PYTHONPATH:/app
+
 WORKDIR /app
-COPY --from=build /build /app/
+COPY --from=build $PYROOT/lib/ $PYROOT/lib/
 COPY . /app
 
 EXPOSE 8082

--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.1.1
+appVersion: 2.1.2


### PR DESCRIPTION
# Motivation and Context
Converted Dockerfiles to multi-stage build: this allows the new release of pipenv to build from our existing Pipfile and Pipfile.lock, with the added bonus of cutting the image size in half.

If this is acceptable, then we won't need to switch to requirements files yet, and we can take our time resolving the question of how best to manage python packages.

<!--- Why is this change required? What problem does it solve? -->

# What has changed
Refactored Dockerfile and _infra/docker/Dockerfile
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
**Local**:
- `make unit-tests`
- `make integration-tests`

**Dev**:
- in a dev cluster, spin up the frontstage pod with the image `multistage`
- run acceptance tests

<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
https://trello.com/c/PQZNp4Wo
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):
