### PR TITLE
Changes to provide hyperlink expiry and not valid pages for share and…

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -19,4 +19,4 @@ version: 1.2.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.3.2
+appVersion: 2.3.3

--- a/frontstage/templates/surveys/surveys-link-expired.html
+++ b/frontstage/templates/surveys/surveys-link-expired.html
@@ -1,0 +1,18 @@
+{% extends "layouts/_block_content.html" %}
+{% from "components/breadcrumb/_macro.njk" import onsBreadcrumb %}
+{% from "components/fieldset/_macro.njk" import onsFieldset %}
+{% from "components/input/_macro.njk" import onsInput %}
+{% from "components/lists/_macro.njk" import onsList %}
+{% from "components/button/_macro.njk" import onsButton %}
+{% set page_title = "survey link has expired" %}
+{% block main %}
+    {% if is_transfer %}
+        <h1 class="u-fs-xl">Transferred survey link has expired</h1>
+        <p>This link has expired.</p>
+        <p>If you still need access to the surveys, you should ask your colleague to transfer the surveys again.</p>
+    {% else %}
+        <h1 class="u-fs-xl">Shared survey link has expired</h1>
+        <p>This link has expired.</p>
+        <p>If you still need access to the surveys, you should ask your colleague to share the surveys again.</p>
+    {% endif %}
+{% endblock main %}

--- a/frontstage/templates/surveys/surveys-link-not-valid.html
+++ b/frontstage/templates/surveys/surveys-link-not-valid.html
@@ -1,0 +1,18 @@
+{% extends "layouts/_block_content.html" %}
+{% from "components/breadcrumb/_macro.njk" import onsBreadcrumb %}
+{% from "components/fieldset/_macro.njk" import onsFieldset %}
+{% from "components/input/_macro.njk" import onsInput %}
+{% from "components/lists/_macro.njk" import onsList %}
+{% from "components/button/_macro.njk" import onsButton %}
+{% set page_title = "survey link not valid" %}
+{% block main %}
+    {% if is_transfer %}
+        <h1 class="u-fs-xl">Transfer survey link is not valid</h1>
+        <p>This link is no longer available.</p>
+        <p>If you still need access to the surveys, you should ask your colleague to transfer the surveys again.</p>
+    {% else %}
+        <h1 class="u-fs-xl">Shared survey link is not valid</h1>
+        <p>This link is no longer available.</p>
+        <p>If you still need access to the surveys, you should ask your colleague to share the surveys again.</p>
+    {% endif %}
+{% endblock main %}

--- a/frontstage/views/account/accept_share_survey.py
+++ b/frontstage/views/account/accept_share_survey.py
@@ -1,6 +1,6 @@
 import logging
 
-from flask import abort, flash, render_template, request, url_for
+from flask import flash, render_template, request, url_for
 from structlog import wrap_logger
 from werkzeug.utils import redirect
 
@@ -60,7 +60,7 @@ def get_share_survey_summary(token):
                 api_url=exc.url,
                 api_status_code=exc.status_code,
             )
-            abort(409)
+            return render_template("surveys/surveys-link-expired.html", is_transfer=False)
         elif exc.status_code == 404:
             logger.warning(
                 "Unrecognised share survey email verification token",
@@ -68,7 +68,7 @@ def get_share_survey_summary(token):
                 api_url=exc.url,
                 api_status_code=exc.status_code,
             )
-            abort(404)
+            return render_template("surveys/surveys-link-not-valid.html", is_transfer=False)
         else:
             logger.info(
                 "Failed to verify share survey email", token=token, api_url=exc.url, api_status_code=exc.status_code

--- a/frontstage/views/account/accept_transfer_survey.py
+++ b/frontstage/views/account/accept_transfer_survey.py
@@ -1,6 +1,6 @@
 import logging
 
-from flask import abort, flash, render_template, request, url_for
+from flask import flash, render_template, request, url_for
 from structlog import wrap_logger
 from werkzeug.utils import redirect
 
@@ -63,7 +63,7 @@ def get_transfer_survey_summary(token):
                 api_url=exc.url,
                 api_status_code=exc.status_code,
             )
-            abort(409)
+            return render_template("surveys/surveys-link-expired.html", is_transfer=True)
         elif exc.status_code == 404:
             logger.warning(
                 "Unrecognised transfer survey email verification token",
@@ -71,7 +71,7 @@ def get_transfer_survey_summary(token):
                 api_url=exc.url,
                 api_status_code=exc.status_code,
             )
