### PR TITLE
Standardise fieldname on secure message 

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.2.88
+appVersion: 2.2.89

--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -18,5 +18,5 @@ version: 1.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.2.89
+appVersion: 2.2.90
 

--- a/frontstage/common/message_helper.py
+++ b/frontstage/common/message_helper.py
@@ -13,7 +13,7 @@ def refine(message):
         'thread_id': message.get('thread_id'),
         'subject': get_message_subject(message),
         'body': message.get('body'),
-        'survey_id': message.get('survey'),
+        'survey_id': message.get('survey_id'),
         'ru_ref': get_ru_ref_from_message(message),
         'from': get_from_name(message),                     # As displayed to user
         'from_internal': from_internal(message),

--- a/frontstage/views/secure_messaging/create_message.py
+++ b/frontstage/views/secure_messaging/create_message.py
@@ -17,13 +17,13 @@ logger = wrap_logger(logging.getLogger(__name__))
 @jwt_authorization(request)
 def create_message(session):
     """Creates and sends a message outside of the context of an existing conversation"""
-    survey = request.args['survey']
+    survey_id = request.args['survey_id']
     ru_ref = request.args['ru_ref']
     party_id = session.get_party_id()
     form = SecureMessagingForm(request.form)
     if request.method == 'POST' and form.validate():
         logger.info("Form validation successful", party_id=party_id)
-        sent_message = _send_new_message(party_id, survey, ru_ref)
+        sent_message = _send_new_message(party_id, survey_id, ru_ref)
         thread_url = url_for("secure_message_bp.view_conversation",
                              thread_id=sent_message['thread_id']) + "#latest-message"
         flash(Markup(f'Message sent. <a href={thread_url}>View Message</a>'))
@@ -32,7 +32,7 @@ def create_message(session):
     else:
         unread_message_count = {'unread_message_count': conversation_controller.try_message_count_from_session(session)}
         return render_template('secure-messages/secure-messages-view.html',
-                               ru_ref=ru_ref, survey=survey,
+                               ru_ref=ru_ref, survey_id=survey_id,
                                form=form, errors=form.errors, message={},
                                unread_message_count=unread_message_count)
 

--- a/frontstage/views/secure_messaging/create_message.py
+++ b/frontstage/views/secure_messaging/create_message.py
@@ -37,7 +37,7 @@ def create_message(session):
                                unread_message_count=unread_message_count)
 
 
-def _send_new_message(party_id, survey, business_id):
+def _send_new_message(party_id, survey_id, business_id):
     logger.info('Attempting to send message', party_id=party_id, business_id=business_id)
     form = SecureMessagingForm(request.form)
 
@@ -49,7 +49,7 @@ def _send_new_message(party_id, survey, business_id):
         "body": form['body'].data,
         "thread_id": form['thread_id'].data,
         "business_id": business_id,
-        "survey": survey,
+        "survey_id": survey_id,
     }
 
     response = conversation_controller.send_message(json.dumps(message_json))

--- a/frontstage/views/secure_messaging/create_message.py
+++ b/frontstage/views/secure_messaging/create_message.py
@@ -17,7 +17,7 @@ logger = wrap_logger(logging.getLogger(__name__))
 @jwt_authorization(request)
 def create_message(session):
     """Creates and sends a message outside of the context of an existing conversation"""
-    survey_id = request.args['survey_id']
+    survey_id = request.args['survey']
     ru_ref = request.args['ru_ref']
     party_id = session.get_party_id()
     form = SecureMessagingForm(request.form)

--- a/frontstage/views/secure_messaging/message_get.py
+++ b/frontstage/views/secure_messaging/message_get.py
@@ -101,7 +101,7 @@ def _get_message_json(form, first_message_in_conversation, msg_to, msg_from):
         'subject': form.subject.data,
         'body': form.body.data,
         'thread_id': first_message_in_conversation['thread_id'],
-        'survey': first_message_in_conversation['survey_id'],
+        'survey_id': first_message_in_conversation['survey_id'],
         'business_id': first_message_in_conversation['ru_ref']})
 
 

--- a/frontstage/views/surveys/help/surveys_help.py
+++ b/frontstage/views/surveys/help/surveys_help.py
@@ -215,7 +215,7 @@ def send_help_message(session, short_name, business_id):
         return redirect(url_for('surveys_bp.get_survey_list', tag='todo'))
 
 
-def _send_new_message(subject, party_id, survey, business_id):
+def _send_new_message(subject, party_id, survey_id, business_id):
     logger.info('Attempting to send message', party_id=party_id, business_id=business_id)
     form = SecureMessagingForm(request.form)
     message_json = {
@@ -225,7 +225,7 @@ def _send_new_message(subject, party_id, survey, business_id):
         "body": form['body'].data,
         "thread_id": form['thread_id'].data,
         "business_id": business_id,
-        "survey": survey,
+        "survey_id": survey_id,
     }
 
     response = conversation_controller.send_message(json.dumps(message_json))

--- a/tests/test_data/collection_instrument/collection_instrument_eq_no_eq_id.json
+++ b/tests/test_data/collection_instrument/collection_instrument_eq_no_eq_id.json
@@ -8,6 +8,6 @@
   "id": "68ad4018-2ddd-4894-89e7-33f0135887a2",
   "len": 5,
   "stamp": null,
