### PR TITLE
Pen Test Force logout on password change and 12 char min for password

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 2.4.6
+version: 2.4.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.4.6
+appVersion: 2.4.7

--- a/config.py
+++ b/config.py
@@ -43,7 +43,7 @@ class Config(object):
 
     PASSWORD_MATCH_ERROR_TEXT = "Your passwords do not match"
     PASSWORD_CRITERIA_ERROR_TEXT = "Your password doesn't meet the requirements"
-    PASSWORD_MIN_LENGTH = 8
+    PASSWORD_MIN_LENGTH = 12
     PASSWORD_MAX_LENGTH = 160
 
     AUTH_URL = os.getenv("AUTH_URL")

--- a/frontstage/templates/account/account-change-password.html
+++ b/frontstage/templates/account/account-change-password.html
@@ -100,7 +100,7 @@
                 <div class="message">
                     <p>Your password must have:</p>
                     <ul>
-                        <li>at least 8 characters </li>
+                        <li>at least 12 characters </li>
                         <li>at least 1 uppercase letter</li>
                         <li>at least 1 symbol (eg: ?!£%) </li>
                         <li>at least 1 number</li>

--- a/frontstage/templates/passwords/reset-password.html
+++ b/frontstage/templates/passwords/reset-password.html
@@ -65,7 +65,7 @@
         onsList({
             "itemsList": [
                 {
-                    "text": "at least 8 characters"
+                    "text": "at least 12 characters"
                 },
                 {
                     "text": "at least one capital letter"

--- a/frontstage/templates/register/register-pending-survey-enter-your-details.html
+++ b/frontstage/templates/register/register-pending-survey-enter-your-details.html
@@ -95,7 +95,7 @@
         <h2 class="u-mt-l">Create a password</h2>
         <p>Your password must have:</p>
         <ul>
-            <li>at least 8 characters </li>
+            <li>at least 12 characters </li>
             <li>at least one symbol (eg ?!£%) </li>
             <li>at least one capital letter</li>
             <li>at least one number</li>

--- a/frontstage/templates/register/register.enter-your-details.html
+++ b/frontstage/templates/register/register.enter-your-details.html
@@ -127,7 +127,7 @@
         <h2 class="u-mt-l">Create a password</h2>
         <p>Your password must have:</p>
         <ul>
-            <li>at least 8 characters </li>
+            <li>at least 12 characters </li>
             <li>at least one symbol (eg ?!£%) </li>
             <li>at least one capital letter</li>
             <li>at least one number</li>

--- a/frontstage/templates/sign-in/sign-in.html
+++ b/frontstage/templates/sign-in/sign-in.html
@@ -83,6 +83,22 @@
         {%- endif -%}
     {%- endwith -%}
 
+    {%- with messages = get_flashed_messages(category_filter=["success"]) -%}
+        {%- if messages -%}
+            {% call
+                onsPanel({
+                    "type": 'success',
+                    "classes": "u-mb-s",
+                    "icon": "check",
+                })
+            %}
+                    {%- for message in messages -%}
+                        <p>{{ message }}</p>
+                    {%- endfor -%}
+            {% endcall %}
+        {%- endif -%}
+    {%- endwith -%}
+
     <form method="post" class="form" action="{{ url_for('sign_in_bp.login', next=next) }}" role="form">
         {{ form.csrf_token }}
 

--- a/frontstage/views/account/account.py
+++ b/frontstage/views/account/account.py
@@ -80,8 +80,8 @@ def change_password(session):
             bound_logger.info("Attempting to change password via party service")
             party_controller.change_password(username, new_password)
             bound_logger.info("password changed via party service")
-            flash("Your password has been changed.")
-            return redirect(url_for("surveys_bp.get_survey_list", tag="todo"))
+            flash("Your password has been changed. Please login with your new password.", "success")
+            return redirect(url_for("sign_in_bp.logout"))
         except AuthError as exc:
             error_message = exc.auth_error
             if BAD_CREDENTIALS_ERROR in error_message:

--- a/frontstage/views/sign_in/sign_in.py
+++ b/frontstage/views/sign_in/sign_in.py
@@ -108,7 +108,6 @@ def login():  # noqa: C901
         session.set_unread_message_total(count)
         bound_logger.info("Successfully created session", session_key=session.session_key)
         return response
-
     template_data = {"error": {"type": form.errors, "logged_in": "False"}, "account_activated": account_activated}
     if request.args.get("next"):
         return render_template("sign-in/sign-in.html", form=form, data=template_data, next=request.args.get("next"))

--- a/tests/integration/test_passwords.py
+++ b/tests/integration/test_passwords.py
@@ -168,7 +168,7 @@ class TestPasswords(unittest.TestCase):
     def test_reset_password_post_success(self, mock_request):
         mock_request.get(url_banner_api, status_code=404)
         mock_request.put(url_password_change, status_code=200)
-        password_form = {"password": "Gizmo007!", "password_confirm": "Gizmo007!"}
+        password_form = {"password": "Gizmo007!Gizmo", "password_confirm": "Gizmo007!Gizmo"}
         with app.app_context():
             token = verification.generate_email_token("test.com")
         response = self.app.post(f"passwords/reset-password/{token}", data=password_form, follow_redirects=True)
@@ -180,7 +180,7 @@ class TestPasswords(unittest.TestCase):
     def test_reset_password_post_token_expired(self, mock_request):
         mock_request.get(url_banner_api, status_code=404)
         mock_request.put(url_password_change, status_code=409)
-        password_form = {"password": "Gizmo007!", "password_confirm": "Gizmo007!"}
+        password_form = {"password": "Gizmo007!Gizmo", "password_confirm": "Gizmo007!Gizmo"}
         with app.app_context():
             token = verification.generate_email_token("test.com")
         response = self.app.post(f"passwords/reset-password/{token}", data=password_form, follow_redirects=True)
@@ -192,7 +192,7 @@ class TestPasswords(unittest.TestCase):
     def test_reset_password_post_token_invalid(self, mock_request):
         mock_request.get(url_banner_api, status_code=404)
         mock_request.put(url_password_change, status_code=404)
-        password_form = {"password": "Gizmo007!", "password_confirm": "Gizmo007!"}
+        password_form = {"password": "Gizmo007!Gizmo", "password_confirm": "Gizmo007!Gizmo"}
         with app.app_context():
             token = verification.generate_email_token("test.com")
         response = self.app.post(f"passwords/reset-password/{token}", data=password_form, follow_redirects=True)
@@ -241,7 +241,7 @@ class TestPasswords(unittest.TestCase):
     def test_reset_password_put_party_service_fail(self, mock_request):
         mock_request.get(url_banner_api, status_code=404)
         mock_request.put(url_password_change, status_code=500)
-        password_form = {"password": "Gizmo007!", "password_confirm": "Gizmo007!"}
+        password_form = {"password": "Gizmo007!Gizmo", "password_confirm": "Gizmo007!Gizmo"}
         with app.app_context():
             token = verification.generate_email_token("test.com")
 

--- a/tests/integration/views/account/test_accept_share_survey.py
+++ b/tests/integration/views/account/test_accept_share_survey.py
@@ -216,8 +216,8 @@ class TestAcceptShareSurvey(unittest.TestCase):
         data = {
             "first_name": "test",
             "last_name": "test",
-            "password": "Test!129",
-            "password_confirm": "Test!129",
+            "password": "Test!129Test",
+            "password_confirm": "Test!129Test",
             "phone_number": "07456534567",
         }
 

--- a/tests/integration/views/account/test_accept_transfer_survey.py
+++ b/tests/integration/views/account/test_accept_transfer_survey.py
@@ -217,8 +217,8 @@ class TestAcceptTransferSurvey(unittest.TestCase):
         data = {
             "first_name": "test",
             "last_name": "test",
-            "password": "Test!129",
-            "password_confirm": "Test!129",
+            "password": "Testtest!129",
+            "password_confirm": "Testtest!129",
             "phone_number": "07456534567",
         }
 

--- a/tests/integration/views/account/test_account.py
+++ b/tests/integration/views/account/test_account.py
@@ -161,7 +161,7 @@ class TestSurveyList(unittest.TestCase):
         self.assertTrue("Change your password".encode() in response.data)
         self.assertTrue("Enter your current password".encode() in response.data)
         self.assertTrue("Your password must have:".encode() in response.data)
-        self.assertTrue("at least 8 characters".encode() in response.data)
+        self.assertTrue("at least 12 characters".encode() in response.data)
         self.assertTrue("at least 1 uppercase letter".encode() in response.data)
         self.assertTrue("at least 1 symbol (eg: ?!£%)".encode() in response.data)
         self.assertTrue("at least 1 number".encode() in response.data)

--- a/tests/integration/views/account/test_password_change.py
+++ b/tests/integration/views/account/test_password_change.py
@@ -65,8 +65,10 @@ class TestSurveyList(unittest.TestCase):
             follow_redirects=True,
         )
         self.assertEqual(response.status_code, 200)
-        self.assertTrue("Your password has been changed.".encode() in response.data)
-        self.assertTrue("Use your enrolment code".encode() in response.data)
+        self.assertTrue(
+            "Your password has been changed. Please login with your new password.".encode() in response.data
+        )
+        self.assertTrue("Sign in".encode() in response.data)
 
     @requests_mock.mock()
     @patch("frontstage.controllers.party_controller.get_respondent_party_by_id")


### PR DESCRIPTION
# What and why?
This PR covers two trello cards. 
- changes made to force minimum 12 characters for password.
- changes made to enforce logout when password is changed.
# How to test?
- test min. character for password in account creation, password change, share surveys and transfer surveys
-  test when password is changed you are logged out.

# Trello
https://trello.com/c/kJqhpjMb/1408-frontstage-password-change-should-invalidate-the-current-session-and-force-logout
https://trello.com/c/V85Hppyn/1409-weak-password-policy