### PR TITLE
Fixed issue with not retaining user information after a single

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.3.9
+version: 2.3.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.3.9
+appVersion: 2.3.10

--- a/frontstage/templates/register/register-pending-survey-enter-your-details.html
+++ b/frontstage/templates/register/register-pending-survey-enter-your-details.html
@@ -56,7 +56,11 @@
         {{ form.batch_no }}
         {{ form.is_transfer }}
         <h2>Your name</h2>
-
+        {% if errors %}
+            {% set firstName = form.first_name.data %}
+            {% set lastName = form.last_name.data %}
+            {% set phoneNumber = form.phone_number.data %}
+        {% endif %}
         {%- call onsFieldset({
             "legend": "Your name",
             "legendClasses": "u-vh"
@@ -72,7 +76,8 @@
                     "label": {
                         "text": "First name"
                     },
-                    "error": errorFirstName
+                    "error": errorFirstName,
+                    "value": firstName
                 })
             }}
             {% if errors.last_name %}
@@ -86,7 +91,8 @@
                     "label": {
                         "text": "Last name"
                     },
-                    "error": errorLastName
+                    "error": errorLastName,
+                    "value": lastName
                 })
             }}
         {% endcall %}
@@ -152,7 +158,8 @@
                         "text": "Telephone number",
                         "description": "For international numbers include the country code, for example +33 1234 567 890"
                     },
-                    "error": errorPhoneNumber
+                    "error": errorPhoneNumber,
+                    "value": phoneNumber
                 })
             }}        
         {% endcall %}

--- a/frontstage/templates/register/register-pending-survey-enter-your-details.html
+++ b/frontstage/templates/register/register-pending-survey-enter-your-details.html
@@ -56,11 +56,7 @@
         {{ form.batch_no }}
         {{ form.is_transfer }}
         <h2>Your name</h2>
-        {% if errors %}
-            {% set firstName = form.first_name.data %}
-            {% set lastName = form.last_name.data %}
-            {% set phoneNumber = form.phone_number.data %}
-        {% endif %}
+
         {%- call onsFieldset({
             "legend": "Your name",
             "legendClasses": "u-vh"
@@ -77,7 +73,7 @@
                         "text": "First name"
                     },
                     "error": errorFirstName,
-                    "value": firstName
+                    "value": form.first_name.data
                 })
             }}
             {% if errors.last_name %}
@@ -92,7 +88,7 @@
                         "text": "Last name"
                     },
                     "error": errorLastName,
-                    "value": lastName
+                    "value": form.last_name.data
                 })
             }}
         {% endcall %}
@@ -159,7 +155,7 @@
                         "description": "For international numbers include the country code, for example +33 1234 567 890"
                     },
                     "error": errorPhoneNumber,
-                    "value": phoneNumber
+                    "value": form.phone_number.data
                 })
             }}        
         {% endcall %}

--- a/frontstage/templates/register/register.enter-your-details.html
+++ b/frontstage/templates/register/register.enter-your-details.html
@@ -54,13 +54,19 @@
         {{ form.enrolment_code }}
 
         <h2>Your name</h2>
-
+        {% if errors %}
+            {% set firstName = form.first_name.data %}
+            {% set lastName = form.last_name.data %}
+            {% set emailAddress = form.email_address.data %}
+            {% set phoneNumber = form.phone_number.data %}
+        {% endif %}
         {%- call onsFieldset({
             "legend": "Your name",
             "legendClasses": "u-vh"
         }) -%}
             {% if errors.first_name %}
                 {% set errorFirstName = { "text": errors['first_name'][0],  "id": 'first_name_error' } %}
+
             {% endif %}
             {{
                 onsInput({
@@ -70,7 +76,8 @@
                     "label": {
                         "text": "First name"
                     },
-                    "error": errorFirstName
+                    "error": errorFirstName,
+                    "value": firstName
                 })
             }}
             {% if errors.last_name %}
