### PR TITLE
Count missing eq version as v2

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 2.3.50
+version: 2.3.51
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.3.50
+appVersion: 2.3.51

--- a/frontstage/common/encrypter.py
+++ b/frontstage/common/encrypter.py
@@ -1,7 +1,11 @@
 import json
+import logging
 
 from sdc.crypto.encrypter import encrypt
 from sdc.crypto.key_store import KeyStore, validate_required_keys
+from structlog import wrap_logger
+
+logger = wrap_logger(logging.getLogger(__name__))
 
 KEY_PURPOSE = "authentication"
 
@@ -19,6 +23,7 @@ class Encrypter:
         :param service: The target service, needed to know which key in the keystore to use.
         :return: string of encrypted data
         """
+        logger.info("About to encrypt payload", encryption_for_service=service)
         encrypted_data = encrypt(
             payload, key_store=self.key_store, key_purpose=KEY_PURPOSE, encryption_for_service=service
         )

--- a/frontstage/controllers/case_controller.py
+++ b/frontstage/controllers/case_controller.py
@@ -158,7 +158,13 @@ def get_eq_url(version, case, collection_exercise, party_id, business_party_id, 
     logger.info("Attempting to generate EQ URL", case_id=case_id, party_id=party_id, version=version)
 
     if version not in ["v2", "v3"]:
-        raise ValueError(f"The eq version [{version}] is not supported")
+        # EQ collection exercises created before the concept of versions might have a null value for the version.
+        # If this is the case, we can safely assume it's v2 as that was the only one availible at the time.
+        if version is None:
+            logger.info("EQ version not set, assuming v2", case_id=case_id, party_id=party_id, version=version)
+            version = "v2"
+        else:
+            raise ValueError(f"The eq version [{version}] is not supported")
 
     if case["caseGroup"]["caseGroupStatus"] in ("COMPLETE", "COMPLETEDBYPHONE", "NOLONGERREQUIRED"):
         logger.info("The case group status is complete, opening an EQ is forbidden", case_id=case_id, party_id=party_id)

--- a/tests/integration/controllers/test_case_controllers.py
+++ b/tests/integration/controllers/test_case_controllers.py
@@ -171,6 +171,27 @@ class TestCaseControllers(unittest.TestCase):
                 self.assertIn("https://eq-v3-test/session?token=", eq_url)
 
     @patch("frontstage.controllers.party_controller.is_respondent_enrolled")
+    @patch("frontstage.controllers.case_controller.post_case_event")
+    @patch("frontstage.common.eq_payload.EqPayload.create_payload")
+    @patch("frontstage.controllers.case_controller.get_case_by_case_id")
+    def test_get_eq_url_blank_eq_version_redirects_to_v2(self, get_case_by_id, create_eq_payload, *_):
+        get_case_by_id.return_value = case
+        create_eq_payload.return_value = eq_payload
+        with responses.RequestsMock() as rsps:
+            rsps.add(rsps.GET, url_get_survey_by_short_name_eq, json=survey_eq, status=200)
+            with app.app_context():
+                eq_url = case_controller.get_eq_url(
+                    None,
+                    case,
+                    collection_exercise,
+                    respondent_party["id"],
+                    business_party["id"],
+                    survey_eq["shortName"],
+                )
+
+                self.assertIn("https://eq-test/session?token=", eq_url)
+
+    @patch("frontstage.controllers.party_controller.is_respondent_enrolled")
     @patch("frontstage.controllers.case_controller.get_case_by_case_id")
     def test_get_eq_url_when_caseGroupStatus_is_complete(self, get_case_by_id, _):
         case_copy = deepcopy(case)


### PR DESCRIPTION
# What and why?

For collection exercises created before the concept of eq versions, the eqVersion field is null (which translates to None).  Before this PR, if it was empty then it'll raise an error.  With this PR, if it's blank then we can assume it's v2 and treat it as such.

# How to test?

# Trello
