### PR TITLE
Modify dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.10-slim
 
 RUN apt update && apt install -y build-essential curl
-RUN pip install 'pipenv==2018.11.26'
+RUN pip install pipenv
 
 WORKDIR /app
 EXPOSE 8082


### PR DESCRIPTION
# What and why?

The upgrade to python 3.10 is incompatible with the version of pipenv that was pinned in this dockerfile.  Unpinning it should fix the build issue

# How to test?

# Trello
