### PR TITLE
Refactor 'is_respondent_enrolled' function

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 2.3.45
+version: 2.3.46
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.3.45
+appVersion: 2.3.46

--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 2.3.44
+version: 2.3.45
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.3.44
+appVersion: 2.3.45

--- a/frontstage/common/eq_payload.py
+++ b/frontstage/common/eq_payload.py
@@ -17,12 +17,16 @@ logger = wrap_logger(logging.getLogger(__name__))
 
 
 class EqPayload(object):
-    def create_payload(self, case, collection_exercise, party_id, business_party_id, survey):
+    def create_payload(self, case, collection_exercise, party_id: str, business_party_id: str, survey) -> dict:
         """
         Creates the payload needed to communicate with EQ, built from the Case, Collection Exercise, Party,
         Survey and Collection Instrument services
-        :case_id: The unique UUID references of a case
-        :return Payload for EQ
+        :param case: A dict containing information about the case
+        :param collection_exercise: A dict containing information about the collection exercise
+        :param party_id: The uuid of the respondent
+        :param business_party_id: The uuid of the reporting unit
+        :param survey: A dict containing information about the survey
+        :returns: Payload for EQ
         """
 
         tx_id = str(uuid.uuid4())

--- a/frontstage/controllers/party_controller.py
+++ b/frontstage/controllers/party_controller.py
@@ -544,15 +544,13 @@ def display_button(status, ci_type):
     return not (ci_type == "EQ" and status in CLOSED_STATE)
 
 
-def is_respondent_enrolled(party_id, business_party_id, survey_short_name, return_survey=False):
-    survey = survey_controller.get_survey_by_short_name(survey_short_name)
+def is_respondent_enrolled(party_id: str, business_party_id: str, survey: dict) -> bool:
     respondent = get_respondent_party_by_id(party_id)
     enrolments = get_respondent_enrolments(respondent)
     for enrolment in enrolments:
         if enrolment["business_id"] == business_party_id and enrolment["survey_id"] == survey["id"]:
-            if return_survey:
-                return {"survey": survey}
             return True
+    return False
 
 
 def notify_party_and_respondent_account_locked(respondent_id, email_address, status=None):

--- a/frontstage/views/surveys/download_survey.py
+++ b/frontstage/views/surveys/download_survey.py
@@ -8,6 +8,7 @@ from frontstage.controllers import (
     case_controller,
     collection_instrument_controller,
     party_controller,
+    survey_controller,
 )
 from frontstage.views.surveys import surveys_bp
 
@@ -25,7 +26,8 @@ def download_survey(session):
 
     # Check if respondent has permission to download for this case
     case = case_controller.get_case_by_case_id(case_id)
-    party_controller.is_respondent_enrolled(party_id, business_party_id, survey_short_name)
+    survey = survey_controller.get_survey_by_short_name(survey_short_name)
+    party_controller.is_respondent_enrolled(party_id, business_party_id, survey)
 
     collection_instrument, headers = collection_instrument_controller.download_collection_instrument(
         case["collectionInstrumentId"], case_id, party_id

--- a/frontstage/views/surveys/upload_survey.py
+++ b/frontstage/views/surveys/upload_survey.py
@@ -9,6 +9,7 @@ from frontstage.controllers import (
     collection_instrument_controller,
     conversation_controller,
     party_controller,
+    survey_controller,
 )
 from frontstage.exceptions.exceptions import CiUploadError
 from frontstage.views.surveys import surveys_bp
@@ -38,7 +39,8 @@ def upload_survey(session):
         )
 
     # Check if respondent has permission to upload for this case
-    party_controller.is_respondent_enrolled(party_id, business_party_id, survey_short_name)
+    survey = survey_controller.get_survey_by_short_name(survey_short_name)
+    party_controller.is_respondent_enrolled(party_id, business_party_id, survey)
 
     # Get the uploaded file
     upload_file = request.files["file"]

