### PR TITLE
add test errors by setting config

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.2.16
+appVersion: 2.2.17

--- a/_infra/helm/frontstage/templates/deployment.yaml
+++ b/_infra/helm/frontstage/templates/deployment.yaml
@@ -196,6 +196,8 @@ spec:
             value: "{{- if .Values.security.csrf.protected -}}True{{- else -}}False{{- end -}}"
           - name: WTF_CSRF_TIME_LIMIT
             value: "{{ .Values.security.csrf.timeLimit }}"
+          - name: CANARY_GENERATE_ERRORS
+            value: "{{- if .Values.canary.generate_errors -}}True{{- else -}}False{{- end -}}"
           - name: SECRET_KEY
             valueFrom:
               secretKeyRef:

--- a/_infra/helm/frontstage/values.yaml
+++ b/_infra/helm/frontstage/values.yaml
@@ -65,3 +65,4 @@ dns:
 canary:
   enabled: false
   name: canary
+  generate_errors: false

--- a/config.py
+++ b/config.py
@@ -64,6 +64,7 @@ class Config(object):
     WTF_CSRF_TIME_LIMIT = int(os.getenv('WTF_CSRF_TIME_LIMIT', '7200'))
     GOOGLE_CLOUD_PROJECT = os.getenv("GOOGLE_CLOUD_PROJECT", "ras-rm-sandbox")
     PUBSUB_TOPIC = os.getenv("PUBSUB_TOPIC", "ras-rm-notify-test")
+    CANARY_GENERATE_ERRORS = bool(strtobool(os.getenv('CANARY_GENERATE_ERRORS', "False")))
 
 
 class DevelopmentConfig(Config):

--- a/frontstage/controllers/auth_controller.py
+++ b/frontstage/controllers/auth_controller.py
@@ -12,6 +12,8 @@ logger = wrap_logger(logging.getLogger(__name__))
 
 
 def sign_in(username, password):
+    if app.config["CANARY_GENERATE_ERRORS"]:
+        logger.error("Canary experiment running this error can be ignored", status=500)
     bound_logger = logger.bind(email=obfuscate_email(username))
     bound_logger.info('Attempting to sign in')
 


### PR DESCRIPTION
Add a config for generating errors in a canary. This will allow us to continue tweaking and testing new canary configs without having to release a new version of frontstage each time
