### PR TITLE
change certificate name

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.2.21
+appVersion: 2.2.22

--- a/_infra/helm/frontstage/templates/ingress.yaml
+++ b/_infra/helm/frontstage/templates/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
     kubernetes.io/ingress.global-static-ip-name: frontstage-ip
     kubernetes.io/ingress.class: gce
     {{- if .Values.public }}
-    ingress.gcp.kubernetes.io/pre-shared-cert: surveys
+    ingress.gcp.kubernetes.io/pre-shared-cert: surveyrenew
     {{- else }}
     networking.gke.io/managed-certificates: {{ .Values.ingress.certNameSurveys }}
     {{- end }}


### PR DESCRIPTION
A new certificate has been created and uploaded to GCP.
the cert name is `surveyrenew`
Change the annotation here to update the ingress to use the new cert.
