### PR TITLE
changing to comply with prototype

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.2.39
+appVersion: 2.2.40

--- a/frontstage/templates/account/account-change-email-address.html
+++ b/frontstage/templates/account/account-change-email-address.html
@@ -20,6 +20,13 @@
 ] %}
 
 {% block main %}
+{{
+    onsBreadcrumb({
+        "ariaLabel": "Breadcrumbs",
+        "id": "breadcrumbs",
+        "itemsList": breadcrumbsData
+    })
+}}
 {% with messages = get_flashed_messages() %}
     {% if messages %}
           <div class="panel panel--simple panel--success u-mb-m">
@@ -31,16 +38,9 @@
           </div>
     {% endif %}
 {% endwith %}
-{{
-    onsBreadcrumb({
-        "ariaLabel": "Breadcrumbs",
-        "id": "breadcrumbs",
-        "itemsList": breadcrumbsData
-    })
-}}
 <h1 class="u-fs-xl">Change email address</h1>
-<p>You'll need to authorise a change of email address.</p>
-<p>We'll send a confirmation email to <b>{{ new_email }}</b>.</p>
+<p>You will need to authorise a change of email address.</p>
+<p>We will send a confirmation email to <b>{{ new_email }}</b>.</p>
 <form action="{{ url_for('account_bp.change_email_address')}}" method="post">
         {{ form.csrf_token }}
 

--- a/frontstage/templates/account/account-contact-detail-change.html
+++ b/frontstage/templates/account/account-contact-detail-change.html
@@ -18,6 +18,13 @@
 ] %}
 
 {% block main %}
+{{
+    onsBreadcrumb({
+        "ariaLabel": "Breadcrumbs",
+        "id": "breadcrumbs",
+        "itemsList": breadcrumbsData
+    })
+}}
 {% if errors|length > 0 %}
         {% if errors|length == 1 %}
             {% set errorTitle = 'There is 1 error on this page' %}
@@ -52,13 +59,6 @@
             }}
         {% endcall %}
     {% endif %}
-{{
-    onsBreadcrumb({
-        "ariaLabel": "Breadcrumbs",
-        "id": "breadcrumbs",
-        "itemsList": breadcrumbsData
-    })
-}}
 <h1 class="u-fs-xl">Change your contact details</h1>
 <form action="" method="post">
         {{ form.csrf_token }}

--- a/frontstage/templates/account/account-contact-detail-change.html
+++ b/frontstage/templates/account/account-contact-detail-change.html
@@ -73,7 +73,7 @@
                     "name": "first_name",
                     "type": "text",
                     "label": {
-                        "text": 'First name - <span class="u-lighter u-fw-n">' ~ respondent.firstName ~ '</span>'
+                        "text": 'First name'
                     },
                     "error": errorFirstName,
                     "value": firstName
@@ -90,7 +90,7 @@
                     "name": "last_name",
                     "type": "text",
                     "label": {
-                        "text": 'Surname - <span class="u-lighter u-fw-n">' ~ respondent.lastName ~ '</span>'
+                        "text": 'Surname'
                     },
                     "error": errorLastName,
                     "value": lastName
@@ -107,7 +107,7 @@
                     "name": "email_address",
                     "type": "text",
                     "label": {
-                        "text": 'Email address - <span class="u-lighter u-fw-n">' ~ respondent.emailAddress ~ '</span>'
+                        "text": 'Email address'
                     },
                     "error": errorEmailAddress,
                     "value": emailAddress,
@@ -126,8 +126,7 @@
                     "autocomplete": "tel",
                     "classes": "input--w-8",
                     "label": {
-                        "text": 'Telephone number - <span class="u-lighter u-fw-n">' ~ respondent.telephone ~ '</span>',
-                        "description": "For international numbers include the country code, for example +33 1234 567 890"
+                        "text": 'Phone number'
                     },
                     "error": errorPhoneNumber,
                     "value": phoneNumber

--- a/frontstage/views/account/account.py
+++ b/frontstage/views/account/account.py
@@ -76,7 +76,7 @@ def change_account_details(session):
                 logger.error('Failed to updated account', status=exc.status_code)
                 raise exc
             logger.info('Successfully updated account', party_id=party_id)
-            success_panel = create_success_message(attributes_changed, "We've updated your ")
+            success_panel = create_success_message(attributes_changed, "We have updated your ")
             flash(success_panel)
 
         if is_email_update_required:

--- a/tests/integration/views/account/test_account.py
+++ b/tests/integration/views/account/test_account.py
@@ -54,7 +54,7 @@ class TestSurveyList(unittest.TestCase):
     def test_account_options_selection(self, get_respondent_party_by_id):
         get_respondent_party_by_id.return_value = respondent_party
         response = self.app.post('/my-account', data=self.contact_details_form, follow_redirects=True)
-        self.assertIn("For international numbers include the country code, for example +33 1234 567 890".encode(),
+        self.assertIn("Phone number".encode(),
                       response.data)
 
     @patch('frontstage.controllers.party_controller.get_respondent_party_by_id')
@@ -99,8 +99,8 @@ class TestSurveyList(unittest.TestCase):
                                        "email_address": "exampleone@example.com"}, follow_redirects=True)
         self.assertIn("updated your first name, last name and telephone number".encode(), response.data)
         self.assertIn("Change email address".encode(), response.data)
-        self.assertIn("You'll need to authorise a change of email address.".encode(), response.data)
-        self.assertIn("We'll send a confirmation email to".encode(), response.data)
+        self.assertIn("You will need to authorise a change of email address.".encode(), response.data)
+        self.assertIn("We will send a confirmation email to".encode(), response.data)
         self.assertIn("exampleone@example.com".encode(), response.data)
 
     @patch('frontstage.controllers.party_controller.get_respondent_party_by_id')


### PR DESCRIPTION
Making changes for https://trello.com/c/rKk4XdJA/364-s27-user-account-creation-change-own-email-address to keep it as it is with prototype. 