### PR TITLE
Remove deprecated endpoint

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.1.14
+appVersion: 2.1.15

--- a/frontstage/common/message_helper.py
+++ b/frontstage/common/message_helper.py
@@ -95,9 +95,9 @@ def get_formatted_date(datetime_string, string_format='%Y-%m-%d %H:%M:%S'):
     time = convert_to_bst(datetime_parsed).strftime('%H:%M')
 
     if time_difference.days == 0:
-        return "Today at {}".format(time)
+        return f"Today at {time}"
     elif time_difference.days == -1:
-        return "Yesterday at {}".format(time)
+        return f"Yesterday at {time}"
     return "{} {}".format(datetime_parsed.strftime('%d %b %Y'), time)
 
 

--- a/frontstage/controllers/conversation_controller.py
+++ b/frontstage/controllers/conversation_controller.py
@@ -77,6 +77,14 @@ def get_conversation_list(params):
 
 
 def send_message(message_json):
+    """
+    Creates a message in the secure-message service
+
+    :param message_json: A block of JSON representing a message
+    :type message_json: dict
+    :raises ApiError: Raised when secure-message returns a non-200 status code
+    :return: A json response from secure-message
+    """
     party_id = json.loads(message_json).get('msg_from')
     logger.info('Sending message', party_id=party_id)
 

--- a/frontstage/controllers/iac_controller.py
+++ b/frontstage/controllers/iac_controller.py
@@ -12,6 +12,14 @@ logger = wrap_logger(logging.getLogger(__name__))
 
 
 def get_iac_from_enrolment(enrolment_code):
+    """
+    Gets enrolment details from IAC service for a given enrolment code
+
+    :param enrolment_code: An enrolment code
+    :type enrolment_code: str
+    :raises ApiError: Raised when IAC service returns a 401 status
+    :return: A dict with the IAC details if it exists and is active, and None otherwise
+    """
     bound_logger = logger.bind(enrolment_code=enrolment_code)
     bound_logger.info('Attempting to retrieve IAC')
     url = f"{app.config['IAC_URL']}/iacs/{enrolment_code}"

--- a/frontstage/views/secure_messaging/create_message.py
+++ b/frontstage/views/secure_messaging/create_message.py
@@ -26,11 +26,11 @@ def create_message(session):
         sent_message = _send_new_message(party_id, survey, ru_ref)
         thread_url = url_for("secure_message_bp.view_conversation",
                              thread_id=sent_message['thread_id']) + "#latest-message"
-        flash(Markup('Message sent. <a href={}>View Message</a>'.format(thread_url)))
+        flash(Markup(f'Message sent. <a href={thread_url}>View Message</a>'))
         return redirect(url_for('secure_message_bp.view_conversation_list'))
 
     else:
