### PR TITLE
Remove the old pre-shared cert

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.3.30
+version: 2.3.31
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.3.30
+appVersion: 2.3.31

--- a/_infra/helm/frontstage/templates/ingress.yaml
+++ b/_infra/helm/frontstage/templates/ingress.yaml
@@ -6,9 +6,6 @@ metadata:
   annotations:
     kubernetes.io/ingress.global-static-ip-name: frontstage-ip
     kubernetes.io/ingress.class: gce
-    {{- if .Values.public }}
-    ingress.gcp.kubernetes.io/pre-shared-cert: surveyrenew
-    {{- end }}
     networking.gke.io/managed-certificates: {{ .Values.ingress.certNameSurveys }}
 
 spec:


### PR DESCRIPTION
# What and why?
Using a google managed cert now, so this can be remove

# How to test?

# Trello
