### PR TITLE
update change-own-account wording

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.2.41
+appVersion: 2.2.42

--- a/frontstage/templates/secure-messages/conversation-view.html
+++ b/frontstage/templates/secure-messages/conversation-view.html
@@ -100,7 +100,7 @@
                 {% endfor %}
 
                 {% if not conversation_data.is_closed %}
-                    <p>Make changes to your name, email address, and telephone number
+                    <p>You can now make changes to your name and telephone number
                         in <a href="/my-account" class="u-fs-r--b">your account</a>.</p>
                     {% if form.errors %}
                         {% set error = { "text": "Enter a message", "id": 'form_error' } %}

--- a/frontstage/templates/secure-messages/secure-messages-view.html
+++ b/frontstage/templates/secure-messages/secure-messages-view.html
@@ -46,7 +46,7 @@
                         <div class="panel panel--simple panel--error panel--spacious" id="body-error">
                             <p class="error-message">{{ errors['body'][0] }}</p>
                     {% endif %}
-                    <p>Make changes to your name, email address, and telephone number
+                    <p>You can now make changes to your name and telephone number
                         in <a href="/my-account" class="u-fs-r--b">your account</a>.</p>
                     {% if message %}
                         <label class="u-fs-r--b" for="secure-message-body">Reply</label>

--- a/tests/integration/test_secure_message.py
+++ b/tests/integration/test_secure_message.py
@@ -64,7 +64,7 @@ class TestSecureMessage(unittest.TestCase):
         self.assertTrue('something else'.encode() in response.data)
         self.assertTrue('Quarterly Business Survey'.encode() in response.data)
         self.assertTrue('OFFICE FOR NATIONAL STATISTICS'.encode() in response.data)
-        self.assertIn("Make changes to your name".encode(), response.data)
+        self.assertIn("You can now make changes to your name".encode(), response.data)
 
     @requests_mock.mock()
     @patch("frontstage.controllers.conversation_controller.try_message_count_from_session")


### PR DESCRIPTION
# Motivation and Context
Altered wording to bring this up to date with current version of "change own account details" story.
<!--- Why is this change required? What problem does it solve? -->

# What has changed
Updated wording of a sentence each in conversation view and secure messages view
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
Deploy to dev cluster. Go to "To-do" and click "Send a message". The form should now match the mockup in the story [Privacy notification update to secure messaging platform](https://collaborate2.ons.gov.uk/confluence/pages/viewpage.action?pageId=42295192#Useraccountcreation(RAS/RM)-RAS-235), and clicking the link in the new sentence should take you to the Account Details form.
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
- https://trello.com/c/aKRRIooz
- https://github.com/ONSdigital/ras-frontstage/pull/662
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):
