### PR TITLE
Modify backendconfig depending on environment

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.3.25
+version: 2.3.26
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.3.25
+appVersion: 2.3.26

--- a/_infra/helm/frontstage/templates/backendconfig.yaml
+++ b/_infra/helm/frontstage/templates/backendconfig.yaml
@@ -1,14 +1,12 @@
-{{- if .Values.public }}
 apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
   name: frontstage-backend-config
 spec:
-  {{- if ne .Values.env "prod" }}
+  {{- if not .Values.public }}
   securityPolicy:
     name: "ras-cloud-armor-policy"
   sessionAffinity: 
     affinityType: CLIENT_IP
   {{- end }}
   timeoutSec: {{ .Values.ingress.timeoutSec }}
-{{- end }}

--- a/_infra/helm/frontstage/templates/backendconfig.yaml
+++ b/_infra/helm/frontstage/templates/backendconfig.yaml
@@ -1,12 +1,14 @@
-{{- if not .Values.public }}
+{{- if .Values.public }}
 apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
   name: frontstage-backend-config
 spec:
+  {{- if ne .Values.env "prod" }}
   securityPolicy:
     name: "ras-cloud-armor-policy"
   sessionAffinity: 
     affinityType: CLIENT_IP
+  {{- end }}
   timeoutSec: {{ .Values.ingress.timeoutSec }}
 {{- end }}


### PR DESCRIPTION
# What and why?

Frontstage doesn't define a backendconfig in production as it's historically been used to set the security policy to make sure that authorised IPs can access it (which is the case in rops preprod and prod, and preprod frontstage).

This PR creates a backendconfig if it's public (inversing the logic that was there before) and locking down the backend if the environment is anything other then prod.

# How to test?

# Trello
