### PR TITLE
Moved availaibility message inside grid

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -18,5 +18,5 @@ version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.1.6
+appVersion: 2.1.7
 

--- a/frontstage/templates/layouts/_base.html
+++ b/frontstage/templates/layouts/_base.html
@@ -50,14 +50,15 @@
 {% from "components/panel/_macro.njk" import onsPanel %}
 
 {%- block pageContent %}
+  <div class="page__container container">
     {% if availability_message %}
       {{ 
           onsPanel({
-              "body": availability_message
+              "body": availability_message,
+              "classes": "u-mt-l"
           }) 
       }}
     {% endif %}
-  <div class="page__container container">
     <div class="grid">
       <div class="grid__col col-12@m u-mt-s">
         <main id="main-content" class="page__main {{ pageClasses }}">


### PR DESCRIPTION
# Motivation and Context
Availaibility message is outside grid and so displays incorrectly.

# What has changed
Moved inside grid.

# Screenshots (if appropriate):
Wrong:
![image](https://user-images.githubusercontent.com/1015442/86465603-e61a1800-bd29-11ea-9b24-bd734b9c0176.png)

Correct:
![image](https://user-images.githubusercontent.com/1015442/86465690-0ea21200-bd2a-11ea-8a71-508a209ef4b7.png)
