### PR TITLE
Get smaller number of collection instruments

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.3.33
+version: 2.3.34
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.3.33
+appVersion: 2.3.34

--- a/frontstage/controllers/party_controller.py
+++ b/frontstage/controllers/party_controller.py
@@ -371,7 +371,6 @@ def caching_data_for_survey_list(cache_data, surveys_ids, business_ids, tag):
 
 
 def caching_data_for_collection_instrument(cache_data, enrolled_cases):
-    # This function creates a list of threads from the collection instrument id in the cache_data of the cases.
     collection_instrument_ids = set()
     for case in enrolled_cases:
         collection_instrument_ids.add(case["collectionInstrumentId"])
@@ -427,7 +426,7 @@ def get_survey_list_details_for_party(party_id, tag, business_party_id, survey_i
     # inside of the for loop for get_respondent_enrolments.
     cache_data = {"surveys": dict(), "businesses": dict(), "collexes": dict(), "cases": dict(), "instrument": dict()}
 
-    # These two will call the services to get responses and cache the data for later use.
+    # Populate the cache with all non-instrument data
     caching_data_for_survey_list(cache_data, surveys_ids, business_ids, tag)
 
     enrolments = get_respondent_enrolments_for_started_collex(enrolment_data, cache_data["collexes"])
@@ -450,8 +449,10 @@ def get_survey_list_details_for_party(party_id, tag, business_party_id, survey_i
             if case["caseGroup"]["collectionExerciseId"] in collection_exercises_by_id.keys()
         ]
 
+        # Get and cache the collection instruments for all the cases the respondent is part of
+        caching_data_for_collection_instrument(cache_data, enrolled_cases)
+
         for case in enrolled_cases:
-            caching_data_for_collection_instrument(cache_data, enrolled_cases)
             collection_exercise = collection_exercises_by_id[case["caseGroup"]["collectionExerciseId"]]
             added_survey = True if business_party_id == business_party["id"] and survey_id == survey["id"] else None
             display_access_button = display_button(

--- a/frontstage/controllers/party_controller.py
+++ b/frontstage/controllers/party_controller.py
@@ -373,26 +373,15 @@ def caching_data_for_survey_list(cache_data, surveys_ids, business_ids, tag):
 def caching_data_for_collection_instrument(cache_data, enrolled_cases):
     # This function creates a list of threads from the collection instrument id in the cache_data of the cases.
     collection_instrument_ids = set()
-    threads = []
     for case in enrolled_cases:
         collection_instrument_ids.add(case["collectionInstrumentId"])
     for collection_instrument_id in collection_instrument_ids:
-        threads.append(
-            ThreadWrapper(
-                get_collection_instrument,
-                cache_data,
-                collection_instrument_id,
-                app.config["COLLECTION_INSTRUMENT_URL"],
-                app.config["BASIC_AUTH"],
+        if not cache_data["instrument"].get(collection_instrument_id):
+            cache_data["instrument"][
+                collection_instrument_id
+            ] = collection_instrument_controller.get_collection_instrument(
+                collection_instrument_id, app.config["COLLECTION_INSTRUMENT_URL"], app.config["BASIC_AUTH"]
             )
-        )
-
-    for thread in threads:
-        thread.start()
-
-    # We do a thread join to make sure that the threads have all terminated before it carries on
-    for thread in threads:
-        thread.join()
 
 
 def get_survey_list_details_for_party(party_id, tag, business_party_id, survey_id):

--- a/frontstage/controllers/party_controller.py
+++ b/frontstage/controllers/party_controller.py
@@ -370,9 +370,17 @@ def caching_data_for_survey_list(cache_data, surveys_ids, business_ids, tag):
         thread.join()
 
 
-def caching_data_for_collection_instrument(cache_data, enrolled_cases):
+def caching_data_for_collection_instrument(cache_data: dict, cases: list):
+    """
+    Adds to the collection instrument part of the cache dictionary.  Given a list of cases, it will get a set of
+    the collectionInstrumentId's, then if the id isn't in the cache already, it'll ask the collection instrument service
+    for it.  This doesn't return a dict with the cached data, this will modify the dictionary as a side-effect.
+
+    :param cache_data: The cache dictionary.
+    :param cases: A list of cases
+    """
     collection_instrument_ids = set()
-    for case in enrolled_cases:
+    for case in cases:
         collection_instrument_ids.add(case["collectionInstrumentId"])
     for collection_instrument_id in collection_instrument_ids:
         if not cache_data["instrument"].get(collection_instrument_id):


### PR DESCRIPTION
# What and why?

The performance of the todo page was pretty slow in places.  One of the slowest parts was when it gets all the collection instruments.  It was asking for way more instruments then it could possibly need as it would do the following:
- Get all the businesses the respondent is part of
- Get all the cases that business is part of
- Get all the collection instruments for every case the business is part of (This bit is slow and includes cases for collection exercises that have ended as well as ones the respondent might not be involved with).

I've changed the algorithm so it only gets the instruments it needs by doing the following:
- Get all the businesses the respondent is part of
- Get all the cases the business is part of
- Figure out which cases the respondent is part of (which is determined as a transitive link between respondent -> business -> case) for only LIVE collection exercises.
- Get the collection instruments for ONLY the cases the respondent is part of.

This won't be a huge performance improvement for small businesses, as in the majority of cases, 1 respondent is responsible for every survey for their business (so all cases for a business is the same as all cases the respondent is part of).  This will however improve the performance for businesses that have large numbers of cases that are managed by a variety of people.

# How to test?

# Trello
