### PR TITLE
Implement collection exercise caching

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -149,7 +149,7 @@
                 "sha256:081649da27ced5e75709a1ee542136eaba9842a0fe4c03da4fb0a3d3ed1f3c44",
                 "sha256:e79351e032d0b606b98d38a4b0e6e2275b31a5b85c873e587cc11b73aca026d6"
             ],
-            "markers": "python_version >= '3.6' and python_version < '4'",
+            "markers": "python_version >= '3.6' and python_version < '4.0'",
             "version": "==2.2.0"
         },
         "ecdsa": {
@@ -259,6 +259,9 @@
             "version": "==1.7.0"
         },
         "googleapis-common-protos": {
+            "extras": [
+                "grpc"
+            ],
             "hashes": [
                 "sha256:a4031d6ec6c2b1b6dc3e0be7e10a1bd72fb0b18b07ef9be7b51f2c1004ce2437",
                 "sha256:e54345a2add15dc5e1a7891c27731ff347b4c33765d79b5ed7026a6c0c7cbcae"
@@ -402,7 +405,7 @@
                 "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
                 "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
             ],
-            "markers": "python_version >= '3.5'",
+            "markers": "python_version >= '3'",
             "version": "==3.3"
         },
         "iso8601": {
@@ -605,47 +608,47 @@
         },
         "pycryptodome": {
             "hashes": [
-                "sha256:1181c90d1a6aee68a84826825548d0db1b58d8541101f908d779d601d1690586",
-                "sha256:12c7343aec5a3b3df5c47265281b12b611f26ec9367b6129199d67da54b768c1",
-                "sha256:212c7f7fe11cad9275fbcff50ca977f1c6643f13560d081e7b0f70596df447b8",
-                "sha256:32d15da81959faea6cbed95df2bb44f7f796211c110cf90b5ad3b2aeeb97fc8e",
-                "sha256:341c6bbf932c406b4f3ee2372e8589b67ac0cf4e99e7dc081440f43a3cde9f0f",
-                "sha256:3558616f45d8584aee3eba27559bc6fd0ba9be6c076610ed3cc62bd5229ffdc3",
-                "sha256:39da5807aa1ff820799c928f745f89432908bf6624b9e981d2d7f9e55d91b860",
-                "sha256:3f2f3dd596c6128d91314e60a6bcf4344610ef0e97f4ae4dd1770f86dd0748d8",
-                "sha256:4cded12e13785bbdf4ba1ff5fb9d261cd98162145f869e4fbc4a4b9083392f0b",
-                "sha256:5a8c24d39d4a237dbfe181ea6593792bf9b5582c7fcfa7b8e0e12fda5eec07af",
-                "sha256:5d4264039a2087977f50072aaff2346d1c1c101cb359f9444cf92e3d1f42b4cd",
-                "sha256:6bb0d340c93bcb674ea8899e2f6408ec64c6c21731a59481332b4b2a8143cc60",
-                "sha256:6f8f5b7b53516da7511951910ab458e799173722c91fea54e2ba2f56d102e4aa",
-                "sha256:90ad3381ccdc6a24cc2841e295706a168f32abefe64c679695712acac71fd5da",
-                "sha256:93acad54a72d81253242eb0a15064be559ec9d989e5173286dc21cad19f01765",
-                "sha256:9ea2f6674c803602a7c0437fccdc2ea036707e60456974fe26ca263bd501ec45",
-                "sha256:a6e1bcd9d5855f1a3c0f8d585f44c81b08f39a02754007f374fb8db9605ba29c",
-                "sha256:a78e4324e566b5fbc2b51e9240950d82fa9e1c7eb77acdf27f58712f65622c1d",
-                "sha256:aceb1d217c3a025fb963849071446cf3aca1353282fe1c3cb7bd7339a4d47947",
-                "sha256:aed7eb4b64c600fbc5e6d4238991ad1b4179a558401f203d1fcbd24883748982",
-                "sha256:b07a4238465eb8c65dd5df2ab8ba6df127e412293c0ed7656c003336f557a100",
-                "sha256:b91404611767a7485837a6f1fd20cf9a5ae0ad362040a022cd65827ecb1b0d00",
-                "sha256:d8083de50f6dec56c3c6f270fb193590999583a1b27c9c75bc0b5cac22d438cc",
-                "sha256:d845c587ceb82ac7cbac7d0bf8c62a1a0fe7190b028b322da5ca65f6e5a18b9e",
-                "sha256:db66ccda65d5d20c17b00768e462a86f6f540f9aea8419a7f76cc7d9effd82cd",
-                "sha256:dc88355c4b261ed259268e65705b28b44d99570337694d593f06e3b1698eaaf3",
-                "sha256:de0b711d673904dd6c65307ead36cb76622365a393569bf880895cba21195b7a",
-                "sha256:e05f994f30f1cda3cbe57441f41220d16731cf99d868bb02a8f6484c454c206b",
-                "sha256:e80f7469b0b3ea0f694230477d8501dc5a30a717e94fddd4821e6721f3053eae",
-                "sha256:f699360ae285fcae9c8f53ca6acf33796025a82bb0ccd7c1c551b04c1726def3"
+                "sha256:008ef2c631f112cd5a58736e0b29f4a28b4bb853e68878689f8b476fd56e0691",
+                "sha256:073dedf0f9c490ae22ca081b86357646ac9b76f3e2bd89119d137fc697a9e3b6",
+                "sha256:0896d5d15ffe584d46cb9b69a75cf14a2bc8f6daf635b7bf16c1b041342a44b1",
+                "sha256:1fb7a6f222072412f320b9e48d3ce981920efbfce37b06d028ec9bd94093b37f",
+                "sha256:4f1b594d0cf35bd12ec4244df1155a7f565bf6e6245976ac36174c1564688c90",
+                "sha256:51ebe9624ad0a0b4da1aaaa2d43aabadf8537737fd494cee0ffa37cd6326de02",
+                "sha256:681ac47c538c64305d710eaed2bb49532f62b3f4c93aa7c423c520df981392e5",
+                "sha256:702446a012fd9337b9327d168bb0c7dc714eb93ad361f6f61af9ca8305a301f1",
+                "sha256:720fafdf3e5c5de93039d8308f765cc60b8e9e7e852ad7135aa65dd89238191f",
+                "sha256:72de8c4d71e6b11d54528bb924447fa4fdabcbb3d76cc0e7f61d3b6075def6b3",
+                "sha256:765b8b16bc1fd699e183dde642c7f2653b8f3c9c1a50051139908e9683f97732",
+                "sha256:7a8b0e526ff239b4f4c61dd6898e2474d609843ffc437267f3a27ddff626e6f6",
+                "sha256:7b3478a187d897f003b2aa1793bcc59463e8d57a42e2aafbcbbe9cd47ec46863",
+                "sha256:857c16bffd938254e3a834cd6b2a755ed24e1a953b1a86e33da136d3e4c16a6f",
+                "sha256:88d6d54e83cf9bbd665ce1e7b9079983ee2d97a05f42e0569ff00a70f1dd8b1e",
+                "sha256:95bacf9ff7d1b90bba537d3f5f6c834efe6bfbb1a0195cb3573f29e6716ef08d",
+                "sha256:9c8e0e6c5e982699801b20fa74f43c19aa080d2b53a39f3c132d35958e153bd4",
+                "sha256:9ea70f6c3f6566159e3798e4593a4a8016994a0080ac29a45200615b45091a1b",
+                "sha256:b3af53dddf848afb38b3ac2bae7159ddad1feb9bac14aa3acec6ef1797b82f8d",
+                "sha256:ca6db61335d07220de0b665bfee7b8e9615b2dfc67a54016db4826dac34c2dd2",
+                "sha256:cb9453c981554984c6f5c5ce7682d7286e65e2173d7416114c3593a977a01bf5",
+                "sha256:d92a5eddffb0ad39f582f07c1de26e9daf6880e3e782a94bb7ebaf939567f8bf",
+                "sha256:deede160bdf87ddb71f0a1314ad5a267b1a960be314ea7dc6b7ad86da6da89a3",
+                "sha256:e3affa03c49cce7b0a9501cc7f608d4f8e61fb2522b276d599ac049b5955576d",
+                "sha256:e420cdfca73f80fe15f79bb34756959945231a052440813e5fce531e6e96331a",
+                "sha256:e468724173df02f9d83f3fea830bf0d04aa291b5add22b4a78e01c97aab04873",
+                "sha256:e5d72be02b17e6bd7919555811264403468d1d052fa67c946e402257c3c29a27",
+                "sha256:eec02d9199af4b1ccfe1f9c587691a07a1fa39d949d2c1dc69d079ab9af8212f",
+                "sha256:f5457e44d3f26d9946091e92b28f3e970a56538b96c87b4b155a84e32a40b7b5",
+                "sha256:f7aad304575d075faf2806977b726b67da7ba294adc97d878f92a062e357a56a"
             ],
             "index": "pypi",
-            "version": "==3.12.0"
+            "version": "==3.13.0"
         },
         "pyparsing": {
             "hashes": [
-                "sha256:04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4",
-                "sha256:d9bdec0013ef1eb5a84ab39a3b3868911598afa494f5faa038647101504e2b81"
+                "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea",
+                "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==3.0.6"
+            "version": "==3.0.7"
         },
         "python-dateutil": {
             "hashes": [
@@ -737,7 +740,7 @@
                 "sha256:5c6bd9dc7a543b7fe4304a631f8a8a3b674e2bbfc49c2ae96200cdbe55df6b17",
                 "sha256:95c5d300c4e879ee69708c428ba566c59478fd653cc3a22243eeb8ed846950bb"
             ],
-            "markers": "python_version >= '3.6' and python_version < '4'",
+            "markers": "python_version >= '3.6'",
             "version": "==4.8"
         },
         "sdc-cryptography": {
@@ -747,14 +750,6 @@
             ],
             "index": "pypi",
             "version": "==1.1.0"
-        },
-        "setuptools": {
-            "hashes": [
-                "sha256:2404879cda71495fc4d5cbc445ed52fdaddf352b36e40be8dcc63147cb4edabe",
-                "sha256:68eb94073fc486091447fcb0501efd6560a0e5a1839ba249e5ff3c4c93f05f90"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==60.5.0"
         },
         "six": {
             "hashes": [
@@ -777,7 +772,7 @@
                 "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed",
                 "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
             "version": "==1.26.8"
         },
         "werkzeug": {
@@ -959,6 +954,9 @@
             "version": "==8.0.3"
         },
         "coverage": {
+            "extras": [
+                "toml"
+            ],
             "hashes": [
                 "sha256:01774a2c2c729619760320270e42cd9e797427ecfddd32c2a7b639cdc481f3c0",
                 "sha256:03b20e52b7d31be571c9c06b74746746d4eb82fc260e594dc662ed48145e9efd",
@@ -1024,7 +1022,7 @@
                 "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
                 "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
             ],
-            "markers": "python_version >= '3.5'",
+            "markers": "python_version >= '3'",
             "version": "==3.3"
         },
         "iniconfig": {
@@ -1113,11 +1111,11 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4",
-                "sha256:d9bdec0013ef1eb5a84ab39a3b3868911598afa494f5faa038647101504e2b81"
+                "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea",
+                "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==3.0.6"
+            "version": "==3.0.7"
         },
         "pytest": {
             "hashes": [
@@ -1188,7 +1186,7 @@
                 "sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e",
                 "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"
             ],
-            "markers": "python_version >= '3.10'",
+            "markers": "python_version >= '3.6'",
             "version": "==4.0.1"
         },
         "urllib3": {
@@ -1196,7 +1194,7 @@
                 "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed",
                 "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
             "version": "==1.26.8"
         }
     }

--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 2.3.56
+version: 2.3.57
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.3.56
+appVersion: 2.3.57

--- a/frontstage/common/redis_cache.py
+++ b/frontstage/common/redis_cache.py
@@ -90,14 +90,14 @@ class RedisCache:
 
         return json.loads(result.decode("utf-8"))
 
-    def get_collection_exercise(self, key):
+    def get_collection_exercises_by_survey(self, key):
         """
         Gets the collection-exercise from redis or the collection-exercise service
 
         :param key: Key in redis (for this example will be a frontstage:collection-exercise:id)
         :return: Result from either the cache or collection-exercise service
         """
-        redis_key = f"frontstage:collection-exercise:{key}"
+        redis_key = f"frontstage:collection-exercise-by-survey-id:{key}"
         try:
             result = redis.get(redis_key)
         except RedisError:

--- a/frontstage/common/redis_cache.py
+++ b/frontstage/common/redis_cache.py
@@ -11,6 +11,7 @@ from frontstage.controllers.collection_instrument_controller import (
 )
 from frontstage.controllers.party_controller import get_party_by_business_id
 from frontstage.controllers.survey_controller import get_survey
+from frontstage.controllers.collection_exercise_controller import get_live_collection_exercises_for_survey
 
 logger = wrap_logger(logging.getLogger(__name__))
 
@@ -18,7 +19,8 @@ logger = wrap_logger(logging.getLogger(__name__))
 class RedisCache:
     SURVEY_CATEGORY_EXPIRY = 600  # 10 mins
     COLLECTION_INSTRUMENT_CATEGORY_EXPIRY = 600  # 10 mins
-    BUSINES_PARTY_CATEGORY_EXPIRY = 600
+    BUSINES_PARTY_CATEGORY_EXPIRY = 600  # 10 mins
+    COLLECTION_EXERCISE_CATEGORY_EXPIRY = 600  # 10 mins
 
     def get_survey(self, key):
         """
@@ -82,6 +84,29 @@ class RedisCache:
             logger.info("Key not in cache, getting value from party service", key=redis_key)
             result = get_party_by_business_id(key, app.config["PARTY_URL"], app.config["BASIC_AUTH"])
             self.save(redis_key, result, self.BUSINES_PARTY_CATEGORY_EXPIRY)
+            return result
+
+        return json.loads(result.decode("utf-8"))
+
+    def get_collection_exercise(self, key):
+        """
+        Gets the collection-exercise from redis or the collection-exercise service
+
+        :param key: Key in redis (for this example will be a frontstage:collection-exercise:id)
+        :return: Result from either the cache or collection-exercise service
+        """
+        redis_key = f"frontstage:collection-exercise:{key}"
+        try:
+            result = redis.get(redis_key)
+        except RedisError:
+            logger.error("Error getting value from cache, please investigate", key=redis_key, exc_info=True)
+            result = None
+
+        if not result:
+            logger.info("Key not in cache, getting value from collection-exercise service", key=redis_key)
+            result = get_live_collection_exercises_for_survey(key, app.config["COLLECTION_EXERCISE_URL"], app.config["BASIC_AUTH"])
+            # filter_ended_collection_exercises(key, app.config["COLLECTION_EXERCISE_URL"], app.config["BASIC_AUTH"])
+            self.save(redis_key, result, self.COLLECTION_EXERCISE_CATEGORY_EXPIRY)
             return result
 
         return json.loads(result.decode("utf-8"))

--- a/frontstage/common/redis_cache.py
+++ b/frontstage/common/redis_cache.py
@@ -21,7 +21,7 @@ logger = wrap_logger(logging.getLogger(__name__))
 class RedisCache:
     SURVEY_CATEGORY_EXPIRY = 600  # 10 mins
     COLLECTION_INSTRUMENT_CATEGORY_EXPIRY = 600  # 10 mins
-    BUSINES_PARTY_CATEGORY_EXPIRY = 600  # 10 mins
+    BUSINESS_PARTY_CATEGORY_EXPIRY = 600  # 10 mins
     COLLECTION_EXERCISE_CATEGORY_EXPIRY = 600  # 10 mins
 
     def get_survey(self, key):
@@ -85,7 +85,7 @@ class RedisCache:
         if not result:
             logger.info("Key not in cache, getting value from party service", key=redis_key)
             result = get_party_by_business_id(key, app.config["PARTY_URL"], app.config["BASIC_AUTH"])
-            self.save(redis_key, result, self.BUSINES_PARTY_CATEGORY_EXPIRY)
+            self.save(redis_key, result, self.BUSINESS_PARTY_CATEGORY_EXPIRY)
             return result
 
         return json.loads(result.decode("utf-8"))

--- a/frontstage/common/redis_cache.py
+++ b/frontstage/common/redis_cache.py
@@ -6,12 +6,14 @@ from redis.exceptions import RedisError
 from structlog import wrap_logger
 
 from frontstage import redis
+from frontstage.controllers.collection_exercise_controller import (
+    get_live_collection_exercises_for_survey,
+)
 from frontstage.controllers.collection_instrument_controller import (
     get_collection_instrument,
 )
 from frontstage.controllers.party_controller import get_party_by_business_id
 from frontstage.controllers.survey_controller import get_survey
-from frontstage.controllers.collection_exercise_controller import get_live_collection_exercises_for_survey
 
 logger = wrap_logger(logging.getLogger(__name__))
 
@@ -104,8 +106,9 @@ class RedisCache:
 
         if not result:
             logger.info("Key not in cache, getting value from collection-exercise service", key=redis_key)
-            result = get_live_collection_exercises_for_survey(key, app.config["COLLECTION_EXERCISE_URL"], app.config["BASIC_AUTH"])
-            # filter_ended_collection_exercises(key, app.config["COLLECTION_EXERCISE_URL"], app.config["BASIC_AUTH"])
+            result = get_live_collection_exercises_for_survey(
+                key, app.config["COLLECTION_EXERCISE_URL"], app.config["BASIC_AUTH"]
+            )
             self.save(redis_key, result, self.COLLECTION_EXERCISE_CATEGORY_EXPIRY)
             return result
 

--- a/frontstage/controllers/party_controller.py
+++ b/frontstage/controllers/party_controller.py
@@ -438,7 +438,8 @@ def get_survey_list_details_for_party(respondent: dict, tag: str, business_party
 
     #  Populate the enrolments by creating a dictionary using the redis_cache
     enrolments = get_respondent_enrolments_for_started_collex(
-        enrolment_data, dict((survey_id, redis_cache.get_collection_exercises_by_survey(survey_id)) for survey_id in surveys_ids)
+        enrolment_data,
+        dict((survey_id, redis_cache.get_collection_exercises_by_survey(survey_id)) for survey_id in surveys_ids),
     )
     for enrolment in enrolments:
         business_party = redis_cache.get_business_party(enrolment["business_id"])
@@ -448,7 +449,9 @@ def get_survey_list_details_for_party(respondent: dict, tag: str, business_party
         # collection exercise service, the filter_ended_collection_exercises function will no longer
         # be needed as we can request what we want instead of having to filter what we get.
 
-        live_collection_exercises = filter_ended_collection_exercises(redis_cache.get_collection_exercises_by_survey(survey["id"]))
+        live_collection_exercises = filter_ended_collection_exercises(
+            redis_cache.get_collection_exercises_by_survey(survey["id"])
+        )
 
         collection_exercises_by_id = dict((ce["id"], ce) for ce in live_collection_exercises)
         cases_for_business = cache_data["cases"][business_party["id"]]

--- a/frontstage/controllers/party_controller.py
+++ b/frontstage/controllers/party_controller.py
@@ -356,12 +356,12 @@ def caching_data_for_survey_list(cache_data, surveys_ids, business_ids, tag):
     # in the cache_data.
     threads = []
 
-    for survey_id in surveys_ids:
-        threads.append(
-            ThreadWrapper(
-                get_collex, cache_data, survey_id, app.config["COLLECTION_EXERCISE_URL"], app.config["BASIC_AUTH"]
-            )
-        )
+    # for survey_id in surveys_ids:
+    #     threads.append(
+    #         ThreadWrapper(
+    #             get_collex, cache_data, survey_id, app.config["COLLECTION_EXERCISE_URL"], app.config["BASIC_AUTH"]
+    #         )
+    #     )
 
     for business_id in business_ids:
         threads.append(
@@ -444,6 +444,10 @@ def get_survey_list_details_for_party(respondent: dict, tag: str, business_party
     # Populate the cache with all non-instrument data
     caching_data_for_survey_list(cache_data, surveys_ids, business_ids, tag)
 
+    # Creates a dictionary of collection exercises to be used to generate the enrolments
+    for survey_id in surveys_ids:
+        cache_data["collexes"][survey_id] = redis_cache.get_collection_exercise(survey_id)
+
     enrolments = get_respondent_enrolments_for_started_collex(enrolment_data, cache_data["collexes"])
     for enrolment in enrolments:
         business_party = redis_cache.get_business_party(enrolment["business_id"])
@@ -452,7 +456,8 @@ def get_survey_list_details_for_party(respondent: dict, tag: str, business_party
         # Note: If it ever becomes possible to get only live-but-not-ended collection exercises from the
         # collection exercise service, the filter_ended_collection_exercises function will no longer
         # be needed as we can request what we want instead of having to filter what we get.
-        live_collection_exercises = filter_ended_collection_exercises(cache_data["collexes"][survey["id"]])
+
+        live_collection_exercises = filter_ended_collection_exercises(redis_cache.get_collection_exercise(survey["id"]))
 
         collection_exercises_by_id = dict((ce["id"], ce) for ce in live_collection_exercises)
         cases_for_business = cache_data["cases"][business_party["id"]]

--- a/frontstage/controllers/party_controller.py
+++ b/frontstage/controllers/party_controller.py
@@ -350,9 +350,8 @@ def get_unique_survey_and_business_ids(enrolment_data):
     return surveys_ids, business_ids
 
 
-def caching_data_for_survey_list(cache_data, surveys_ids, business_ids, tag):
-    # Creates a list of threads which will call functions to set the survey, case, party and collex responses
-    # in the cache_data.
+def caching_case_data(cache_data, business_ids, tag):
+    # Creates a list of threads which will call functions to set the case in the cache_data.
     threads = []
 
     for business_id in business_ids:
@@ -433,8 +432,8 @@ def get_survey_list_details_for_party(respondent: dict, tag: str, business_party
     cache_data = {"cases": dict()}
     redis_cache = RedisCache()
 
-    # Populate the cache with all non-instrument data
-    caching_data_for_survey_list(cache_data, surveys_ids, business_ids, tag)
+    # Populate the cache with all case data
+    caching_case_data(cache_data, business_ids, tag)
 
     #  Populate the enrolments by creating a dictionary using the redis_cache
     enrolments = get_respondent_enrolments_for_started_collex(

--- a/frontstage/controllers/party_controller.py
+++ b/frontstage/controllers/party_controller.py
@@ -449,9 +449,7 @@ def get_survey_list_details_for_party(respondent: dict, tag: str, business_party
         # collection exercise service, the filter_ended_collection_exercises function will no longer
         # be needed as we can request what we want instead of having to filter what we get.
 
-        live_collection_exercises = filter_ended_collection_exercises(
-            redis_cache.get_collection_exercises_by_survey(survey["id"])
-        )
+        live_collection_exercises = filter_ended_collection_exercises(collection_exercises[enrolment["survey_id"]])
 
         collection_exercises_by_id = dict((ce["id"], ce) for ce in live_collection_exercises)
         cases_for_business = cache_data["cases"][business_party["id"]]

--- a/frontstage/controllers/party_controller.py
+++ b/frontstage/controllers/party_controller.py
@@ -438,7 +438,7 @@ def get_survey_list_details_for_party(respondent: dict, tag: str, business_party
 
     #  Populate the enrolments by creating a dictionary using the redis_cache
     enrolments = get_respondent_enrolments_for_started_collex(
-        enrolment_data, dict((s_id, redis_cache.get_collection_exercise(s_id)) for s_id in surveys_ids)
+        enrolment_data, dict((survey_id, redis_cache.get_collection_exercise(survey_id)) for survey_id in surveys_ids)
     )
     for enrolment in enrolments:
         business_party = redis_cache.get_business_party(enrolment["business_id"])

--- a/frontstage/controllers/party_controller.py
+++ b/frontstage/controllers/party_controller.py
@@ -11,7 +11,6 @@ from frontstage.common.thread_wrapper import ThreadWrapper
 from frontstage.common.utilities import obfuscate_email
 from frontstage.controllers import (
     case_controller,
-    collection_exercise_controller,
     collection_instrument_controller,
     survey_controller,
 )
@@ -438,9 +437,9 @@ def get_survey_list_details_for_party(respondent: dict, tag: str, business_party
     caching_data_for_survey_list(cache_data, surveys_ids, business_ids, tag)
 
     #  Populate the enrolments by creating a dictionary using the redis_cache
-    enrolments = get_respondent_enrolments_for_started_collex(enrolment_data,
-                                                              dict((s_id, redis_cache.get_collection_exercise(s_id))
-                                                                   for s_id in surveys_ids))
+    enrolments = get_respondent_enrolments_for_started_collex(
+        enrolment_data, dict((s_id, redis_cache.get_collection_exercise(s_id)) for s_id in surveys_ids)
+    )
     for enrolment in enrolments:
         business_party = redis_cache.get_business_party(enrolment["business_id"])
         survey = redis_cache.get_survey(enrolment["survey_id"])

--- a/frontstage/controllers/party_controller.py
+++ b/frontstage/controllers/party_controller.py
@@ -438,7 +438,7 @@ def get_survey_list_details_for_party(respondent: dict, tag: str, business_party
 
     #  Populate the enrolments by creating a dictionary using the redis_cache
     enrolments = get_respondent_enrolments_for_started_collex(
-        enrolment_data, dict((survey_id, redis_cache.get_collection_exercise(survey_id)) for survey_id in surveys_ids)
+        enrolment_data, dict((survey_id, redis_cache.get_collection_exercises_by_survey(survey_id)) for survey_id in surveys_ids)
     )
     for enrolment in enrolments:
         business_party = redis_cache.get_business_party(enrolment["business_id"])
@@ -448,7 +448,7 @@ def get_survey_list_details_for_party(respondent: dict, tag: str, business_party
         # collection exercise service, the filter_ended_collection_exercises function will no longer
         # be needed as we can request what we want instead of having to filter what we get.
 
-        live_collection_exercises = filter_ended_collection_exercises(redis_cache.get_collection_exercise(survey["id"]))
+        live_collection_exercises = filter_ended_collection_exercises(redis_cache.get_collection_exercises_by_survey(survey["id"]))
 
         collection_exercises_by_id = dict((ce["id"], ce) for ce in live_collection_exercises)
         cases_for_business = cache_data["cases"][business_party["id"]]

--- a/frontstage/controllers/party_controller.py
+++ b/frontstage/controllers/party_controller.py
@@ -431,7 +431,7 @@ def get_survey_list_details_for_party(respondent: dict, tag: str, business_party
 
     # This is a dictionary that will store all the data that is going to be cached instead of making multiple calls
     # inside the for loop for get_respondent_enrolments.
-    cache_data = {"collexes": dict(), "cases": dict()}
+    cache_data = {"cases": dict()}
     redis_cache = RedisCache()
 
     # Populate the cache with all non-instrument data

--- a/frontstage/controllers/party_controller.py
+++ b/frontstage/controllers/party_controller.py
@@ -436,10 +436,11 @@ def get_survey_list_details_for_party(respondent: dict, tag: str, business_party
     caching_case_data(cache_data, business_ids, tag)
 
     #  Populate the enrolments by creating a dictionary using the redis_cache
-    enrolments = get_respondent_enrolments_for_started_collex(
-        enrolment_data,
-        dict((survey_id, redis_cache.get_collection_exercises_by_survey(survey_id)) for survey_id in surveys_ids),
-    )
+    collection_exercises = {
+        survey_id: redis_cache.get_collection_exercises_by_survey(survey_id) for survey_id in surveys_ids
+    }
+    enrolments = get_respondent_enrolments_for_started_collex(enrolment_data, collection_exercises)
+
     for enrolment in enrolments:
         business_party = redis_cache.get_business_party(enrolment["business_id"])
         survey = redis_cache.get_survey(enrolment["survey_id"])

--- a/tests/integration/controllers/test_party_controller.py
+++ b/tests/integration/controllers/test_party_controller.py
@@ -28,7 +28,7 @@ from tests.integration.mocked_services import (
     respondent_party,
     survey,
     url_get_business_party,
-    url_get_collection_exercise,
+    url_get_collection_exercises_by_survey,
     url_get_respondent_email,
     url_get_respondent_party,
     url_get_survey,
@@ -264,7 +264,7 @@ class TestPartyController(unittest.TestCase):
         with responses.RequestsMock() as rsps:
             rsps.add(rsps.GET, url_get_survey, json=survey, status=200)
             rsps.add(rsps.GET, url_get_business_party, json=business_party, status=200)
-            rsps.add(rsps.GET, url_get_collection_exercise, json=collection_exercise, status=200)
+            rsps.add(rsps.GET, url_get_collection_exercises_by_survey, json=collection_exercise_by_survey, status=200)
 
             survey_list = party_controller.get_survey_list_details_for_party(
                 respondent_party["id"], "todo", business_party["id"], survey["id"]

--- a/tests/integration/controllers/test_party_controller.py
+++ b/tests/integration/controllers/test_party_controller.py
@@ -9,9 +9,6 @@ import responses
 from config import TestingConfig
 from frontstage import app
 from frontstage.controllers import party_controller
-from frontstage.controllers.collection_exercise_controller import (
-    convert_events_to_new_format,
-)
 from frontstage.controllers.party_controller import (
     display_button,
     filter_ended_collection_exercises,
@@ -251,10 +248,6 @@ class TestPartyController(unittest.TestCase):
         calculate_case_status,
     ):
         enrolments = [{"business_id": business_party["id"], "survey_id": survey["id"]}]
-
-        for collection_exercise_index in collection_exercise_by_survey:
-            if collection_exercise_index["events"]:
-                collection_exercise_index["events"] = convert_events_to_new_format(collection_exercise_index["events"])
 
         get_respondent_enrolments.return_value = enrolments
         get_cases.return_value = case_list

--- a/tests/integration/controllers/test_party_controller.py
+++ b/tests/integration/controllers/test_party_controller.py
@@ -264,7 +264,7 @@ class TestPartyController(unittest.TestCase):
         with responses.RequestsMock() as rsps:
             rsps.add(rsps.GET, url_get_survey, json=survey, status=200)
             rsps.add(rsps.GET, url_get_business_party, json=business_party, status=200)
-            rsps.add(rsps.GET, url_get_collection_exercises_by_survey, json=collection_exercise, status=200)
+            rsps.add(rsps.GET, url_get_collection_exercises_by_survey, json=collection_exercise_by_survey, status=200)
 
             survey_list = party_controller.get_survey_list_details_for_party(
                 respondent_party["id"], "todo", business_party["id"], survey["id"]

--- a/tests/integration/controllers/test_party_controller.py
+++ b/tests/integration/controllers/test_party_controller.py
@@ -264,7 +264,7 @@ class TestPartyController(unittest.TestCase):
         with responses.RequestsMock() as rsps:
             rsps.add(rsps.GET, url_get_survey, json=survey, status=200)
             rsps.add(rsps.GET, url_get_business_party, json=business_party, status=200)
-            rsps.add(rsps.GET, url_get_collection_exercise, json=collection_exercise_by_survey, status=200)
+            rsps.add(rsps.GET, url_get_collection_exercise, json=collection_exercise, status=200)
 
             survey_list = party_controller.get_survey_list_details_for_party(
                 respondent_party["id"], "todo", business_party["id"], survey["id"]

--- a/tests/integration/controllers/test_party_controller.py
+++ b/tests/integration/controllers/test_party_controller.py
@@ -264,7 +264,7 @@ class TestPartyController(unittest.TestCase):
         with responses.RequestsMock() as rsps:
             rsps.add(rsps.GET, url_get_survey, json=survey, status=200)
             rsps.add(rsps.GET, url_get_business_party, json=business_party, status=200)
-            rsps.add(rsps.GET, url_get_collection_exercises_by_survey, json=collection_exercise_by_survey, status=200)
+            rsps.add(rsps.GET, url_get_collection_exercises_by_survey, json=collection_exercise, status=200)
 
             survey_list = party_controller.get_survey_list_details_for_party(
                 respondent_party["id"], "todo", business_party["id"], survey["id"]

--- a/tests/integration/controllers/test_party_controller.py
+++ b/tests/integration/controllers/test_party_controller.py
@@ -28,6 +28,7 @@ from tests.integration.mocked_services import (
     respondent_party,
     survey,
     url_get_business_party,
+    url_get_collection_exercise,
     url_get_respondent_email,
     url_get_respondent_party,
     url_get_survey,
@@ -241,12 +242,10 @@ class TestPartyController(unittest.TestCase):
     @patch("frontstage.controllers.case_controller.calculate_case_status")
     @patch("frontstage.controllers.collection_instrument_controller.get_collection_instrument")
     @patch("frontstage.controllers.case_controller.get_cases_for_list_type_by_party_id")
-    @patch("frontstage.controllers.collection_exercise_controller.get_live_collection_exercises_for_survey")
     @patch("frontstage.controllers.party_controller.get_respondent_enrolments")
     def test_get_survey_list_details_for_party(
         self,
         get_respondent_enrolments,
-        get_collection_exercises,
         get_cases,
         get_collection_instrument,
         calculate_case_status,
@@ -258,7 +257,6 @@ class TestPartyController(unittest.TestCase):
                 collection_exercise_index["events"] = convert_events_to_new_format(collection_exercise_index["events"])
 
         get_respondent_enrolments.return_value = enrolments
-        get_collection_exercises.return_value = collection_exercise_by_survey
         get_cases.return_value = case_list
         get_collection_instrument.return_value = collection_instrument_seft
         calculate_case_status.return_value = "In Progress"
@@ -266,6 +264,7 @@ class TestPartyController(unittest.TestCase):
         with responses.RequestsMock() as rsps:
             rsps.add(rsps.GET, url_get_survey, json=survey, status=200)
             rsps.add(rsps.GET, url_get_business_party, json=business_party, status=200)
+            rsps.add(rsps.GET, url_get_collection_exercise, json=collection_exercise_by_survey, status=200)
 
             survey_list = party_controller.get_survey_list_details_for_party(
                 respondent_party["id"], "todo", business_party["id"], survey["id"]


### PR DESCRIPTION
# What and why?
Changing where the collection exercise cache is stored, in the common redis cache rather than in instance cached_data. This is to match what has been done with survey and collection instrument and business party, also the population of enrolments has been changed since it used the entire collex dictionary

# How to test?

# Trello
