### PR TITLE
Improve error handling around account creation

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 2.4.29
+version: 2.4.30
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.4.29
+appVersion: 2.4.30

--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 2.4.32
+version: 2.4.33
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.4.32
+appVersion: 2.4.33

--- a/frontstage/controllers/auth_controller.py
+++ b/frontstage/controllers/auth_controller.py
@@ -23,8 +23,7 @@ def sign_in(username, password):
     """
     if app.config["CANARY_GENERATE_ERRORS"]:
         logger.error("Canary experiment running this error can be ignored", status=500)
-    bound_logger = logger.bind(email=obfuscate_email(username))
-    bound_logger.info("Attempting to sign in")
+    logger.info("Attempting to sign in", email=obfuscate_email(username))
 
     url = f"{app.config['AUTH_URL']}/api/v1/tokens/"
     data = {
@@ -46,11 +45,10 @@ def sign_in(username, password):
 
             raise AuthError(logger, response, log_level="warning", message=message, auth_error=auth_error)
         else:
-            bound_logger.error("Failed to authenticate")
+            logger.error("Failed to authenticate", email=obfuscate_email(username))
             raise ApiError(logger, response)
 
-    bound_logger.info("Successfully signed in")
-    bound_logger.unbind("email")
+    logger.info("Successfully signed in", email=obfuscate_email(username))
     return {}
 
 

--- a/frontstage/controllers/case_controller.py
+++ b/frontstage/controllers/case_controller.py
@@ -22,37 +22,27 @@ from frontstage.exceptions.exceptions import (
 logger = wrap_logger(logging.getLogger(__name__))
 
 
-def calculate_case_status(case_group_status, collection_instrument_type):
+def calculate_case_status(case_group_status: str, collection_instrument_type: str) -> str:
     """
     Given a case group status and instrument type, this will generate user readable text to describe the status.
 
     :param case_group_status: Status of the case group
-    :type case_group_status: str
     :param collection_instrument_type: The type of collection instrument.  Either EQ or SEFT
