### PR TITLE
Replacing X-FORWARDED-PROTO custom header

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.2.2
+appVersion: 2.2.3

--- a/_infra/helm/frontstage/templates/ingress.yaml
+++ b/_infra/helm/frontstage/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled }}
-apiVersion: networking.k8s.io/v1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ .Chart.Name }}-ingress

--- a/frontstage/create_app.py
+++ b/frontstage/create_app.py
@@ -22,7 +22,7 @@ class GCPLoadBalancer:
         self.app = app
 
     def __call__(self, environ, start_response):
-        scheme = environ.get("HTTP_X_FORWARDED_PROTO", "http")
+        scheme = os.environ.get("SCHEME", "http")
         if scheme:
             environ["wsgi.url_scheme"] = scheme
         return self.app(environ, start_response)


### PR DESCRIPTION
# Motivation and Context
Changes to the backend config to remove X-FORWARD-Proto (not supported) and relying on scheme config value to setup the `wsgi.url_scheme`.
# What has changed

