### PR TITLE
Support 'Response Expires At'

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.3.31
+version: 2.3.32
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.3.31
+appVersion: 2.3.32

--- a/frontstage/common/eq_payload.py
+++ b/frontstage/common/eq_payload.py
@@ -102,6 +102,7 @@ class EqPayload(object):
             "ref_p_end_date": self._find_event_date_by_tag("ref_period_end", collex_events, collex_id, True),
             "employment_date": self._find_event_date_by_tag("employment", collex_events, collex_id, False),
             "return_by": self._find_event_date_by_tag("return_by", collex_events, collex_id, True),
+            "response_expires_at": self._find_event_date_by_tag("exercise_end", collex_events, collex_id, True),
         }
 
     def _find_event_date_by_tag(self, search_param, collex_events, collex_id, mandatory):

--- a/tests/test_data/collection_exercise/collection_exercise_events.json
+++ b/tests/test_data/collection_exercise/collection_exercise_events.json
@@ -1,20 +1,26 @@
 [
-    {
-      "id": "39632788-50ab-420a-9408-2979133d1fdb",
-      "collectionExerciseId": "df634637-2aac-487f-9d2f-eb56615ed80e",
-      "tag": "return_by",
-      "timestamp": "2018-05-08T00:00:00.000Z"
-    },
-    {
+  {
+    "id": "39632788-50ab-420a-9408-2979133d1fdb",
+    "collectionExerciseId": "df634637-2aac-487f-9d2f-eb56615ed80e",
+    "tag": "return_by",
+    "timestamp": "2018-05-08T00:00:00.000Z"
+  },
+  {
     "id": "c7ea9f4a-4f6c-4d15-8996-8a08463291ee",
     "collectionExerciseId": "df634637-2aac-487f-9d2f-eb56615ed80e",
     "tag": "ref_period_start",
     "timestamp": "2018-04-10T00:00:00.000Z"
-    },
-    {
+  },
+  {
     "id": "db4bf724-cec8-4114-866d-06443efbb1cb",
     "collectionExerciseId": "df634637-2aac-487f-9d2f-eb56615ed80e",
     "tag": "ref_period_end",
     "timestamp": "2020-05-31T00:00:00.000Z"
-    }
+  },
+  {
+    "id": "5629d715-ec3e-4ca2-9232-be5c1d56cf32",
+    "collectionExerciseId": "df634637-2aac-487f-9d2f-eb56615ed80e",
+    "tag": "exercise_end",
+    "timestamp": "2023-05-31T00:00:00.000Z"
+  }
 ]


### PR DESCRIPTION
# What and why?
There's a new optional field in the EQ payload called response expires at. For EQ v3 we need to provide this field, equal to the collection exercise end date in ISO_8601 format

# How to test?

# Trello
https://trello.com/c/mQbYzg2o/1129-s48-eq-v3-support-response-expires-at