### PR TITLE
Implement business party caching

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -236,11 +236,11 @@
                 "grpc"
             ],
             "hashes": [
-                "sha256:3c562d393aed7e3d2011fcd1f103b490c411dcf5644b6312ca11a166a6ea8faf",
-                "sha256:c8889f45cf58deca522888ae1d39b2a25e93e7d1b019ae8cee6456d5c726a40c"
+                "sha256:58e2c1171a3d51778bf4e428fbb4bf79cbd05007b4b44deaa80cf73c80eebc0f",
+                "sha256:ba8787b7c61632cd0340f095e1c036bef9426b2594f10afb290ba311ae8cb2cb"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2.3.2"
+            "version": "==2.4.0"
         },
         "google-auth": {
             "hashes": [
@@ -524,41 +524,43 @@
         },
         "phonenumbers": {
             "hashes": [
-                "sha256:00f2955a456b458f9b6ab0d24329049c3e7358c44dfc1979fe4908ced40f1eb8",
-                "sha256:fc105364dfee2bdb5be9116071e877b66fc7afbff6491c1b739fe7cff9a4c7bf"
+                "sha256:2b8c7a7ffac4fe2be3d8bf20dad316ea1292f27422c9e18b1f3cd16734d4a5ed",
+                "sha256:f477da623a51cba084567d6a67b1882a8aaaf3e7beadad655f8613a8f887ac62"
             ],
             "index": "pypi",
-            "version": "==8.12.40"
+            "version": "==8.12.41"
         },
         "protobuf": {
             "hashes": [
-                "sha256:038daf4fa38a7e818dd61f51f22588d61755160a98db087a046f80d66b855942",
-                "sha256:28ccea56d4dc38d35cd70c43c2da2f40ac0be0a355ef882242e8586c6d66666f",
-                "sha256:36d90676d6f426718463fe382ec6274909337ca6319d375eebd2044e6c6ac560",
-                "sha256:3cd0458870ea7d1c58e948ac8078f6ba8a7ecc44a57e03032ed066c5bb318089",
-                "sha256:5935c8ce02e3d89c7900140a8a42b35bc037ec07a6aeb61cc108be8d3c9438a6",
-                "sha256:615b426a177780ce381ecd212edc1e0f70db8557ed72560b82096bd36b01bc04",
-                "sha256:62a8e4baa9cb9e064eb62d1002eca820857ab2138440cb4b3ea4243830f94ca7",
-                "sha256:655264ed0d0efe47a523e2255fc1106a22f6faab7cc46cfe99b5bae085c2a13e",
-                "sha256:6e8ea9173403219239cdfd8d946ed101f2ab6ecc025b0fda0c6c713c35c9981d",
-                "sha256:71b0250b0cfb738442d60cab68abc166de43411f2a4f791d31378590bfb71bd7",
-                "sha256:74f33edeb4f3b7ed13d567881da8e5a92a72b36495d57d696c2ea1ae0cfee80c",
-                "sha256:77d2fadcf369b3f22859ab25bd12bb8e98fb11e05d9ff9b7cd45b711c719c002",
-                "sha256:8b30a7de128c46b5ecb343917d9fa737612a6e8280f440874e5cc2ba0d79b8f6",
-                "sha256:8e51561d72efd5bd5c91490af1f13e32bcba8dab4643761eb7de3ce18e64a853",
-                "sha256:a529e7df52204565bcd33738a7a5f288f3d2d37d86caa5d78c458fa5fabbd54d",
-                "sha256:b691d996c6d0984947c4cf8b7ae2fe372d99b32821d0584f0b90277aa36982d3",
-                "sha256:d80f80eb175bf5f1169139c2e0c5ada98b1c098e2b3c3736667f28cbbea39fc8",
-                "sha256:d83e1ef8cb74009bebee3e61cc84b1c9cd04935b72bca0cbc83217d140424995",
-                "sha256:d8919368410110633717c406ab5c97e8df5ce93020cfcf3012834f28b1fab1ea",
-                "sha256:db3532d9f7a6ebbe2392041350437953b6d7a792de10e629c1e4f5a6b1fe1ac6",
-                "sha256:e7b24c11df36ee8e0c085e5b0dc560289e4b58804746fb487287dda51410f1e2",
-                "sha256:e7e8d2c20921f8da0dea277dfefc6abac05903ceac8e72839b2da519db69206b",
-                "sha256:e813b1c9006b6399308e917ac5d298f345d95bb31f46f02b60cd92970a9afa17",
-                "sha256:fd390367fc211cc0ffcf3a9e149dfeca78fecc62adb911371db0cec5c8b7472d"
+                "sha256:1291a0a7db7d792745c99d4657b4c5c4942695c8b1ac1bfb993a34035ec123f7",
+                "sha256:18c40a1b8721026a85187640f1786d52407dc9c1ba8ec38accb57a46e84015f6",
+                "sha256:1cb2ed66aac593adbf6dca4f07cd7ee7e2958b17bbc85b2cc8bc564ebeb258ec",
+                "sha256:2acd7ca329be544d1a603d5f13a4e34a3791c90d651ebaf130ba2e43ae5397c6",
+                "sha256:2cddcbcc222f3144765ccccdb35d3621dc1544da57a9aca7e1944c1a4fe3db11",
+                "sha256:397d82f1c58b76445469c8c06b8dee1ff67b3053639d054f52599a458fac9bc6",
+                "sha256:3bf3a07d17ba3511fe5fa916afb7351f482ab5dbab5afe71a7a384274a2cd550",
+                "sha256:3f80a3491eaca767cdd86cb8660dc778f634b44abdb0dffc9b2a8e8d0cd617d0",
+                "sha256:49677e5e9c7ea1245a90c2e8a00d304598f22ea3aa0628f0e0a530a9e70665fa",
+                "sha256:544fe9705189b249380fae07952d220c97f5c6c9372a6f936cc83a79601dcb70",
+                "sha256:6202df8ee8457cb00810c6e76ced480f22a1e4e02c899a14e7b6e6e1de09f938",
+                "sha256:84bf3aa3efb00dbe1c7ed55da0f20800b0662541e582d7e62b3e1464d61ed365",
+                "sha256:898bda9cd37ec0c781b598891e86435de80c3bfa53eb483a9dac5a11ec93e942",
+                "sha256:8ad761ef3be34c8bdc7285bec4b40372a8dad9e70cfbdc1793cd3cf4c1a4ce74",
+                "sha256:8ceaf5fdb72c8e1fcb7be9f2b3b07482ce058a3548180c0bdd5c7e4ac5e14165",
+                "sha256:a9401d96552befcc7311f5ef8f0fa7dba0ef5fd805466b158b141606cd0ab6a8",
+                "sha256:af7238849fa79285d448a24db686517570099739527a03c9c2971cce99cc5ae2",
+                "sha256:afa8122de8064fd577f49ae9eef433561c8ace97a0a7b969d56e8b1d39b5d177",
+                "sha256:b53519b2ebec70cfe24b4ddda21e9843f0918d7c3627a785393fb35d402ab8ad",
+                "sha256:c781402ed5396ab56358d7b866d78c03a77cbc26ba0598d8bb0ac32084b1a257",
+                "sha256:d975a6314fbf5c524d4981e24294739216b5fb81ef3c14b86fb4b045d6690907",
+                "sha256:df2ba379ee42427e8fcc6a0a76843bff6efb34ef5266b17f95043939b5e25b69",
+                "sha256:e54b8650e849ee8e95e481024bff92cf98f5ec61c7650cb838d928a140adcb63",
+                "sha256:e765e6dfbbb02c55e4d6d1145743401a84fc0b508f5a81b2c5a738cf86353139",
+                "sha256:ef02d112c025e83db5d1188a847e358beab3e4bbfbbaf10eaf69e67359af51b2",
+                "sha256:f6d4b5b7595a57e69eb7314c67bef4a3c745b4caf91accaf72913d8e0635111b"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==3.19.1"
+            "version": "==3.19.3"
         },
         "pyasn1": {
             "hashes": [
@@ -712,11 +714,11 @@
         },
         "redis": {
             "hashes": [
-                "sha256:21f0a23bce707909076e6ba2ce076cba59bff60d2ab22972e0647fdf620ffe47",
-                "sha256:e13fad67c098a33141bacde872786960e86a5c97a4255009bcd43c795fa1cc77"
+                "sha256:07420a3fbedd8e012c31d4fadac943fb81568946da202c5a5bc237774e5280a0",
+                "sha256:bc97d18938ca18d66737d0ef88584a2073069589e4026813cfba9ad6df9a9f40"
             ],
             "index": "pypi",
-            "version": "==4.1.0"
+            "version": "==4.1.1"
         },
         "requests": {
             "hashes": [
@@ -770,7 +772,7 @@
                 "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed",
                 "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.26.8"
         },
         "werkzeug": {
@@ -1149,11 +1151,11 @@
         },
         "responses": {
             "hashes": [
-                "sha256:a2e3aca2a8277e61257cd3b1c154b1dd0d782b1ae3d38b7fa37cbe3feb531791",
-                "sha256:f358ef75e8bf431b0aa203cc62625c3a1c80a600dbe9de91b944bf4e9c600b92"
+                "sha256:e4fc472fb7374fb8f84fcefa51c515ca4351f198852b4eb7fc88223780b472ea",
+                "sha256:ec675e080d06bf8d1fb5e5a68a1e5cd0df46b09c78230315f650af5e4036bec7"
             ],
             "index": "pypi",
-            "version": "==0.16.0"
+            "version": "==0.17.0"
         },
         "six": {
             "hashes": [
@@ -1176,6 +1178,7 @@
                 "sha256:05b6166bff487dc068d322585c7ea4ef78deed501cc124060e0f238e89a9231f",
                 "sha256:e3069e4be3ead9668e21cb9b074cd948f7b3113fd9c8bba083f48247aab8b11c"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==1.2.3"
         },
         "typing-extensions": {
@@ -1191,7 +1194,7 @@
                 "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed",
                 "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.26.8"
         }
     }

--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 2.3.51
+version: 2.3.52
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.3.51
+appVersion: 2.3.52

--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 2.3.53
+version: 2.3.54
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.3.53
+appVersion: 2.3.54

--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 2.3.50
+version: 2.3.51
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.3.50
+appVersion: 2.3.51

--- a/frontstage/common/redis_cache.py
+++ b/frontstage/common/redis_cache.py
@@ -6,6 +6,7 @@ from redis.exceptions import RedisError
 from structlog import wrap_logger
 
 from frontstage import redis
+from frontstage.controllers.party_controller import get_party_by_business_id
 from frontstage.controllers.collection_instrument_controller import (
     get_collection_instrument,
 )
@@ -17,6 +18,7 @@ logger = wrap_logger(logging.getLogger(__name__))
 class RedisCache:
     SURVEY_CATEGORY_EXPIRY = 600  # 10 mins
     COLLECTION_INSTRUMENT_CATEGORY_EXPIRY = 600  # 10 mins
+    BUSINES_PARTY_CATEGORY_EXPIRY = 600
 
     def get_survey(self, key):
         """
@@ -58,6 +60,28 @@ class RedisCache:
             logger.info("Key not in cache, getting value from collection instrument service", key=redis_key)
             result = get_collection_instrument(key, app.config["COLLECTION_INSTRUMENT_URL"], app.config["BASIC_AUTH"])
             self.save(redis_key, result, self.COLLECTION_INSTRUMENT_CATEGORY_EXPIRY)
+            return result
+
+        return json.loads(result.decode("utf-8"))
+
+    def get_business_party(self, key):
+        """
+        Gets the business party from redis or the party service
+
+        :param key: Key in redis (for this example will be a frontstage:business-party:id)
+        :return: Result from either the cache or party service
+        """
+        redis_key = f"frontstage:business-party:{key}"
+        try:
+            result = redis.get(redis_key)
+        except RedisError:
+            logger.error("Error getting value from cache, please investigate", key=redis_key, exc_info=True)
+            result = None
+
+        if not result:
+            logger.info("Key not in cache, getting value from party service", key=redis_key)
+            result = get_party_by_business_id(key, app.config["PARTY_URL"], app.config["BASIC_AUTH"])
+            self.save(redis_key, result, self.BUSINES_PARTY_CATEGORY_EXPIRY)
             return result
 
         return json.loads(result.decode("utf-8"))

--- a/frontstage/common/redis_cache.py
+++ b/frontstage/common/redis_cache.py
@@ -6,10 +6,10 @@ from redis.exceptions import RedisError
 from structlog import wrap_logger
 
 from frontstage import redis
-from frontstage.controllers.party_controller import get_party_by_business_id
 from frontstage.controllers.collection_instrument_controller import (
     get_collection_instrument,
 )
+from frontstage.controllers.party_controller import get_party_by_business_id
 from frontstage.controllers.survey_controller import get_survey
 
 logger = wrap_logger(logging.getLogger(__name__))

--- a/frontstage/controllers/party_controller.py
+++ b/frontstage/controllers/party_controller.py
@@ -435,7 +435,7 @@ def get_survey_list_details_for_party(respondent: dict, tag: str, business_party
 
     # This is a dictionary that will store all the data that is going to be cached instead of making multiple calls
     # inside the for loop for get_respondent_enrolments.
-    cache_data = {"businesses": dict(), "collexes": dict(), "cases": dict()}
+    cache_data = {"collexes": dict(), "cases": dict()}
     redis_cache = RedisCache()
 
     # Populate the cache with all non-instrument data
@@ -443,7 +443,7 @@ def get_survey_list_details_for_party(respondent: dict, tag: str, business_party
 
     enrolments = get_respondent_enrolments_for_started_collex(enrolment_data, cache_data["collexes"])
     for enrolment in enrolments:
-        business_party = cache_data["businesses"][enrolment["business_id"]]
+        business_party = redis_cache.get_business_party(enrolment["business_id"])
         survey = redis_cache.get_survey(enrolment["survey_id"])
 
         # Note: If it ever becomes possible to get only live-but-not-ended collection exercises from the

--- a/frontstage/controllers/party_controller.py
+++ b/frontstage/controllers/party_controller.py
@@ -7,7 +7,7 @@ from dateutil.parser import parse
 from flask import current_app as app
 from structlog import wrap_logger
 
-from frontstage.common.redis_cache import RedisCache
+
 from frontstage.common.thread_wrapper import ThreadWrapper
 from frontstage.common.utilities import obfuscate_email
 from frontstage.controllers import (
@@ -134,6 +134,9 @@ def get_party_by_business_id(party_id, party_url, party_auth, collection_exercis
         "Successfully retrieved party by business", party_id=party_id, collection_exercise_id=collection_exercise_id
     )
     return response.json()
+
+
+from frontstage.common.redis_cache import RedisCache
 
 
 def get_respondent_by_email(email):
@@ -361,9 +364,6 @@ def caching_data_for_survey_list(cache_data, surveys_ids, business_ids, tag):
         threads.append(
             ThreadWrapper(get_case, cache_data, business_id, app.config["CASE_URL"], app.config["BASIC_AUTH"], tag)
         )
-        threads.append(
-            ThreadWrapper(get_party, cache_data, business_id, app.config["PARTY_URL"], app.config["BASIC_AUTH"])
-        )
 
     for thread in threads:
         thread.start()
@@ -523,10 +523,6 @@ def get_case(cache_data, business_id, case_url, case_auth, tag):
     cache_data["cases"][business_id] = case_controller.get_cases_for_list_type_by_party_id(
         business_id, case_url, case_auth, tag
     )
-
-
-def get_party(cache_data, business_id, party_url, party_auth):
-    cache_data["businesses"][business_id] = get_party_by_business_id(business_id, party_url, party_auth)
 
 
 def display_button(status, ci_type):

--- a/frontstage/controllers/party_controller.py
+++ b/frontstage/controllers/party_controller.py
@@ -7,7 +7,6 @@ from dateutil.parser import parse
 from flask import current_app as app
 from structlog import wrap_logger
 
-
 from frontstage.common.thread_wrapper import ThreadWrapper
 from frontstage.common.utilities import obfuscate_email
 from frontstage.controllers import (

--- a/frontstage/controllers/party_controller.py
+++ b/frontstage/controllers/party_controller.py
@@ -135,6 +135,10 @@ def get_party_by_business_id(party_id, party_url, party_auth, collection_exercis
     return response.json()
 
 
+"""
+This import had to be moved as redis_cache calls the get_party_by_business_id method which needs to be
+initialised before being used
+"""
 from frontstage.common.redis_cache import RedisCache  # NOQA: E402
 
 

--- a/frontstage/controllers/party_controller.py
+++ b/frontstage/controllers/party_controller.py
@@ -135,7 +135,7 @@ def get_party_by_business_id(party_id, party_url, party_auth, collection_exercis
     return response.json()
 
 
-from frontstage.common.redis_cache import RedisCache
+from frontstage.common.redis_cache import RedisCache  # NOQA: E402
 
 
 def get_respondent_by_email(email):

--- a/tests/integration/controllers/test_party_controller.py
+++ b/tests/integration/controllers/test_party_controller.py
@@ -251,7 +251,6 @@ class TestPartyController(unittest.TestCase):
         get_cases,
         get_collection_instrument,
         calculate_case_status,
-        get_business,
     ):
         enrolments = [{"business_id": business_party["id"], "survey_id": survey["id"]}]
 
@@ -264,10 +263,10 @@ class TestPartyController(unittest.TestCase):
         get_cases.return_value = case_list
         get_collection_instrument.return_value = collection_instrument_seft
         calculate_case_status.return_value = "In Progress"
-        get_business.return_value = business_party
 
         with responses.RequestsMock() as rsps:
             rsps.add(rsps.GET, url_get_survey, json=survey, status=200)
+            rsps.add(rsps.GET, url_get_business_party, json=business_party, status=200)
 
             survey_list = party_controller.get_survey_list_details_for_party(
                 respondent_party["id"], "todo", business_party["id"], survey["id"]

--- a/tests/integration/controllers/test_party_controller.py
+++ b/tests/integration/controllers/test_party_controller.py
@@ -238,7 +238,6 @@ class TestPartyController(unittest.TestCase):
             self.assertTrue(enrolment["business_id"] is not None)
             self.assertTrue(enrolment["survey_id"] is not None)
 
-    @patch("frontstage.controllers.party_controller.get_party_by_business_id")
     @patch("frontstage.controllers.case_controller.calculate_case_status")
     @patch("frontstage.controllers.collection_instrument_controller.get_collection_instrument")
     @patch("frontstage.controllers.case_controller.get_cases_for_list_type_by_party_id")


### PR DESCRIPTION
# What and why?
Changing where the business party cache is stored, in the common redis cache rather than in instance cached_data. This is to match what has been done with survey and collection instrument
# How to test?

# Trello
