### PR TITLE
Changing account to my account and adding validation for email

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.2.40
+appVersion: 2.2.41

--- a/frontstage/controllers/party_controller.py
+++ b/frontstage/controllers/party_controller.py
@@ -130,6 +130,18 @@ def get_party_by_business_id(party_id, party_url, party_auth, collection_exercis
     return response.json()
 
 
+def is_email_already_used_to_register(email):
+    bound_logger = logger.bind(email=obfuscate_email(email))
+    bound_logger.info('Attempting to find respondent party by email')
+
+    url = f"{app.config['PARTY_URL']}/party-api/v1/respondents/email"
+    response = requests.get(url, json={"email": email}, auth=app.config['BASIC_AUTH'])
+    if response.status_code == 404:
+        bound_logger.info('Email is not in use')
+        return False
+    return True
+
+
 def get_respondent_by_email(email):
     bound_logger = logger.bind(email=obfuscate_email(email))
     bound_logger.info('Attempting to find respondent party by email')

--- a/frontstage/templates/account/account-change-email-address-almost-done.html
+++ b/frontstage/templates/account/account-change-email-address-almost-done.html
@@ -10,7 +10,7 @@
     "url": "/surveys/todo"
   },
   {
-    "text": "Account",
+    "text": "My Account",
     "url": "/my-account"
   },
   {

--- a/frontstage/templates/account/account-change-email-address.html
+++ b/frontstage/templates/account/account-change-email-address.html
@@ -10,7 +10,7 @@
     "url": "/surveys/todo"
   },
   {
-    "text": "Account",
+    "text": "My Account",
     "url": "/my-account"
   },
   {

--- a/frontstage/templates/account/account-contact-detail-change.html
+++ b/frontstage/templates/account/account-contact-detail-change.html
@@ -12,7 +12,7 @@
     "url": "/surveys/todo"
   },
   {
-    "text": "Account",
+    "text": "My Account",
     "url": "/my-account"
   }
 ] %}