@@ -84,7 +91,8 @@
                     "label": {
                         "text": "Last name"
                     },
-                    "error": errorLastName
+                    "error": errorLastName,
+                    "value": lastName
                 })
             }}
         {% endcall %}
@@ -106,7 +114,8 @@
                     "label": {
                         "text": "Email address"
                     },
-                    "error": errorEmailAddress
+                    "error": errorEmailAddress,
+                    "value": emailAddress
                 })
             }}
             {{
@@ -183,7 +192,8 @@
                         "text": "Telephone number",
                         "description": "For international numbers include the country code, for example +33 1234 567 890"
                     },
-                    "error": errorPhoneNumber
+                    "error": errorPhoneNumber,
+                    "value": phoneNumber
                 })
             }}        
         {% endcall %}

--- a/frontstage/templates/register/register.enter-your-details.html
+++ b/frontstage/templates/register/register.enter-your-details.html
@@ -54,12 +54,6 @@
         {{ form.enrolment_code }}
 
         <h2>Your name</h2>
-        {% if errors %}
-            {% set firstName = form.first_name.data %}
-            {% set lastName = form.last_name.data %}
-            {% set emailAddress = form.email_address.data %}
-            {% set phoneNumber = form.phone_number.data %}
-        {% endif %}
         {%- call onsFieldset({
             "legend": "Your name",
             "legendClasses": "u-vh"
@@ -77,7 +71,7 @@
                         "text": "First name"
                     },
                     "error": errorFirstName,
-                    "value": firstName
+                    "value": form.first_name.data
                 })
             }}
             {% if errors.last_name %}
@@ -92,7 +86,7 @@
                         "text": "Last name"
                     },
                     "error": errorLastName,
-                    "value": lastName
+                    "value": form.last_name.data
                 })
             }}
         {% endcall %}
@@ -115,7 +109,7 @@
                         "text": "Email address"
                     },
                     "error": errorEmailAddress,
-                    "value": emailAddress
+                    "value": form.email_address.data
                 })
             }}
             {{
@@ -193,7 +187,7 @@
                         "description": "For international numbers include the country code, for example +33 1234 567 890"
                     },
                     "error": errorPhoneNumber,
-                    "value": phoneNumber
+                    "value": form.phone_number.data
                 })
             }}        
         {% endcall %}

--- a/tests/integration/test_registration.py
+++ b/tests/integration/test_registration.py
@@ -358,6 +358,28 @@ class TestRegistration(unittest.TestCase):
         self.assertTrue("Your email addresses do not match".encode() in response.data)
 
     @requests_mock.mock()
+    def test_create_account_register_wrong_email_retains_information(self, mock_request):
+        mock_request.get(url_banner_api, status_code=404)
+        mock_request.get(url_validate_enrolment, json={"active": True, "caseId": case["id"]})
+        self.test_user["email_address_confirm"] = "wrongemail@email.com"
+
+        response = self.app.post(
+            "register/create-account/enter-account-details",
+            query_string=self.params,
+            data=self.test_user,
+            headers=self.headers,
+            follow_redirects=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue("Your email addresses do not match".encode() in response.data)
+        self.assertTrue("john".encode() in response.data)
+        self.assertTrue("doe".encode() in response.data)
+        self.assertTrue("testuser2@email.com".encode() in response.data)
+        self.assertFalse("Password123!".encode() in response.data)
+        self.assertTrue("07717275049".encode() in response.data)
+
+    @requests_mock.mock()
     def test_create_account_register_no_password(self, mock_request):
         mock_request.get(url_banner_api, status_code=404)
         mock_request.get(url_validate_enrolment, json={"active": True, "caseId": case["id"]})


### PR DESCRIPTION
Fixed issue with not retaining user information after a single validation failure on account registration

# What and why?

# How to test?

# Trello
https://trello.com/c/soD3v81b/821-retain-data-on-account-sign-up-screen-when-error-has-been-made