-        unread_message_count = { 'unread_message_count': conversation_controller.try_message_count_from_session(session) }
+        unread_message_count = {'unread_message_count': conversation_controller.try_message_count_from_session(session)}
         return render_template('secure-messages/secure-messages-view.html',
                                ru_ref=ru_ref, survey=survey,
                                form=form, errors=form.errors, message={},

--- a/frontstage/views/secure_messaging/message_get.py
+++ b/frontstage/views/secure_messaging/message_get.py
@@ -15,27 +15,19 @@ from frontstage.views.secure_messaging import secure_message_bp
 logger = wrap_logger(logging.getLogger(__name__))
 
 
-@secure_message_bp.route('/thread/<thread_id>', methods=['GET', 'POST'])
 @secure_message_bp.route('/threads/<thread_id>', methods=['GET', 'POST'])
 @jwt_authorization(request)
 def view_conversation(session, thread_id):
-    """Endpoint to view conversations by thread_id
-
-    NOTE: /thread/<thread_id> endpoint is there for compatability reasons.  All new emails use /threads/<thread_id>.
-    From September 2019 onwards, it should be safe to remove the /thread endpoint (just check the analytics to make
-    sure that it's a very small number of people trying to hit it first!).
-    """
+    """Endpoint to view conversations by thread_id"""
     party_id = session.get_party_id()
     logger.info("Getting conversation", thread_id=thread_id, party_id=party_id)
-    # TODO, do we really want to do a GET every time, even if we're POSTing? Rops does it this
-    # way so we can get it working, then get it right.
     conversation = get_conversation(thread_id)
     logger.info('Successfully retrieved conversation', thread_id=thread_id, party_id=party_id)
     try:
         refined_conversation = [refine(message) for message in reversed(conversation['messages'])]
-    except KeyError as e:
+    except KeyError:
         logger.error('Message is missing important data', thread_id=thread_id, party_id=party_id)
-        raise e
+        raise
 
     if refined_conversation[-1]['unread']:
         remove_unread_label(refined_conversation[-1]['message_id'])
@@ -50,10 +42,10 @@ def view_conversation(session, thread_id):
             send_message(_get_message_json(form, refined_conversation[0], msg_to=msg_to, msg_from=party_id))
             logger.info("Successfully sent message", thread_id=thread_id, party_id=party_id)
             thread_url = url_for("secure_message_bp.view_conversation", thread_id=thread_id) + "#latest-message"
-            flash(Markup('Message sent. <a href={}>View Message</a>'.format(thread_url)))
+            flash(Markup(f'Message sent. <a href={thread_url}>View Message</a>'))
             return redirect(url_for('secure_message_bp.view_conversation_list'))
 
-    unread_message_count = { 'unread_message_count': get_message_count_from_api(session) }
+    unread_message_count = {'unread_message_count': get_message_count_from_api(session)}
 
     return render_template('secure-messages/conversation-view.html',
                            form=form,
@@ -74,11 +66,11 @@ def view_conversation_list(session):
 
     try:
         refined_conversation = [refine(message) for message in conversation]
-    except KeyError as e:
+    except KeyError:
         logger.error('A key error occurred', party_id=party_id)
-        raise e
+        raise
     logger.info('Retrieving and refining conversation successful', party_id=party_id)
-    unread_message_count = { 'unread_message_count': try_message_count_from_session(session) }
+    unread_message_count = {'unread_message_count': try_message_count_from_session(session)}
     return render_template('secure-messages/conversation-list.html',
                            messages=refined_conversation,
                            is_closed=strtobool(is_closed),
@@ -86,14 +78,12 @@ def view_conversation_list(session):
 
 
 def _get_message_json(form, first_message_in_conversation, msg_to, msg_from):
-
     return json.dumps({
         'msg_from': msg_from,
         'msg_to': msg_to,
         'subject': form.subject.data,
         'body': form.body.data,
         'thread_id': first_message_in_conversation['thread_id'],
-        'collection_case': "",
         'survey': first_message_in_conversation['survey_id'],
         'business_id': first_message_in_conversation['ru_ref']})
 

--- a/frontstage/views/surveys/access_survey.py
+++ b/frontstage/views/surveys/access_survey.py
@@ -30,7 +30,7 @@ def access_survey(session):
     case_data = case_controller.get_case_data(case_id, party_id, business_party_id, survey_short_name)
 
     logger.info('Successfully retrieved case data', party_id=party_id, case_id=case_id)
-    unread_message_count = { 'unread_message_count': conversation_controller.try_message_count_from_session(session) }
+    unread_message_count = {'unread_message_count': conversation_controller.try_message_count_from_session(session)}
     return render_template('surveys/surveys-access.html', case_id=case_id,
                            collection_instrument_id=case_data['collection_instrument']['id'],
                            collection_instrument_size=case_data['collection_instrument']['len'],

--- a/frontstage/views/surveys/add_survey_confirm_organisation_survey.py
+++ b/frontstage/views/surveys/add_survey_confirm_organisation_survey.py
@@ -60,6 +60,4 @@ def survey_confirm_organisation(_):
                 business_party_id=business_party_id,
                 survey_id=survey_id)
 
-    return render_template('surveys/surveys-confirm-organisation.html',
-                           context=business_context,
-                           )
+    return render_template('surveys/surveys-confirm-organisation.html', context=business_context)

--- a/frontstage/views/surveys/add_survey_submit.py
+++ b/frontstage/views/surveys/add_survey_submit.py
@@ -58,8 +58,7 @@ def add_survey_submit(session):
             party_controller.add_survey(party_id, enrolment_code)
 
     except ApiError as exc:
-        logger.error('Failed to assign user to a survey',
-                     party_id=party_id, status_code=exc.status_code)
+        logger.error('Failed to assign user to a survey', party_id=party_id, status_code=exc.status_code)
         raise
 
     logger.info('Successfully retrieved data for confirm add organisation/survey page',

--- a/tests/integration/mocked_services.py
+++ b/tests/integration/mocked_services.py
@@ -126,7 +126,6 @@ url_get_survey_by_short_name = f"{app.config['SURVEY_URL']}/surveys/shortname/{s
 url_get_survey_by_short_name_eq = f"{app.config['SURVEY_URL']}/surveys/shortname/{survey_eq['shortName']}"
 url_get_survey_by_short_name_rsi = f"{app.config['SURVEY_URL']}/surveys/shortname/{survey_rsi['shortName']}"
 url_get_thread = app.config['SECURE_MESSAGE_URL'] + '/threads/9e3465c0-9172-4974-a7d1-3a01592d1594'
-url_get_thread_old = app.config['SECURE_MESSAGE_URL'] + '/thread/9e3465c0-9172-4974-a7d1-3a01592d1594'
 url_get_conversation_count = f"{app.config['SECURE_MESSAGE_URL']}/messages/count?unread_conversations=true"
 url_get_threads = app.config['SECURE_MESSAGE_URL'] + '/threads'
 url_auth_token = f"{app.config['AUTH_URL']}/api/v1/tokens/"

--- a/tests/integration/test_secure_message.py
+++ b/tests/integration/test_secure_message.py
@@ -7,7 +7,7 @@ from frontstage import app
 from frontstage.exceptions.exceptions import IncorrectAccountAccessError
 from tests.integration.mocked_services import (conversation_json, conversation_list_json,
                                                encoded_jwt_token, url_get_thread, url_get_threads,
-                                               url_get_thread_old, url_send_message, url_get_conversation_count)
+                                               url_send_message, url_get_conversation_count)
 
 
 def create_api_error(status_code, data=None):
@@ -44,16 +44,10 @@ class TestSecureMessage(unittest.TestCase):
     @requests_mock.mock()
     def test_get_thread_success(self, mock_request):
         mock_request.get(url_get_thread, json={'messages': [conversation_json], 'is_closed': False})
-        mock_request.get(url_get_thread_old, json={'messages': [conversation_json], 'is_closed': False})
         mock_request.get(url_get_conversation_count, json={'total': 0})
 
-        response = self.app.get("secure-message/threads/9e3465c0-9172-4974-a7d1-3a01592d1594", headers=self.headers, follow_redirects=True)
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue('Peter Griffin'.encode() in response.data)
-        self.assertTrue('testy2'.encode() in response.data)
-        self.assertTrue('something else'.encode() in response.data)
-
-        response = self.app.get("secure-message/thread/9e3465c0-9172-4974-a7d1-3a01592d1594", headers=self.headers, follow_redirects=True)
+        response = self.app.get("secure-message/threads/9e3465c0-9172-4974-a7d1-3a01592d1594",
+                                headers=self.headers, follow_redirects=True)
         self.assertEqual(response.status_code, 200)
         self.assertTrue('Peter Griffin'.encode() in response.data)
         self.assertTrue('testy2'.encode() in response.data)


### PR DESCRIPTION
# Motivation and Context
There was an endpoint that has been deprecated since September 2019.  We left the endpoint to handle the transition but it's been 9 months so we're certainly not sending emails with the old url.

Also found various spacing things to fix and a few .formats that could turn into f-strings.
Also updated a few functions to have docstrings

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):