-  "survey": "2e517b4f-2854-4afa-ba8a-e3443034cc98",
+  "survey_id": "2e517b4f-2854-4afa-ba8a-e3443034cc98",
   "type": "EQ"
 }

--- a/tests/test_data/collection_instrument/collection_instrument_eq_no_form_type.json
+++ b/tests/test_data/collection_instrument/collection_instrument_eq_no_form_type.json
@@ -8,6 +8,6 @@
   "id": "68ad4018-2ddd-4894-89e7-33f0135887a2",
   "len": 5,
   "stamp": null,
-  "survey": "2e517b4f-2854-4afa-ba8a-e3443034cc98",
+  "survey_id": "2e517b4f-2854-4afa-ba8a-e3443034cc98",
   "type": "EQ"
 }

--- a/tests/test_data/conversation_list.json
+++ b/tests/test_data/conversation_list.json
@@ -83,7 +83,7 @@
         "href": "http:\/\/localhost:5050\/message\/667dc566-3bc8-42b1-87d7-b7181a880528"
       }
     },
-    "survey": "cb8accda-6118-4d3b-85a3-149e28960c54",
+    "survey_id": "cb8accda-6118-4d3b-85a3-149e28960c54",
     "business_id": "b868a847-db51-413c-9a04-b05eb3103bb1"
   }
 ]}

--- a/tests/test_data/message.json
+++ b/tests/test_data/message.json
@@ -38,7 +38,7 @@
   "labels": [
     "SENT"
   ],
-  "survey": "02b9c366-7397-42f7-942a-76dc5876d86d",
+  "survey_id": "02b9c366-7397-42f7-942a-76dc5876d86d",
   "sent_date": "2018-04-02 09:27:11.354399",
   "msg_to": [
     "GROUP"

--- a/tests/test_data/secure_messaging/message.json
+++ b/tests/test_data/secure_messaging/message.json
@@ -48,6 +48,7 @@
   "read_date": "2017-09-20 10:35:34.250858",
   "business_id": "f1a5e99c-8edf-489a-9c72-6cabe6c387fc",
   "sent_date": "2017-09-20 10:21:51.912869",
-  "subject": "TEST", "survey": "BRES",
+  "subject": "TEST",
+  "survey_id": "BRES",
   "thread_id": "dfcb2b2c-a1d8-4d86-a974-7ffe05a3141b"
 }

--- a/tests/test_data/secure_messaging/messages_list_inbox.json
+++ b/tests/test_data/secure_messaging/messages_list_inbox.json
@@ -58,7 +58,7 @@
       "read_date": "2017-09-20 10:35:34.250858", 
       "business_id": "f1a5e99c-8edf-489a-9c72-6cabe6c387fc",
       "sent_date": "2017-09-20 10:21:51.912869", 
-      "subject": "TEST", "survey": "BRES", 
+      "subject": "TEST", "survey_id": "BRES", 
       "thread_id": "dfcb2b2c-a1d8-4d86-a974-7ffe05a3141b"
     }, 
     {
@@ -155,7 +155,7 @@
       "business_id": "1f5e1d68-2a4c-4698-8086-e23c0b98923f", 
       "sent_date": "2017-09-11 11:39:03.185794", 
       "subject": "Testing send message", 
-      "survey": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87", 
+      "survey_id": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87", 
       "thread_id": "5e4be17d-f192-4196-befc-ccb1c85d9e87"
     }, 
     {
@@ -249,7 +249,7 @@
       "business_id": "1f5e1d68-2a4c-4698-8086-e23c0b98923f",
       "sent_date": "2017-09-11 11:03:49.871302",
       "subject": "Testing send message", 
-      "survey": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
+      "survey_id": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
       "thread_id": "5e4be17d-f192-4196-befc-ccb1c85d9e87"
     }
   ]

--- a/tests/test_data/secure_messaging/thread.json
+++ b/tests/test_data/secure_messaging/thread.json
@@ -76,7 +76,7 @@
       "business_id": "1216a88f-ee2a-420c-9e6a-ee34893c29cf", 
       "sent_date": "2017-10-16 12:36:44.407486", 
       "subject": "Send message", 
-      "survey": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87", 
+      "survey_id": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87", 
       "thread_id": "dfcb2b2c-a1d8-4d86-a974-7ffe05a3141c"
     }, 
     {
@@ -147,7 +147,7 @@
       "business_id": "1216a88f-ee2a-420c-9e6a-ee34893c29cf", 
       "sent_date": "2017-10-16 13:10:43.720414", 
       "subject": "Send message", 
-      "survey": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87", 
+      "survey_id": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87", 
       "thread_id": "dfcb2b2c-a1d8-4d86-a974-7ffe05a3141c"
     }
   ]

--- a/tests/test_data/secure_messaging/thread_no_party.json
+++ b/tests/test_data/secure_messaging/thread_no_party.json
@@ -76,7 +76,7 @@
       "business_id": "1216a88f-ee2a-420c-9e6a-ee34893c29cf",
       "sent_date": "2017-10-16 12:36:44.407486",
       "subject": "Send message",
-      "survey": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
+      "survey_id": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
       "thread_id": "dfcb2b2c-a1d8-4d86-a974-7ffe05a3141c"
     }
   ]


### PR DESCRIPTION
# What and why?
Create a database script to standardise the naming convention in secure message service.
# How to test?
run in dev
# Trello
S33 RASRM database rationalisation - Secure Message