### PR TITLE
Fix security account key deprecation

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -12,10 +12,15 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.event.comment.body, '/deploy')
     steps:
-      - uses: google-github-actions/setup-gcloud@v0
+      - name: Authenticate with Google Cloud
+        id: 'auth'
+        uses: 'google-github-actions/auth@v0'
+        with:
+          credentials_json: '${{ secrets.GCR_KEY }}'
+      - name: Setup Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ secrets.GOOGLE_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCR_KEY }}
           export_default_credentials: true
 
       - uses: onsdigital/ras-rm-spinnaker-action@main

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -7,22 +7,30 @@ on:
 env:
   SERVICE: frontstage
 
+name: comment
+
+on:
+  issue_comment:
+    types: [created]
+
+env:
+  SERVICE: csv-worker
+
 jobs:
   comment:
     runs-on: ubuntu-latest
     if: contains(github.event.comment.body, '/deploy')
     steps:
+      - uses: actions/checkout@v3
       - name: Authenticate with Google Cloud
-        id: 'auth'
-        uses: 'google-github-actions/auth@v0'
+        id: auth
+        uses: google-github-actions/auth@v0
         with:
-          credentials_json: '${{ secrets.GCR_KEY }}'
+          credentials_json: ${{ secrets.GCR_KEY }}
       - name: Setup Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ secrets.GOOGLE_PROJECT_ID }}
-          export_default_credentials: true
-
       - uses: onsdigital/ras-rm-spinnaker-action@main
         with:
           comment-body: ${{ github.event.comment.body }}

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -7,15 +7,6 @@ on:
 env:
   SERVICE: frontstage
 
-name: comment
-
-on:
-  issue_comment:
-    types: [created]
-
-env:
-  SERVICE: csv-worker
-
 jobs:
   comment:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,10 +63,13 @@ jobs:
       - name: Test
         run: |
           make test
-      - uses: google-github-actions/setup-gcloud@v0
+      - name: Authenticate with Google Cloud
+        id: 'auth'
+        uses: 'google-github-actions/auth@v0'
         with:
-          service_account_key: ${{ secrets.GCR_KEY }}
-        # Configure docker to use the gcloud command-line tool as a credential helper
+          credentials_json: '${{ secrets.GCR_KEY }}'
+      - name: Setup Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v0
       - run: |
           gcloud auth configure-docker
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,10 +64,10 @@ jobs:
         run: |
           make test
       - name: Authenticate with Google Cloud
-        id: 'auth'
-        uses: 'google-github-actions/auth@v0'
+        id: auth
+        uses: google-github-actions/auth@v0
         with:
-          credentials_json: '${{ secrets.GCR_KEY }}'
+          credentials_json: ${{ secrets.GCR_KEY }}
       - name: Setup Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
       - run: |

--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 2.4.25
+version: 2.4.26
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.4.25
+appVersion: 2.4.26


### PR DESCRIPTION
# What and why?
This PR updates Github actions to fix "service_account_key" has been deprecate. Replacing it with google-github-actions/auth in both main.yml and comment.yml
# How to test?
For main.yml check https://github.com/ONSdigital/ras-frontstage/runs/7210847187?check_suite_focus=true
For comment.yml see https://github.com/ONSdigital/response-operations-ui/pull/747 on how I tested in response-operations, as it is a virtual copy bar the service I didn't repeat it here