### PR TITLE
Combine unit and integration test commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 DESIGN_SYSTEM_VERSION=`cat .design-system-version`
-UNIT_TESTS=tests/unit
-INTEGRATION_TESTS=tests/integration
+TESTS=tests/
 
 build:
 	pipenv install --dev
@@ -18,7 +17,7 @@ start: load-design-system-templates
 	pipenv run python run.py
 
 docker-test: REDIS_PORT=6379
-docker-test: unit-tests integration-tests
+docker-test: test
 
 lint:
 	pipenv check
@@ -32,10 +31,6 @@ lint-check: load-design-system-templates
 	pipenv run black --line-length 120 --check .
 	pipenv run flake8
 
-test: lint-check unit-tests integration-tests
+test: lint-check
+	APP_SETTINGS=TestingConfig pipenv run pytest $(TESTS) --cov frontstage --cov-report term-missing
 
-unit-tests:
-	APP_SETTINGS=TestingConfig pipenv run pytest $(UNIT_TESTS) --cov frontstage --cov-report term-missing
-
-integration-tests:
-	APP_SETTINGS=TestingConfig pipenv run pytest $(INTEGRATION_TESTS) --cov frontstage --cov-report term-missing

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ docker run --name redis -p 6379:6379 -d redis
 
 ## Run the application
 ```
-pipenv run python run.py
+make start
 ```
 
 ## Run tests
@@ -38,11 +38,10 @@ Install test dependencies with
 ```bash
 pipenv install --dev
 ```
-The Makefile will run the tests in the unit or integration tests folder using pytest, and present a coverage report.
+The Makefile will run the unit and integration tests folder using pytest, and present a coverage report.
 These can be easily run via the following commands:
 ```bash
-make unit-tests
-make integration-tests
+make test
 ```
 or if you are running redis in the docker environment
 ```bash
@@ -50,12 +49,9 @@ make docker-test
 ```
 or if you wish to run a single test file, it can be specified as follows:
 ```bash
-make INTEGRATION_TESTS=tests/integration/views/surveys/test_surveys_list.py integration-tests
-make UNIT_TESTS=tests/unit/test_filters.py unit-tests
-
+make TESTS=tests/integration/views/surveys/test_surveys_list.py test
 ```
 The syntax above will work equally well with the 'docker-test' target
-
 
 Note that this script will fail if there is a `node_modules` folder in the repo
 
@@ -89,9 +85,6 @@ Environment variables available for configuration are listed below:
 | REDIS_HOST                  | Host address for the redis instance                 | 'localhost'                                     |
 | REDIS_PORT                  | Port for the redis instance                         | 6379                                            |
 | REDIS_DB                    | Database number for the redis instance              | 1                                               |
-| RAS_FRONTSTAGE_API_PROTOCOL | Protocol used for frontstage-api uri                | 'http'                                          |
-| RAS_FRONTSTAGE_API_HOST     | Host address used for frontstage-api uri            | 'localhost'                                     |
-| RAS_FRONTSTAGE_API_PORT     | Port used for frontstage-api uri                    | 8083                                            |
 
 These are set in [config.py](config.py)
 

--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 2.4.29
+version: 2.4.30
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.4.29
+appVersion: 2.4.30

--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 2.4.30
+version: 2.4.31
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.4.30
+appVersion: 2.4.31


### PR DESCRIPTION
# What and why?

A while ago, we split the commands up, mostly so you can run unit tests as they don't have any dependencies and are much faster than the integration tests.

This kindof works, but in practice you almost always run both suites at once anyway and doing this way messes up the coverage report

# How to test?

# Trello