-    :type collection_instrument_type: str
     :return: A user readable description of the status.
     """
-    logger.info(
-        "Getting the status of caseGroup",
-        case_group_status=case_group_status,
-        collection_instrument_type=collection_instrument_type,
-    )
-
-    status = "Not started"
 
     if case_group_status == "COMPLETE":
-        status = "Complete"
+        return "Complete"
     elif case_group_status == "COMPLETEDBYPHONE":
-        status = "Completed by phone"
+        return "Completed by phone"
     elif case_group_status == "NOLONGERREQUIRED":
-        status = "No longer required"
+        return "No longer required"
     elif case_group_status == "INPROGRESS" and collection_instrument_type == "EQ":
-        status = "In progress"
+        return "In progress"
     elif case_group_status == "INPROGRESS" and collection_instrument_type == "SEFT":
-        status = "Downloaded"
-
-    logger.info("Retrieved the status of case", collection_instrument_type=collection_instrument_type, status=status)
-    return status
+        return "Downloaded"
+    else:
+        return "Not started"
 
 
 def get_case_by_case_id(case_id):

--- a/frontstage/controllers/notify_controller.py
+++ b/frontstage/controllers/notify_controller.py
@@ -61,11 +61,14 @@ class NotifyGateway:
 
             msg_id = future.result()
             bound_logger.info("Publish succeeded", msg_id=msg_id)
+            logger.unbind("template_id", "project_id", "topic_id")
         except TimeoutError as e:
             bound_logger.error("Publish to pubsub timed out", exc_info=True)
+            logger.unbind("template_id", "project_id", "topic_id")
             raise exceptions.RasNotifyError("Publish to pubsub timed out", error=e)
         except Exception as e:  # noqa
             bound_logger.error("A non-timeout error was raised when publishing to pubsub", exc_info=True)
+            logger.unbind("template_id", "project_id", "topic_id")
             raise exceptions.RasNotifyError("A non-timeout error was raised when publishing to pubsub", error=e)
 
     def request_to_notify(self, email, personalisation=None, reference=None):

--- a/frontstage/controllers/party_controller.py
+++ b/frontstage/controllers/party_controller.py
@@ -72,7 +72,8 @@ def change_password(email, password):
 
 
 def create_account(registration_data):
-    logger.info("Attempting to create account")
+    obfuscated_email = obfuscate_email(registration_data["emailAddress"])
+    logger.info("Attempting to create account", email=obfuscated_email)
 
     url = f"{app.config['PARTY_URL']}/party-api/v1/respondents"
     registration_data["status"] = "CREATED"
@@ -82,12 +83,12 @@ def create_account(registration_data):
         response.raise_for_status()
     except requests.exceptions.HTTPError:
         if response.status_code == 400:
-            logger.info("Email has already been used")
+            logger.info("Email has already been used", email=obfuscated_email)
         else:
-            logger.error("Failed to create account")
+            logger.error("Failed to create account", email=obfuscated_email)
         raise ApiError(logger, response)
 
-    logger.info("Successfully created account")
+    logger.info("Successfully created account", email=obfuscated_email)
 
 
 def update_account(respondent_data):

--- a/frontstage/templates/register/register.enter-your-details.html
+++ b/frontstage/templates/register/register.enter-your-details.html
@@ -9,6 +9,21 @@
 {% set page_title = "Enter account details" %}
 
 {% block main %}
+    {% with messages = get_flashed_messages(category_filter=["error"]) %}
+        {% if messages %}
+            {% call
+                onsPanel({
+                        "type": "error",
+                        "classes": "ons-u-mb-l",
+                        "title":  errorTitle
+                    })
+            %}
+                {% for message in messages %}
+                    <p id="flashed-message-{{ loop.index }}">{{ message }}</p>
+                {% endfor %}
+            {% endcall %}
+        {% endif %}
+    {% endwith %}
     {% if errors|length > 0 %}
         {% if errors|length == 1 %}
             {% set errorTitle = 'There is 1 error on this page' %}
@@ -25,6 +40,7 @@
             <p>These <strong>must be corrected</strong> to continue.</p>
             {% set errorData = [] %}
             {% for error in errors %}
+
                 {% set error_text = 'passwords' if error == 'password' else error %}
                 {% do errorData.append(
                     {

--- a/frontstage/views/register/enter_account_details.py
+++ b/frontstage/views/register/enter_account_details.py
@@ -33,7 +33,6 @@ def register_enter_your_details():
 
     if request.method == "POST" and form.validate():
         email_address = form.email_address.data
-        logger.info("Attempting to create account", email=obfuscate_email(email_address))
 
         registration_data = {
             "emailAddress": email_address,
@@ -60,14 +59,12 @@ def register_enter_your_details():
                 flash("Something went wrong, please try again or contact us", "error")
                 return render_template("register/register.enter-your-details.html", form=form, errors=form.errors)
             elif exc.status_code == 409:
-                logger.info("Email already used", email=obfuscate_email(email_address), enrolment_code=enrolment_code)
                 error = {"email_address": ["This email has already been used to register an account"]}
                 return render_template("register/register.enter-your-details.html", form=form, errors=error)
             else:
                 logger.error("Failed to create account", status=exc.status_code, error=exc.message)
                 raise exc
 
-        logger.info("Successfully created account", email=obfuscate_email(email_address))
         return render_template("register/register.almost-done.html", email=email_address)
 
     else:

--- a/frontstage/views/sign_in/sign_in.py
+++ b/frontstage/views/sign_in/sign_in.py
@@ -74,6 +74,7 @@ def login():  # noqa: C901
             else:
                 bound_logger.error("Unexpected error was returned from Auth service", auth_error=error_message)
 
+            logger.unbind("email")
             return render_template("sign-in/sign-in.html", form=form, data={"error": {"type": "failed"}})
 
         bound_logger.info("Successfully found user in auth service.  Attempting to find user in party service")

--- a/tests/integration/test_registration.py
+++ b/tests/integration/test_registration.py
@@ -520,7 +520,7 @@ class TestRegistration(unittest.TestCase):
     def test_create_account_duplicate_email(self, mock_request):
         mock_request.get(url_banner_api, status_code=404)
         mock_request.get(url_validate_enrolment, json={"active": True, "caseId": case["id"]})
-        mock_request.post(url_create_account, status_code=409)
+        mock_request.post(url_create_account, status_code=409, json={"description": "Email address already exists"})
 
         response = self.app.post(
             "register/create-account/enter-account-details",

--- a/tests/integration/test_registration.py
+++ b/tests/integration/test_registration.py
@@ -500,10 +500,27 @@ class TestRegistration(unittest.TestCase):
         self.assertTrue("Almost done".encode() in response.data)
 
     @requests_mock.mock()
+    def test_create_account_party_client_error(self, mock_request):
+        mock_request.get(url_banner_api, status_code=404)
+        mock_request.get(url_validate_enrolment, json={"active": True, "caseId": case["id"]})
+        mock_request.post(url_create_account, json={"description": "The key 'lastName' is missing"}, status_code=400)
+
+        response = self.app.post(
+            "register/create-account/enter-account-details",
+            query_string=self.params,
+            data=self.test_user,
+            headers=self.headers,
+            follow_redirects=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue("Something went wrong, please try again or contact us".encode() in response.data)
+
+    @requests_mock.mock()
     def test_create_account_duplicate_email(self, mock_request):
         mock_request.get(url_banner_api, status_code=404)
         mock_request.get(url_validate_enrolment, json={"active": True, "caseId": case["id"]})
-        mock_request.post(url_create_account, status_code=400)
+        mock_request.post(url_create_account, status_code=409)
 
         response = self.app.post(
             "register/create-account/enter-account-details",


### PR DESCRIPTION
# What and why?
The errors around account creation failures weren't easy to diagnose, so this PR adds a little more logging and more accurate status codes to help figure out future issues.

# How to test?

- Deploy this and the party PR with the same branch name (https://github.com/ONSdigital/ras-party/pull/371) to your environment. 
- Run the acceptance tests to seed data
- Try to create an account that already exists ([example@example.com](mailto:example@example.com)) and look at both the frontstage and party logs. The logging should make it more clear what is going on.
- Try and create an account to make sure nothing else has broken!


# Trello
