### PR TITLE
Return empty string if banner service unavailable

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.2.51
+appVersion: 2.2.52

--- a/frontstage/controllers/banner_controller.py
+++ b/frontstage/controllers/banner_controller.py
@@ -15,7 +15,12 @@ def current_banner():
     :return: The banner text, if any, else an empty string
     """
     url = f"{app.config['BANNER_SERVICE_URL']}/banner"
-    response = requests.get(url)
+    try:
+        response = requests.get(url)
+    except requests.exceptions.ConnectionError:
+        logger.error("Failed to connect to banner", exc_info=True)
+        return ""
+
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError:

--- a/tests/integration/controllers/test_banner_controller.py
+++ b/tests/integration/controllers/test_banner_controller.py
@@ -42,5 +42,14 @@ class TestBannerController(unittest.TestCase):
                 actual = banner_controller.current_banner()
                 self.assertEqual(expected, actual)
 
-
-
+    @responses.activate
+    def test_get_banner_connection_error(self):
+        """responses.activate will raise a ConnectionError if a url isn't mocked.  On a connection error
+        we want to be sure that we'll still get an empty string response if it's not working
+        """
+        with app.app_context():
+            with self.assertLogs(level='INFO') as logs:
+                expected = ""
+                actual = banner_controller.current_banner()
+                self.assertEqual(expected, actual)
+                self.assertIn("Failed to connect to banner", logs.output[0])


### PR DESCRIPTION
# Motivation and Context
If the banner service was unavailable, the whole of frontstage would fail.  With this PR, we handle the case of a connection error more gracefully so the show can continue even if the banner is unavailable

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):