--- a/tests/integration/views/surveys/test_download_survey.py
+++ b/tests/integration/views/surveys/test_download_survey.py
@@ -13,6 +13,7 @@ from tests.integration.mocked_services import (
     encoded_jwt_token,
     survey,
     url_banner_api,
+    url_get_survey_by_short_name,
 )
 
 
@@ -36,6 +37,7 @@ class TestDownloadSurvey(unittest.TestCase):
     @patch("frontstage.controllers.case_controller.get_case_by_case_id")
     def test_download_survey_success(self, mock_request, get_case_by_id, _, download_collection_instrument):
         mock_request.get(url_banner_api, status_code=404)
+        mock_request.get(url_get_survey_by_short_name, json=survey, status_code=200)
         str = json.dumps(collection_instrument_seft)
         binary = " ".join(format(ord(letter), "b") for letter in str)
         get_case_by_id.return_value = case

--- a/tests/integration/views/surveys/test_upload_survey.py
+++ b/tests/integration/views/surveys/test_upload_survey.py
@@ -15,6 +15,7 @@ from tests.integration.mocked_services import (
     encoded_jwt_token,
     survey,
     url_banner_api,
+    url_get_survey_by_short_name,
     url_upload_ci,
 )
 
@@ -40,6 +41,7 @@ class TestUploadSurvey(unittest.TestCase):
     @patch("frontstage.controllers.party_controller.is_respondent_enrolled")
     def test_upload_survey_success(self, mock_request, *_):
         mock_request.get(url_banner_api, status_code=404)
+        mock_request.get(url_get_survey_by_short_name, json=survey, status_code=200)
         self.survey_file = dict(file=(io.BytesIO(b"my file contents"), "testfile.xlsx"))
         response = self.app.post(
             f'/surveys/upload-survey?case_id={case["id"]}&business_party_id={business_party["id"]}'
@@ -53,6 +55,7 @@ class TestUploadSurvey(unittest.TestCase):
     @patch("frontstage.controllers.party_controller.is_respondent_enrolled")
     def test_upload_survey_fail_unexpected_error(self, mock_request, _, upload_ci):
         mock_request.get(url_banner_api, status_code=404)
+        mock_request.get(url_get_survey_by_short_name, json=survey, status_code=200)
         error_response = Response()
         error_response.status_code = 500
         error_response.url = url_upload_ci
@@ -73,6 +76,7 @@ class TestUploadSurvey(unittest.TestCase):
     @patch("frontstage.controllers.party_controller.is_respondent_enrolled")
     def test_upload_survey_fail_type_error(self, mock_request, _, upload_ci):
         mock_request.get(url_banner_api, status_code=404)
+        mock_request.get(url_get_survey_by_short_name, json=survey, status_code=200)
         error_response = Response()
         error_response.status_code = 500
         error_response.url = url_upload_ci
@@ -93,6 +97,7 @@ class TestUploadSurvey(unittest.TestCase):
     @patch("frontstage.controllers.party_controller.is_respondent_enrolled")
     def test_upload_survey_fail_char_limit_error(self, mock_request, _, upload_ci):
         mock_request.get(url_banner_api, status_code=404)
+        mock_request.get(url_get_survey_by_short_name, json=survey, status_code=200)
         error_response = Response()
         error_response.status_code = 500
         error_response.url = url_upload_ci
@@ -113,6 +118,7 @@ class TestUploadSurvey(unittest.TestCase):
     @patch("frontstage.controllers.party_controller.is_respondent_enrolled")
     def test_upload_survey_fail_size_error(self, mock_request, _, upload_ci):
         mock_request.get(url_banner_api, status_code=404)
+        mock_request.get(url_get_survey_by_short_name, json=survey, status_code=200)
         error_response = Response()
         error_response.status_code = 500
         error_response.url = url_upload_ci


### PR DESCRIPTION
# What and why?

The `is_respondent_enrolled` function had a weird return type where it could be either a boolean or a dict.  This is bad practice so this PR modifies that function and everything that uses it to only care about the value returned

# How to test?

# Trello
