### PR TITLE
Fix cookies preference page

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 2.4.22
+version: 2.4.23
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.4.22
+appVersion: 2.4.23

--- a/frontstage/templates/cookies.html
+++ b/frontstage/templates/cookies.html
@@ -10,12 +10,13 @@
 
 {% block main %}
     {% call onsPanel({
-            "classes": "ons-u-mb-s ons-u-d-no cookies-confirmation-message",
+            "classes": "ons-u-mb-s ons-u-d-no ons-cookies-confirmation-message",
             "type": "success"
         })
     %}
-        <p class="ons-u-fs-r-b">Your cookie settings have been saved</p>
+        <h2>Your cookie settings have been saved</h2>
         <p>Some parts of surveys.ons.gov.uk may use additional cookies and will have their own cookie policy and banner.</p>
+        <a class="ons-js-return-link ons-u-mt-s ons-u-dib" href="#0">Return to previous page</a>
     {% endcall %}
     <h1 class="ons-u-fs-xxl">Cookies on surveys.ons.gov.uk</h1>
     <p>Cookies are small files saved on your phone, tablet or computer when you visit a website.</p>


### PR DESCRIPTION
# What and why?
This PR updates the cookies preference page, making sure cookie preference are saved correctly to ons_cookie_policy. The component was missing a required parameter class (ons-js-return-link) which creates a return to link. The onsPanel class also needed updating to ons-cookies-confirmation-message so visibility could be toggled on after the update. I also matched the DS style and update the title to H2

N.B attempts to add a test for this were unsuccessful, this was down to how ons_cookie_policy policy is created and trying to then get hold of it and change it in integration tests
 
# How to test?
Deploy the app locally or push up to GCP. Note your current cookie settings, you should have a cookie called ons_cookie_policy, (for chrome and local chrome://settings/cookies/detail?site=localhost&search=chrome) Now go to the cookies page and update the page, the page will confirm the change and the cookie will update.

The easiest way to check these changes actual do what they are supposed to is go to developer tools in your browser and open the network pane, if analytics is on you will see if firing, if it is off it wont

# Trello
https://trello.com/c/oyraxbOy/1633-issues-when-saving-cookies-selection
