### PR TITLE
Removing next parameter from url

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 2.4.11
+version: 2.4.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.4.11
+appVersion: 2.4.12

--- a/frontstage/common/authorisation.py
+++ b/frontstage/common/authorisation.py
@@ -2,7 +2,7 @@ import logging
 from datetime import datetime
 from functools import wraps
 
-from flask import flash, url_for, session
+from flask import flash, session, url_for
 from jose import JWTError
 from jose.jwt import decode
 from structlog import wrap_logger
@@ -53,7 +53,7 @@ def jwt_authorization(request):
             else:
                 logger.warning("No authorization token provided")
                 flash("To help protect your information we have signed you out.", "info")
-                session['next'] = request.url
+                session["next"] = request.url
                 return redirect(url_for("sign_in_bp.login"))
 
             if app.config["VALIDATE_JWT"]:

--- a/frontstage/common/authorisation.py
+++ b/frontstage/common/authorisation.py
@@ -2,7 +2,7 @@ import logging
 from datetime import datetime
 from functools import wraps
 
-from flask import flash, url_for
+from flask import flash, url_for, session
 from jose import JWTError
 from jose.jwt import decode
 from structlog import wrap_logger
@@ -40,8 +40,8 @@ def jwt_authorization(request):
         @wraps(original_function)
         def extract_session_wrapper(*args, **kwargs):
             session_key = request.cookies.get("authorization")
-            session = Session.from_session_key(session_key)
-            encoded_jwt = session.get_encoded_jwt()
+            redis_session = Session.from_session_key(session_key)
+            encoded_jwt = redis_session.get_encoded_jwt()
             if encoded_jwt:
                 logger.debug("Attempting to authorize token")
                 try:
@@ -53,12 +53,13 @@ def jwt_authorization(request):
             else:
                 logger.warning("No authorization token provided")
                 flash("To help protect your information we have signed you out.", "info")
-                return redirect(url_for("sign_in_bp.login", next=request.url))
+                session['next'] = request.url
+                return redirect(url_for("sign_in_bp.login"))
 
             if app.config["VALIDATE_JWT"]:
                 if validate(jwt):
-                    session.refresh_session()
-                    return original_function(session, *args, **kwargs)
+                    redis_session.refresh_session()
+                    return original_function(redis_session, *args, **kwargs)
                 else:
                     logger.warning("Token is not valid for this request")
                     raise JWTValidationError

--- a/frontstage/error_handlers.py
+++ b/frontstage/error_handlers.py
@@ -40,7 +40,8 @@ def handle_csrf_error(error):
     if not encoded_jwt:
         return render_template("errors/400-error.html"), 400
     else:
-        return redirect(url_for("sign_in_bp.logout", csrf_error=True, next=request.url))
+        session["next"] = request.url
+        return redirect(url_for("sign_in_bp.logout", csrf_error=True))
 
 
 @app.errorhandler(ApiError)

--- a/frontstage/error_handlers.py
+++ b/frontstage/error_handlers.py
@@ -1,6 +1,6 @@
 import logging
 
-from flask import render_template, request, url_for
+from flask import render_template, request, session, url_for
 from flask_wtf.csrf import CSRFError
 from requests.exceptions import ConnectionError
 from structlog import wrap_logger

--- a/frontstage/views/sign_in/sign_in.py
+++ b/frontstage/views/sign_in/sign_in.py
@@ -85,8 +85,8 @@ def login():  # noqa: C901
         bound_logger = bound_logger.bind(party_id=party_id)
 
         if session.get("next"):
-            session.pop("next")
             response = make_response(redirect(session.get("next")))
+            session.pop("next")
         else:
             response = make_response(
                 redirect(

--- a/frontstage/views/sign_in/sign_in.py
+++ b/frontstage/views/sign_in/sign_in.py
@@ -74,9 +74,7 @@ def login():  # noqa: C901
             else:
                 bound_logger.error("Unexpected error was returned from Auth service", auth_error=error_message)
 
-            return render_template(
-                "sign-in/sign-in.html", form=form, data={"error": {"type": "failed"}}
-            )
+            return render_template("sign-in/sign-in.html", form=form, data={"error": {"type": "failed"}})
 
         bound_logger.info("Successfully found user in auth service.  Attempting to find user in party service")
         party_json = party_controller.get_respondent_by_email(username)
@@ -86,8 +84,9 @@ def login():  # noqa: C901
         party_id = party_json["id"]
         bound_logger = bound_logger.bind(party_id=party_id)
 
-        if session.get('next'):
-            response = make_response(redirect(session.get('next')))
+        if session.get("next"):
+            session.pop("next")
+            response = make_response(redirect(session.get("next")))
         else:
             response = make_response(
                 redirect(
@@ -100,7 +99,11 @@ def login():  # noqa: C901
         redis_session = Session.from_party_id(party_id)
         secure = app.config["WTF_CSRF_ENABLED"]
         response.set_cookie(
-            "authorization", value=redis_session.session_key, expires=redis_session.get_expires_in(), secure=secure, httponly=secure
+            "authorization",
+            value=redis_session.session_key,
+            expires=redis_session.get_expires_in(),
+            secure=secure,
+            httponly=secure,
         )
         count = conversation_controller.get_message_count_from_api(redis_session)
         redis_session.set_unread_message_total(count)

--- a/tests/integration/test_sign_in.py
+++ b/tests/integration/test_sign_in.py
@@ -126,9 +126,9 @@ class TestSignIn(unittest.TestCase):
         mock_request.get(url_get_respondent_email, json=party)
         mock_request.post(url_auth_token, status_code=200, json=self.auth_response)
         mock_request.get(url_get_conversation_count, json=message_count)
-        response = self.app.post(
-            "/sign-in/", data=self.sign_in_form, query_string={"next": "http://localhost:8082/secure-message/threads"}
-        )
+        with self.app.session_transaction() as mock_session:
+            mock_session["next"] = "http://localhost:8082/secure-message/threads"
+        response = self.app.post("/sign-in/", data=self.sign_in_form)
         self.assertEqual(response.status_code, 302)
         self.assertTrue("/secure-message/threads".encode() in response.data)
 


### PR DESCRIPTION
# What and why?

Currently, if you access a page you need to be logged in for, it'll redirect you and  put where you came from in the `next` parameter in the http request.  This is bad practice so we needed to change it.  

I took a leaf out of flask-login's book using their `USE_SESSION_FOR_NEXT` functionality to write the next parameter into the flask session (which is an encrypted value saved as a cookie).  The exact bit can be found https://github.com/maxcountryman/flask-login/blob/9c43d645672141aba66e652d0d9484784b429072/flask_login/login_manager.py#L168

A bad actor can't easily modify the flask session cookie and we can write the value to the cookie for the short time needed.

# How to test?

- While logged out, try to access a page that needs authentication, `<host>/my-account` is a good one.
- Check you get redirected to the login page
- Log in, then you should be redirected to the my-account page without the `next` value ever being in any url

# Trello
