### PR TITLE
setting samesite cookie to strict

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 2.4.16
+version: 2.4.17
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.4.16
+appVersion: 2.4.17

--- a/frontstage/views/sign_in/sign_in.py
+++ b/frontstage/views/sign_in/sign_in.py
@@ -104,6 +104,7 @@ def login():  # noqa: C901
             expires=redis_session.get_expires_in(),
             secure=secure,
             httponly=secure,
+            samesite="strict",
         )
         count = conversation_controller.get_message_count_from_api(redis_session)
         redis_session.set_unread_message_total(count)


### PR DESCRIPTION
# What and why?
During the pen test, the `authorization` cookie generated when a user logs in was discovered to not have the `samesite` setting set. This PR sets the cookie to `strict` (which is also used for the `authorization` cookie in response ops).

# How to test?
Log in to front stage with Google Chrome, click on the three dots in the top-right corner of your window, click on "more tools", then "developer tools", then in the developer tools menu, click "application" in the top bar, followed by "cookies" in the left menu. Ensure that the `authorization` cookie's `samesite` variable is set to `strict`.

# Trello
[Card](https://trello.com/c/lrVwM0jo)