--- a/frontstage/templates/layouts/configs/service-links.html
+++ b/frontstage/templates/layouts/configs/service-links.html
@@ -5,7 +5,7 @@
     {% set signInOutText = "Sign out" %}
     {% do serviceLinks | setAttribute("itemsList", [
         {
-          "text": "Account",
+          "text": "My Account",
           "url": "/my-account"
         },
         {

--- a/frontstage/views/account/account.py
+++ b/frontstage/views/account/account.py
@@ -8,7 +8,6 @@ from frontstage.common.authorisation import jwt_authorization
 from frontstage.controllers import party_controller
 from frontstage.exceptions.exceptions import ApiError
 from frontstage.models import OptionsForm, ContactDetailsChangeForm, ConfirmEmailChangeForm
-
 from frontstage.views.account import account_bp
 
 logger = wrap_logger(logging.getLogger(__name__))
@@ -69,6 +68,11 @@ def change_account_details(session):
                                                                     respondent_details,
                                                                     is_contact_details_update_required)
         is_email_update_required = form['email_address'].data != respondent_details['emailAddress']
+        if is_email_update_required and party_controller.is_email_already_used_to_register(form['email_address'].data):
+            logger.info('Email already used')
+            error = {"email_address": ["This email has already been used to register an account"]}
+            return render_template('account/account-contact-detail-change.html',
+                                   form=form, errors=error, respondent=respondent_details)
         if is_contact_details_update_required:
             try:
                 party_controller.update_account(respondent_details)

--- a/tests/integration/controllers/test_party_controller.py
+++ b/tests/integration/controllers/test_party_controller.py
@@ -146,6 +146,20 @@ class TestPartyController(unittest.TestCase):
                 self.assertEqual(len(rsps.calls), 1)
                 self.assertEqual(rsps.calls[0].request.url, called_url)
 
+    def test_is_email_already_used_to_register_true(self):
+        with responses.RequestsMock() as rsps:
+            rsps.add(rsps.GET, url_get_respondent_email, json=respondent_party, status=200)
+            with app.app_context():
+                response = party_controller.is_email_already_used_to_register(respondent_party['emailAddress'])
+                self.assertEqual(True, response)
+
+    def test_is_email_already_used_to_register_false(self):
+        with responses.RequestsMock() as rsps:
+            rsps.add(rsps.GET, url_get_respondent_email, json=respondent_party, status=404)
+            with app.app_context():
+                response = party_controller.is_email_already_used_to_register(respondent_party['emailAddress'])
+                self.assertEqual(False, response)
+
     def test_get_respondent_by_email_success(self):
         with responses.RequestsMock() as rsps:
             rsps.add(rsps.GET, url_get_respondent_email, json=respondent_party, status=200)

--- a/tests/integration/views/account/test_account.py
+++ b/tests/integration/views/account/test_account.py
@@ -1,8 +1,10 @@
 import unittest
+import responses
 from unittest.mock import patch
 
 from frontstage import app
-from tests.integration.mocked_services import encoded_jwt_token, respondent_party, survey_list_todo
+from tests.integration.mocked_services import encoded_jwt_token, respondent_party, survey_list_todo, \
+    url_get_respondent_party
 
 
 class TestSurveyList(unittest.TestCase):
@@ -84,34 +86,40 @@ class TestSurveyList(unittest.TestCase):
         self.assertIn("updated your first name, last name and telephone number".encode(), response.data)
 
     @patch('frontstage.controllers.party_controller.get_respondent_party_by_id')
-    @patch('frontstage.controllers.party_controller.update_account')
     @patch('frontstage.controllers.party_controller.get_survey_list_details_for_party')
+    @patch('frontstage.controllers.party_controller.is_email_already_used_to_register')
     def test_account_change_account_email_address(self,
+                                                  is_email_already_used_to_register,
                                                   get_survey_list,
-                                                  update_account,
                                                   get_respondent_party_by_id):
         get_respondent_party_by_id.return_value = respondent_party
         get_survey_list.return_value = survey_list_todo
-        response = self.app.post('/my-account/change-account-details',
-                                 data={"first_name": "test account",
-                                       "last_name": "test_account",
-                                       "phone_number": "07772257773",
-                                       "email_address": "exampleone@example.com"}, follow_redirects=True)
-        self.assertIn("updated your first name, last name and telephone number".encode(), response.data)
-        self.assertIn("Change email address".encode(), response.data)
-        self.assertIn("You will need to authorise a change of email address.".encode(), response.data)
-        self.assertIn("We will send a confirmation email to".encode(), response.data)
-        self.assertIn("exampleone@example.com".encode(), response.data)
+        is_email_already_used_to_register.return_value = False
+        with responses.RequestsMock() as rsps:
+            rsps.add(rsps.PUT, url_get_respondent_party, json=respondent_party, status=200)
+            response = self.app.post('/my-account/change-account-details',
+                                     data={"first_name": "test account",
+                                           "last_name": "test_account",
+                                           "phone_number": "07772257773",
+                                           "email_address": "exampleone@example.com"}, follow_redirects=True)
+            self.assertIn("updated your first name, last name and telephone number".encode(), response.data)
+            self.assertIn("Change email address".encode(), response.data)
+            self.assertIn("You will need to authorise a change of email address.".encode(), response.data)
+            self.assertIn("We will send a confirmation email to".encode(), response.data)
+            self.assertIn("exampleone@example.com".encode(), response.data)
 
     @patch('frontstage.controllers.party_controller.get_respondent_party_by_id')
     @patch('frontstage.controllers.party_controller.update_account')
     @patch('frontstage.controllers.party_controller.get_survey_list_details_for_party')
+    @patch('frontstage.controllers.party_controller.is_email_already_used_to_register')
     def test_account_change_account_email_addres_almost_done(self,
+                                                             is_email_already_used_to_register,
                                                              get_survey_list,
                                                              update_account,
                                                              get_respondent_party_by_id):
         get_respondent_party_by_id.return_value = respondent_party
         get_survey_list.return_value = survey_list_todo
+        is_email_already_used_to_register.return_value = False
         response = self.app.post('/my-account/change-account-email-address',
                                  data={"email_address": "exampleone@example.com"}, follow_redirects=True)
         self.assertIn("Almost done".encode(), response.data)
@@ -129,8 +137,7 @@ class TestSurveyList(unittest.TestCase):
                                   get_respondent_party_by_id):
         get_respondent_party_by_id.return_value = respondent_party
         get_survey_list.return_value = survey_list_todo
-        is_value = True
-        is_email_already_used_to_register.return_value = is_value
+        is_email_already_used_to_register.return_value = True
         response = self.app.post('/my-account/change-account-details',
                                  data={"first_name": "new first name",
                                        "last_name": "new last name",

--- a/tests/integration/views/account/test_account.py
+++ b/tests/integration/views/account/test_account.py
@@ -70,26 +70,6 @@ class TestSurveyList(unittest.TestCase):
     @patch('frontstage.controllers.party_controller.get_respondent_party_by_id')
     @patch('frontstage.controllers.party_controller.update_account')
     @patch('frontstage.controllers.party_controller.get_survey_list_details_for_party')
-    @patch('frontstage.controllers.party_controller.is_email_already_used_to_register')
-    def test_email_already_in_use(self,
-                                  is_email_already_used_to_register,
-                                  get_survey_list,
-                                  update_account,
-                                  get_respondent_party_by_id):
-        get_respondent_party_by_id.return_value = respondent_party
-        get_survey_list.return_value = survey_list_todo
-        is_value=True
-        is_email_already_used_to_register.return_value = is_value
-        response = self.app.post('/my-account/change-account-details',
-                                 data={"first_name": "new first name",
-                                       "last_name": "new last name",
-                                       "phone_number": "8882257773",
-                                       "email_address": "example_@example.com"}, follow_redirects=True)
-        self.assertIn("This email has already been used to register an account".encode(), response.data)
-
-    @patch('frontstage.controllers.party_controller.get_respondent_party_by_id')
-    @patch('frontstage.controllers.party_controller.update_account')
-    @patch('frontstage.controllers.party_controller.get_survey_list_details_for_party')
     def test_account_contact_details_success(self,
                                              get_survey_list,
                                              update_account,
@@ -137,3 +117,23 @@ class TestSurveyList(unittest.TestCase):
         self.assertIn("Almost done".encode(), response.data)
         self.assertIn("Once you have received it, you need to follow the link".encode(), response.data)
         self.assertIn("please call 0300 1234 931".encode(), response.data)
+
+    @patch('frontstage.controllers.party_controller.get_respondent_party_by_id')
+    @patch('frontstage.controllers.party_controller.update_account')
+    @patch('frontstage.controllers.party_controller.get_survey_list_details_for_party')
+    @patch('frontstage.controllers.party_controller.is_email_already_used_to_register')
+    def test_email_already_in_use(self,
+                                  is_email_already_used_to_register,
+                                  get_survey_list,
+                                  update_account,
+                                  get_respondent_party_by_id):
+        get_respondent_party_by_id.return_value = respondent_party
+        get_survey_list.return_value = survey_list_todo
+        is_value = True
+        is_email_already_used_to_register.return_value = is_value
+        response = self.app.post('/my-account/change-account-details',
+                                 data={"first_name": "new first name",
+                                       "last_name": "new last name",
+                                       "phone_number": "8882257773",
+                                       "email_address": "something@something.com"}, follow_redirects=True)
+        self.assertIn("This email has already been used to register an account".encode(), response.data)

--- a/tests/integration/views/account/test_account.py
+++ b/tests/integration/views/account/test_account.py
@@ -70,6 +70,26 @@ class TestSurveyList(unittest.TestCase):
     @patch('frontstage.controllers.party_controller.get_respondent_party_by_id')
     @patch('frontstage.controllers.party_controller.update_account')
     @patch('frontstage.controllers.party_controller.get_survey_list_details_for_party')
+    @patch('frontstage.controllers.party_controller.is_email_already_used_to_register')
+    def test_email_already_in_use(self,
+                                  is_email_already_used_to_register,
+                                  get_survey_list,
+                                  update_account,
+                                  get_respondent_party_by_id):
+        get_respondent_party_by_id.return_value = respondent_party
+        get_survey_list.return_value = survey_list_todo
+        is_value=True
+        is_email_already_used_to_register.return_value = is_value
+        response = self.app.post('/my-account/change-account-details',
+                                 data={"first_name": "new first name",
+                                       "last_name": "new last name",
+                                       "phone_number": "8882257773",
+                                       "email_address": "example_@example.com"}, follow_redirects=True)
+        self.assertIn("This email has already been used to register an account".encode(), response.data)
+
+    @patch('frontstage.controllers.party_controller.get_respondent_party_by_id')
+    @patch('frontstage.controllers.party_controller.update_account')
+    @patch('frontstage.controllers.party_controller.get_survey_list_details_for_party')
     def test_account_contact_details_success(self,
                                              get_survey_list,
                                              update_account,


### PR DESCRIPTION
Business has asked for Account to be changed to My Account against `https://trello.com/c/rKk4XdJA/364-s27-user-account-creation-change-own-email-address` also a email validation for existing email in use has been added with this PR.