### PR TITLE
changed message body character limit to 50000

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.1.18
+appVersion: 2.1.19

--- a/frontstage/models.py
+++ b/frontstage/models.py
@@ -167,8 +167,8 @@ class SecureMessagingForm(FlaskForm):
     @staticmethod
     def validate_body(form, field):
         body = field.data
-        if len(body) > 10000:
-            raise ValidationError(_('Body field length must not be greater than 10000'))
+        if len(body) > 50000:
+            raise ValidationError(_('Body field length must not be greater than 50000'))
         if form.send.data and not body:
             raise ValidationError(_('Please enter a message'))
 

--- a/frontstage/templates/secure-messages/conversation-view.html
+++ b/frontstage/templates/secure-messages/conversation-view.html
@@ -107,7 +107,7 @@
                                     "label": {
                                         "text": "Reply"
                                     },
-                                    "maxlength": '10000',
+                                    "maxlength": '50000',
                                     "error": errorData if errorData
                                 })
                             }}

--- a/frontstage/templates/secure-messages/secure-messages-view.html
+++ b/frontstage/templates/secure-messages/secure-messages-view.html
@@ -52,7 +52,7 @@
                     {% else %}
                         <label class="u-fs-r--b" for="secure-message-body">Message</label>
                     {% endif %}
-                    {{ form.body(id='secure-message-body', class_='input input--textarea input--textarea-message', rows='10', maxlength='10000') }}
+                    {{ form.body(id='secure-message-body', class_='input input--textarea input--textarea-message', rows='10', maxlength='50000') }}
                     {% if "body" in errors %}
                         </div>
                     {% endif %}

--- a/tests/integration/test_secure_message.py
+++ b/tests/integration/test_secure_message.py
@@ -153,7 +153,7 @@ class TestSecureMessage(unittest.TestCase):
                                  data=self.message_form, headers=self.headers, follow_redirects=True)
 
         self.assertEqual(response.status_code, 200)
-        self.assertTrue('Body field length must not be greater than 10000'.encode() in response.data)
+        self.assertTrue('Body field length must not be greater than 50000'.encode() in response.data)
 
     @patch("frontstage.controllers.conversation_controller.try_message_count_from_session")
     def test_create_message_post_subject_too_long(self, message_count):

--- a/tests/integration/test_secure_message.py
+++ b/tests/integration/test_secure_message.py
@@ -147,7 +147,7 @@ class TestSecureMessage(unittest.TestCase):
     @patch("frontstage.controllers.conversation_controller.try_message_count_from_session")
     def test_create_message_post_body_too_long(self, message_count):
         message_count.return_value = 0
-        self.message_form['body'] = 'a' * 10100
+        self.message_form['body'] = 'a' * 50100
 
         response = self.app.post("/secure-message/create-message/?case_id=123&ru_ref=456&survey=789",
                                  data=self.message_form, headers=self.headers, follow_redirects=True)


### PR DESCRIPTION
# Motivation and Context
The message body character limit needed to be increased to 50000.

# What has changed
* Changed validation checks to allow for messages of up to 50000, instead of 10000, as it used to be.

# How to test?
Try entering a message of over 10000, and check that it validates

# Links
[Jira card](https://collaborate2.ons.gov.uk/jira/browse/RAS-16)


[Related secure message PR](https://github.com/ONSdigital/ras-secure-message/pull/308)
