### PR TITLE
fix typo and add hyperlink to hackerone

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.2.6
+appVersion: 2.2.7

--- a/frontstage/templates/vunerability_disclosure.html
+++ b/frontstage/templates/vunerability_disclosure.html
@@ -28,7 +28,9 @@
 <p>
 If you have discovered something you believe to be an in-scope security 
 vulnerability, first you should check the above details for more information 
-about scope, then submit a report on this page.In your submission, include details of:
+about scope, then submit a report on 
+<a href="https://hackerone.com/52fa7bc0-5356-4c86-9f79-eeb03e1d55cc/embedded_submissions/new">this page</a>.  
+In your submission, include details of:
 <ul>
   <li>The website or page where the vulnerability can be observed.</li>
   <li>A brief description of the type of vulnerability, for example an 'XSS vulnerability'.</li>
@@ -87,7 +89,7 @@ of some vulnerabilities, such as sub-domain takeovers.</p>
       been mitigated or rectified. However, this is not intended to stop you 
       notifying a vulnerability to 3rd parties for whom the vulnerability is directly relevant. 
       An example would be where the vulnerability being reported is in a 3rd party 
-      software library or framework. Detailsof the specific vulnerability as it applies 
+      software library or framework. Details of the specific vulnerability as it applies 
       to the ONS must not be referenced in such reports.</li>
   </ul>
 </p>


### PR DESCRIPTION
Add hackerone hyperlink for users to be able to navigate to the correct submission page in our vulnerability disclosure policy.
Fix typo