### PR TITLE
Return empty list if there are no live exercises

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 2.3.58
+version: 2.3.59
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.3.58
+appVersion: 2.3.59

--- a/frontstage/controllers/collection_exercise_controller.py
+++ b/frontstage/controllers/collection_exercise_controller.py
@@ -67,6 +67,9 @@ def get_collection_exercises_for_survey(survey_id, collex_url, collex_auth, live
         raise ApiError(logger, response)
 
     if response.status_code == 204:
+        logger.info(
+            "No live exercises found, returning empty list for collection exercises by survey", survey_id=survey_id
+        )
         return []
     logger.info("Successfully retrieved collection exercises for survey", survey_id=survey_id)
     collection_exercises = response.json()

--- a/frontstage/controllers/collection_exercise_controller.py
+++ b/frontstage/controllers/collection_exercise_controller.py
@@ -66,6 +66,8 @@ def get_collection_exercises_for_survey(survey_id, collex_url, collex_auth, live
         logger.error("Failed to retrieve collection exercises for survey", survey_id=survey_id)
         raise ApiError(logger, response)
 
+    if response.status_code == 204:
+        return []
     logger.info("Successfully retrieved collection exercises for survey", survey_id=survey_id)
     collection_exercises = response.json()
 


### PR DESCRIPTION
# What and why?

If you're signed up for a survey that has no live collection exercise then collection when you try and load the survey list, you'll see an error.
This is because collection exercise gives a 204 with no content when there aren't any (which is correct).  The code takes a successful response then does `response.json()` to it.  For a 200 response this works fine, but if you do that when theres no content it complains.

We'll simply change it so that if it's a 204 then just return an empty list to represent nothing.

# How to test?

- Create collection exercise in response ops (with a quick end date)
- Make it live
- Enrol for that collection exercise as a respondent (optional: and verify it appears in your survey todo list)
- Wait for the collection exercise to end
- Try and load your todo list page again. Previously this step would result in an error.  Now it just results in a happy todo page.

# Trello
