### PR TITLE
added FrontstageConfig resource

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 2.4.29
+version: 2.4.30
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.4.29
+appVersion: 2.4.30

--- a/_infra/helm/frontstage/templates/frontendconfig.yaml
+++ b/_infra/helm/frontstage/templates/frontendconfig.yaml
@@ -5,3 +5,4 @@ metadata:
   name: frontstage-frontend-config
 spec:
   sslPolicy: {{ .Values.frontendConfig.sslPolicy }}
+{{- end }}

--- a/_infra/helm/frontstage/templates/frontendconfig.yaml
+++ b/_infra/helm/frontstage/templates/frontendconfig.yaml
@@ -1,0 +1,7 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.gke.io/v1beta1
+kind: FrontendConfig
+metadata:
+  name: frontstage-frontend-config
+spec:
+  sslPolicy: {{ .Values.frontendConfig.sslPolicy }}

--- a/_infra/helm/frontstage/templates/ingress.yaml
+++ b/_infra/helm/frontstage/templates/ingress.yaml
@@ -9,7 +9,6 @@ metadata:
     networking.gke.io/managed-certificates: {{ .Values.ingress.certNameSurveys }}
 
 spec:
-  sslPolicy: {{ .Values.ingress.sslPolicy }}
   rules:
   - host: {{ .Values.ingress.host | quote }}
     http:

--- a/_infra/helm/frontstage/values.yaml
+++ b/_infra/helm/frontstage/values.yaml
@@ -24,6 +24,8 @@ ingress:
   surveysHost: surveys.example.com
   certNameSurveys: surveys-cert
   timeoutSec: 30
+
+frontendConfig:
   sslPolicy: frontstage-ingress-ssl-policy
 
 analytics:


### PR DESCRIPTION
# What and why?
Upon attempting to deploy a previous [a previous PR](https://github.com/ONSdigital/ras-frontstage/pull/846) to preprod, it failed on account of the `sslPolicy` variable not being understood. Looking up kubernetes documentation, I discovered that ingress resources don't accept `sslPolicy` as a valid parameter. Instead, it has to be in a `FrontendConfig` resource, which I have created a file of for frontstage. The config is based off the example on [this page](https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-features#configuring_ingress_features_through_frontendconfig_parameters).

# How to test?
TBD

# Trello
[Card](https://trello.com/c/dUS1ubPX)
