### PR TITLE
Fix error message on 'something else' pages

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.3.15
+version: 2.3.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.3.15
+appVersion: 2.3.16

--- a/frontstage/views/surveys/help/surveys_help.py
+++ b/frontstage/views/surveys/help/surveys_help.py
@@ -25,6 +25,7 @@ from frontstage.views.surveys import surveys_bp
 logger = wrap_logger(logging.getLogger(__name__))
 help_completing_this_survey_title = "Help completing this survey"
 info_about_this_survey_title = "Information about this survey"
+info_about_the_ons = "Information about the ONS"
 something_else_title = "Something else"
 option_template_url_mapping = {
     "help-completing-this-survey": "surveys/help/surveys-help-completing-this-survey.html",
@@ -76,6 +77,9 @@ breadcrumb_text_mapping = {
     "who-is-the-ons": [info_about_this_survey_title, "Who is the ONS?"],
     "how-safe-is-my-data": [info_about_this_survey_title, "How safe is my data?"],
     "my-survey-is-not-listed": [something_else_title, "My survey is not listed"],
+    "help-completing-this-survey": [help_completing_this_survey_title],
+    "info-about-the-ons": [info_about_the_ons],
+    "something-else": [something_else_title],
 }
 
 
@@ -296,10 +300,8 @@ def get_help_option_sub_option_select(session, survey_ref, ru_ref, option, sub_o
 @jwt_authorization(request)
 def get_send_help_message(session, survey_ref, ru_ref, option):
     """Gets the send message page once the option is selected"""
-
     short_name, business_id = get_short_name_and_business_id(survey_ref, ru_ref)
-    if option == "help-completing-this-survey":
-        breadcrumbs_title = help_completing_this_survey_title
+    breadcrumbs_title = breadcrumb_text_mapping[option][0]
     return render_template(
         "secure-messages/help/secure-message-send-messages-view.html",
         short_name=short_name,

--- a/tests/integration/views/surveys/help/test_surveys_help_info_about_the_ons.py
+++ b/tests/integration/views/surveys/help/test_surveys_help_info_about_the_ons.py
@@ -198,3 +198,29 @@ class TestSurveyHelpInfoAboutThisSurvey(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("Message sent.".encode(), response.data)
+
+    @requests_mock.mock()
+    @patch("frontstage.controllers.party_controller.get_survey_list_details_for_party")
+    @patch("frontstage.controllers.conversation_controller.send_message")
+    @patch("frontstage.controllers.party_controller.get_business_by_ru_ref")
+    @patch("frontstage.controllers.survey_controller.get_survey_by_survey_ref")
+    def test_create_message_post_something_else_failure(
+        self, mock_request, get_survey, get_business, send_message, get_survey_list
+    ):
+        mock_request.get(url_banner_api, status_code=404)
+        get_survey.return_value = survey
+        get_business.return_value = business_party
+        form = {"body": ""}
+        response = self.app.post(
+            "/surveys/help/074/49900000001F/send-message?short_name=Bricks&subject=Information+about+the+ONS"
+            "&option=info-about-the-ons&sub_option=not_defined",
+            data=form,
+            follow_redirects=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("There is 1 error on this page".encode(), response.data)
+        self.assertIn("Message is required".encode(), response.data)
+        self.assertIn("Send a message".encode(), response.data)
+        self.assertIn("Describe your issue and we will get back to you.".encode(), response.data)
+        self.assertIn("Information about the ONS".encode(), response.data)

--- a/tests/integration/views/surveys/help/test_surveys_help_something_else.py
+++ b/tests/integration/views/surveys/help/test_surveys_help_something_else.py
@@ -102,7 +102,7 @@ class TestSurveyHelpInfoAboutThisSurvey(unittest.TestCase):
     @requests_mock.mock()
     @patch("frontstage.controllers.party_controller.get_business_by_ru_ref")
     @patch("frontstage.controllers.survey_controller.get_survey_by_survey_ref")
-    def test_survey_help_send_message_info_bricks_with_sub_option_who_is_the_ons(
+    def test_survey_help_send_message_info_bricks_with_sub_option_my_survey_is_not_listed(
         self, mock_request, get_survey, get_business
     ):
         mock_request.get(url_banner_api, status_code=404)
@@ -141,3 +141,29 @@ class TestSurveyHelpInfoAboutThisSurvey(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("Message sent.".encode(), response.data)
+
+    @requests_mock.mock()
+    @patch("frontstage.controllers.party_controller.get_survey_list_details_for_party")
+    @patch("frontstage.controllers.conversation_controller.send_message")
+    @patch("frontstage.controllers.party_controller.get_business_by_ru_ref")
+    @patch("frontstage.controllers.survey_controller.get_survey_by_survey_ref")
+    def test_create_message_post_something_else_failure(
+        self, mock_request, get_survey, get_business, send_message, get_survey_list
+    ):
+        mock_request.get(url_banner_api, status_code=404)
+        get_survey.return_value = survey
+        get_business.return_value = business_party
+        form = {"body": ""}
+        response = self.app.post(
+            "/surveys/help/074/49900000001F/send-message?short_name=Bricks&subject=Something+else&option=something-else"
+            "&sub_option=not_defined",
+            data=form,
+            follow_redirects=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("There is 1 error on this page".encode(), response.data)
+        self.assertIn("Message is required".encode(), response.data)
+        self.assertIn("Send a message".encode(), response.data)
+        self.assertIn("Describe your issue and we will get back to you.".encode(), response.data)
+        self.assertIn("Something else".encode(), response.data)


### PR DESCRIPTION
# What and why?

On 2 of the something else pages (info about the ons -> something else, and something else -> something else) if you didn't put any text in the message, it would Error in an ugly way instead of just showing a standard validation error.

This PR fixes this by making sure the breadcrumbs are correctly set up on error.  There are also tests for the offending pages to make sure it doesn't regress.

# How to test?

# Trello
