### PR TITLE
Fix integration test that missing mocked urls

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.2.62
+appVersion: 2.2.63

--- a/frontstage/views/surveys/surveys_list.py
+++ b/frontstage/views/surveys/surveys_list.py
@@ -34,7 +34,7 @@ def get_survey_list(session, tag):
                                                                      survey_id=survey_id)
 
     sorted_survey_list = sorted(survey_list, key=lambda k: datetime.strptime(k['submit_by'], '%d %b %Y'), reverse=True)
-    bound_logger.info("Successfully retreived survey list")
+    bound_logger.info("Successfully retrieved survey list")
 
     unread_message_count = { 'unread_message_count': conversation_controller.try_message_count_from_session(session) }
     if tag == 'todo':

--- a/tests/integration/views/account/test_password_change.py
+++ b/tests/integration/views/account/test_password_change.py
@@ -31,11 +31,23 @@ class TestSurveyList(unittest.TestCase):
 
     @requests_mock.mock()
     @patch('frontstage.controllers.party_controller.get_respondent_party_by_id')
-    def test_account_password_change_success(self, mock_request, get_respondent_party_by_id):
+    @patch('frontstage.controllers.party_controller.get_survey_list_details_for_party')
+    def test_account_password_change_success(self, mock_request, get_survey_list, get_respondent_party_by_id):
+        survey_list = [{"case_id": "6f698975-0a36-45ff-ba66-7a575e414023",
+                        "status": "Not started", "collection_instrument_type": "EQ",
+                        "survey_id": "02b9c366-7397-42f7-942a-76dc5876d86d",
+                        "survey_long_name": "Quarterly Business Survey",
+                        "survey_short_name": "QBS", "survey_ref": "139",
+                        "business_party_id": "44d8db36-2319-41c6-8887-79033ce55a4b",
+                        "business_name": "PC UNIVERSE", "trading_as": "PC LTD",
+                        "business_ref": "49900000007", "period": "December 2019",
+                        "submit_by": "26 Mar 2021", "collection_exercise_ref": "1912",
+                        "added_survey": None, "display_button": True}]
         mock_request.get(url_banner_api, status_code=404)
         mock_request.post(url_auth_token, status_code=204)
         mock_request.put(url_password_change, status_code=200)
         get_respondent_party_by_id.return_value = respondent_party
+        get_survey_list.return_value = survey_list
         response = self.app.post('/my-account/change-password', data={"password": 'test',
                                                                       "new_password": 'Password123!',
                                                                       "new_password_confirm": 'Password123!'},


### PR DESCRIPTION
# What and why?

One of the password change tests had a warning that there was a missing mocked.  This was around the survey list screen.  Tried to mock the urls but there were too many.  Instead this replicates (roughly, I'm returning a list rather then a generator) what the `get_survey_list_details_for_party` function returns to bypass the need to mock a bunch of stuff

# How to test?

# Trello
