### PR TITLE
Change survey list to get respondent only once

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.3.33
+version: 2.3.34
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.3.33
+appVersion: 2.3.34

--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.3.35
+version: 2.3.36
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.3.35
+appVersion: 2.3.36

--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.3.36
+version: 2.3.37
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.3.36
+appVersion: 2.3.37

--- a/frontstage/controllers/party_controller.py
+++ b/frontstage/controllers/party_controller.py
@@ -22,7 +22,7 @@ CLOSED_STATE = ["COMPLETE", "COMPLETEDBYPHONE", "NOLONGERREQUIRED"]
 logger = wrap_logger(logging.getLogger(__name__))
 
 
-def get_respondent_party_by_id(party_id):
+def get_respondent_party_by_id(party_id: str) -> dict:
     logger.info("Retrieving party from party service by id", party_id=party_id)
 
     url = f"{app.config['PARTY_URL']}/party-api/v1/respondents/id/{party_id}"
@@ -295,7 +295,13 @@ def confirm_pending_survey(batch_number):
     return response
 
 
-def get_respondent_enrolments(respondent):
+def get_respondent_enrolments(respondent: dict):
+    """
+    Returns a generator containing all the business_id and survey_id for all the active enrolments for the
+    respondent.
+
+    :param respondent: A dict containing respondent data
+    """
     if "associations" in respondent:
         for association in respondent["associations"]:
             for enrolment in association["enrolments"]:
@@ -390,7 +396,7 @@ def caching_data_for_collection_instrument(cache_data: dict, cases: list):
             )
 
 
-def get_survey_list_details_for_party(respondent, tag, business_party_id, survey_id):
+def get_survey_list_details_for_party(respondent: dict, tag: str, business_party_id: str, survey_id: str):
     """
     Gets a list of cases (and any useful metadata) for a respondent.  Depending on the tag the list of cases will be
     ones that require action (in the form of an EQ or SEFT submission); Or they will be cases that have been completed
@@ -417,10 +423,10 @@ def get_survey_list_details_for_party(respondent, tag, business_party_id, survey
               - Create an entry in the returned list for each of these cases as the respondent is implicitly part
                 of the case by being enrolled for the survey with that business.
 
-    :party_id: This is the respondents uuid
-    :tag: This is the page that is being called e.g. to-do, history
-    :business_party_id: This is the businesses uuid
-    :survey_id: This is the surveys uuid
+    :param respondent: A dict containing respondent data
+    :param tag: This is the page that is being called e.g. to-do, history
+    :param business_party_id: This is the businesses uuid
+    :param survey_id: This is the surveys uuid
 
     """
     enrolment_data = list(get_respondent_enrolments(respondent))

--- a/frontstage/views/surveys/surveys_list.py
+++ b/frontstage/views/surveys/surveys_list.py
@@ -33,7 +33,6 @@ def get_survey_list(session, tag):
     # This logic is added to make sure a user is provided an option to delete an account if there is no
     # active enrolment which is ENABLED
     respondent = party_controller.get_respondent_party_by_id(party_id)
-
     delete_option_allowed = is_delete_account_respondent_allowed(respondent)
 
     survey_list = party_controller.get_survey_list_details_for_party(
@@ -70,6 +69,12 @@ def get_survey_list(session, tag):
 
 
 def is_delete_account_respondent_allowed(respondent: dict) -> bool:
+    """
+    Determine if the user has any active enrolments for the purpose of displaying the delete account option
+
+    :param respondent: A dict containing respondent data
+    :return: True if allowed, false if not.
+    """
     if "associations" in respondent:
         for association in respondent["associations"]:
             for enrolment in association["enrolments"]:

--- a/frontstage/views/surveys/surveys_list.py
+++ b/frontstage/views/surveys/surveys_list.py
@@ -33,15 +33,11 @@ def get_survey_list(session, tag):
     # This logic is added to make sure a user is provided an option to delete an account if there is no
     # active enrolment which is ENABLED
     respondent = party_controller.get_respondent_party_by_id(party_id)
-    delete_option_allowed = True
-    if "associations" in respondent:
-        for association in respondent["associations"]:
-            for enrolment in association["enrolments"]:
-                if enrolment["enrolmentStatus"] == "ENABLED":
-                    delete_option_allowed = False
+
+    delete_option_allowed = is_delete_account_respondent_allowed(respondent)
 
     survey_list = party_controller.get_survey_list_details_for_party(
-        party_id, tag, business_party_id=business_id, survey_id=survey_id
+        respondent, tag, business_party_id=business_id, survey_id=survey_id
     )
     sorted_survey_list = sorted(survey_list, key=lambda k: datetime.strptime(k["submit_by"], "%d %b %Y"), reverse=True)
     bound_logger.info("Successfully retrieved survey list")
@@ -71,3 +67,12 @@ def get_survey_list(session, tag):
             history=True,
             unread_message_count=unread_message_count,
         )
