### PR TITLE
Mock email sending so test is instant

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.2.54
+appVersion: 2.2.55

--- a/tests/integration/test_passwords.py
+++ b/tests/integration/test_passwords.py
@@ -34,7 +34,8 @@ class TestPasswords(unittest.TestCase):
         self.assertTrue('reset your password'.encode() in response.data)
 
     @requests_mock.mock()
-    def test_forgot_password_post_success(self, mock_request):
+    @patch("frontstage.controllers.notify_controller.NotifyGateway.request_to_notify")
+    def test_forgot_password_post_success(self, mock_request, mock_notify):
         mock_request.get(url_banner_api, status_code=404)
         mock_request.post(url_reset_password_request, status_code=200)
         mock_request.get(url_get_respondent_by_email, status_code=200, json={"firstName": "Bob", "id": "123456"})
@@ -42,6 +43,7 @@ class TestPasswords(unittest.TestCase):
         response = self.app.post("passwords/forgot-password", data=self.email_form, follow_redirects=True)
 
         self.assertEqual(response.status_code, 200)
+        mock_notify.assert_called_once()
         self.assertTrue('Check your email'.encode() in response.data)
 
     @requests_mock.mock()
@@ -68,7 +70,7 @@ class TestPasswords(unittest.TestCase):
     def test_forgot_password_post_unrecognised_email_party(self, mock_request):
         mock_request.get(url_banner_api, status_code=404)
         mock_request.post(url_reset_password_request, status_code=404)
-        mock_request.get(url_get_respondent_by_email, status_code=200, json={"firstName": "Bob", "id": "123456"})
+        mock_request.get(url_get_respondent_by_email, status_code=404)
 
         self.email_form['email_address'] = "test@email.com"
 


### PR DESCRIPTION
# Motivation and Context
The call to notify wasn't mocked so the test took forever to run (and time out).  This PR mocks 1 and fixes another test to bring the runtime of the integration tests from 2min15secs to about 10secs

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):
