### PR TITLE
bug fix for duplication character validation error on secure message …

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.2.59
+appVersion: 2.2.60

--- a/frontstage/models.py
+++ b/frontstage/models.py
@@ -158,23 +158,6 @@ class SecureMessagingForm(FlaskForm):
     thread_id = HiddenField('Thread id')
     hidden_subject = HiddenField('Hidden Subject')
 
-    @staticmethod
-    def validate_subject(form, field):
-        subject = form['hidden_subject'].data if form['hidden_subject'].data else field.data
-
-        if len(subject) > 96:
-            raise ValidationError(_('Subject field length must not be greater than 100'))
-        if form.send.data and not subject or subject.isspace():
-            raise ValidationError(_('Please enter a subject'))
-
-    @staticmethod
-    def validate_body(form, field):
-        body = field.data
-        if len(body) > 50000:
-            raise ValidationError(_('Body field length must not be greater than 50000'))
-        if form.send.data and not body:
-            raise ValidationError(_('Please enter a message'))
-
 
 class RespondentStatus(enum.IntEnum):
     CREATED = 0

--- a/tests/integration/test_secure_message.py
+++ b/tests/integration/test_secure_message.py
@@ -148,32 +148,6 @@ class TestSecureMessage(unittest.TestCase):
 
     @requests_mock.mock()
     @patch("frontstage.controllers.conversation_controller.try_message_count_from_session")
-    def test_create_message_post_no_subject(self, mock_request, message_count):
-        mock_request.get(url_banner_api, status_code=404)
-        message_count.return_value = 0
-        del self.message_form['subject']
-
-        response = self.app.post("/secure-message/create-message/?case_id=123&ru_ref=456&survey=789",
-                                 data=self.message_form, headers=self.headers, follow_redirects=True)
-
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue('Please enter a subject'.encode() in response.data)
-
-    @requests_mock.mock()
-    @patch("frontstage.controllers.conversation_controller.try_message_count_from_session")
-    def test_create_message_post_whitespace_subject(self, mock_request, message_count):
-        mock_request.get(url_banner_api, status_code=404)
-        message_count.return_value = 0
-        self.message_form['subject'] = ' '
-
-        response = self.app.post("/secure-message/create-message/?case_id=123&ru_ref=456&survey=789",
-                                 data=self.message_form, headers=self.headers, follow_redirects=True)
-
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue('Please enter a subject'.encode() in response.data)
-
-    @requests_mock.mock()
-    @patch("frontstage.controllers.conversation_controller.try_message_count_from_session")
     def test_create_message_post_body_too_long(self, mock_request, message_count):
         mock_request.get(url_banner_api, status_code=404)
         message_count.return_value = 0
@@ -184,19 +158,6 @@ class TestSecureMessage(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertTrue('Message must be less than 50000 characters'.encode() in response.data)
-
-    @requests_mock.mock()
-    @patch("frontstage.controllers.conversation_controller.try_message_count_from_session")
-    def test_create_message_post_subject_too_long(self, mock_request, message_count):
-        mock_request.get(url_banner_api, status_code=404)
-        message_count.return_value = 0
-        self.message_form['subject'] = 'a' * 110
-
-        response = self.app.post("/secure-message/create-message/?case_id=123&ru_ref=456&survey=789",
-                                 data=self.message_form, headers=self.headers, follow_redirects=True)
-
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue('Subject field length must not be greater than 100'.encode() in response.data)
 
     @requests_mock.mock()
     @patch("frontstage.controllers.conversation_controller.try_message_count_from_session")


### PR DESCRIPTION
bug fix for duplication character validation error on secure message conversation page

[Trello](https://trello.com/c/YIqwCllL/553-s29-bug-getting-two-messages-on-character-validation-for-secure-messages)