+
+
+def is_delete_account_respondent_allowed(respondent: dict) -> bool:
+    if "associations" in respondent:
+        for association in respondent["associations"]:
+            for enrolment in association["enrolments"]:
+                if enrolment["enrolmentStatus"] == "ENABLED":
+                    return False
+    return True

--- a/frontstage/views/surveys/surveys_list.py
+++ b/frontstage/views/surveys/surveys_list.py
@@ -25,10 +25,14 @@ def get_survey_list(session, tag):
     business_id = request.args.get("business_party_id")
     survey_id = request.args.get("survey_id")
     already_enrolled = request.args.get("already_enrolled")
-    bound_logger = logger.bind(
-        party_id=party_id, business_id=business_id, survey_id=survey_id, already_enrolled=already_enrolled, tag=tag
+    logger.info(
+        "Retrieving survey list",
+        party_id=party_id,
+        business_id=business_id,
+        survey_id=survey_id,
+        already_enrolled=already_enrolled,
+        tag=tag,
     )
-    bound_logger.info("Retrieving survey list")
 
     # This logic is added to make sure a user is provided an option to delete an account if there is no
     # active enrolment which is ENABLED
@@ -39,7 +43,14 @@ def get_survey_list(session, tag):
         respondent, tag, business_party_id=business_id, survey_id=survey_id
     )
     sorted_survey_list = sorted(survey_list, key=lambda k: datetime.strptime(k["submit_by"], "%d %b %Y"), reverse=True)
-    bound_logger.info("Successfully retrieved survey list")
+    logger.info(
+        "Successfully retrieved survey list",
+        party_id=party_id,
+        business_id=business_id,
+        survey_id=survey_id,
+        already_enrolled=already_enrolled,
+        tag=tag,
+    )
 
     unread_message_count = {"unread_message_count": conversation_controller.try_message_count_from_session(session)}
     if tag == "todo":

--- a/tests/integration/controllers/test_party_controller.py
+++ b/tests/integration/controllers/test_party_controller.py
@@ -230,11 +230,8 @@ class TestPartyController(unittest.TestCase):
         self.assertDictEqual({"survey_id": "survey1", "enrolment_data": "enrolment1"}, result[0])
         self.assertDictEqual({"survey_id": "survey3", "enrolment_data": "enrolment3"}, result[1])
 
-    @patch("frontstage.controllers.party_controller.get_respondent_party_by_id")
-    def test_get_respondent_enrolments(self, get_respondent_party):
-        get_respondent_party.return_value = respondent_party
-
-        enrolments = party_controller.get_respondent_enrolments(respondent_party["id"])
+    def test_get_respondent_enrolments(self):
+        enrolments = party_controller.get_respondent_enrolments(respondent_party)
 
         for enrolment in enrolments:
             self.assertTrue(enrolment["business_id"] is not None)


### PR DESCRIPTION
# What and why?

In the survey list page, party was called twice to get the respondent data.  This is reasonably expensive because party has to spend time figuring out associations, enrolments, etc.

This PR makes the call once and passes the respondent returned to the 2 places that it needs it.  This should shave off about 400ms~ off the time it takes to load the survey list

As part of this, I unbound some of the logging as it was being applied to every log line in the survey list process, even if it was an empty value (and would never have a value).  This is a bit of a quick tidy up and could be looked at in the future once we have some data and can figure out what we need.

# How to test?

# Trello