-            abort(404)
+            return render_template("surveys/surveys-link-not-valid.html", is_transfer=True)
         else:
             logger.info(
                 "Failed to verify transfer survey email", token=token, api_url=exc.url, api_status_code=exc.status_code

--- a/tests/integration/views/account/test_accept_share_survey.py
+++ b/tests/integration/views/account/test_accept_share_survey.py
@@ -109,7 +109,13 @@ class TestAcceptShareSurvey(unittest.TestCase):
         mock_request.get(url_get_survey_second, status_code=200, json=dummy_survey)
         mock_request.get(url_get_share_survey_verify, status_code=409)
         response = self.app.get(f"/my-account/share-surveys/accept-share-surveys/{token}")
-        self.assertEqual(409, response.status_code)
+        self.assertEqual(200, response.status_code)
+        self.assertIn("Shared survey link has expired".encode(), response.data)
+        self.assertIn("This link has expired.".encode(), response.data)
+        self.assertIn(
+            "If you still need access to the surveys, you should ask your colleague to share the surveys again.".encode(),
+            response.data,
+        )
 
     @requests_mock.mock()
     def test_get_share_survey_summary_not_found(self, mock_request):
@@ -120,7 +126,13 @@ class TestAcceptShareSurvey(unittest.TestCase):
         mock_request.get(url_get_survey_second, status_code=200, json=dummy_survey)
         mock_request.get(url_get_share_survey_verify, status_code=404)
         response = self.app.get(f"/my-account/share-surveys/accept-share-surveys/{token}")
-        self.assertEqual(404, response.status_code)
+        self.assertEqual(200, response.status_code)
+        self.assertIn("Shared survey link is not valid".encode(), response.data)
+        self.assertIn("This link is no longer available.".encode(), response.data)
+        self.assertIn(
+            "If you still need access to the surveys, you should ask your colleague to share the surveys again.".encode(),
+            response.data,
+        )
 
     @requests_mock.mock()
     @patch("frontstage.controllers.party_controller.get_survey_list_details_for_party")

--- a/tests/integration/views/account/test_accept_transfer_survey.py
+++ b/tests/integration/views/account/test_accept_transfer_survey.py
@@ -110,7 +110,13 @@ class TestAcceptTransferSurvey(unittest.TestCase):
         mock_request.get(url_get_survey_second, status_code=200, json=dummy_survey)
         mock_request.get(url_get_transfer_survey_verify, status_code=409)
         response = self.app.get(f"/my-account/transfer-surveys/accept-transfer-surveys/{token}")
-        self.assertEqual(409, response.status_code)
+        self.assertEqual(200, response.status_code)
+        self.assertIn("Transferred survey link has expired".encode(), response.data)
+        self.assertIn("This link has expired.".encode(), response.data)
+        self.assertIn(
+            "If you still need access to the surveys, you should ask your colleague to transfer the surveys again.".encode(),
+            response.data,
+        )
 
     @requests_mock.mock()
     def test_get_transfer_survey_summary_not_found(self, mock_request):
@@ -121,7 +127,13 @@ class TestAcceptTransferSurvey(unittest.TestCase):
         mock_request.get(url_get_survey_second, status_code=200, json=dummy_survey)
         mock_request.get(url_get_transfer_survey_verify, status_code=404)
         response = self.app.get(f"/my-account/transfer-surveys/accept-transfer-surveys/{token}")
-        self.assertEqual(404, response.status_code)
+        self.assertEqual(200, response.status_code)
+        self.assertIn("Transfer survey link is not valid".encode(), response.data)
+        self.assertIn("This link is no longer available.".encode(), response.data)
+        self.assertIn(
+            "If you still need access to the surveys, you should ask your colleague to transfer the surveys again.".encode(),
+            response.data,
+        )
 
     @requests_mock.mock()
     @patch("frontstage.controllers.party_controller.get_survey_list_details_for_party")


### PR DESCRIPTION
Changes to provide hyperlink expiry and not valid pages for share and transfer surveys

# What and why?

# How to test?

# Trello
https://trello.com/c/5WxcYR7Q/777-user-account-creation-share-and-transfer-survey-email-link-expired-cancelled