### PR TITLE
Expired email tokens will cause 500 on password reminder

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 2.4.34
+version: 2.4.35
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.4.34
+appVersion: 2.4.35

--- a/frontstage/views/passwords/reset_password.py
+++ b/frontstage/views/passwords/reset_password.py
@@ -115,6 +115,10 @@ def request_password_change(email):
     party_id = str(respondent["id"])
     password_reset_counter = party_controller.get_password_reset_counter(party_id)["counter"]
 
+    # When the password verification token has expired, it is deleted from the DB. The password counter would always be
+    # >0 and the the try below would be entered (when only the passworrd_reset_counter was in the if). When this
+    # occurred, the code would error as the password_verfication_token would be missing from the dictionary. I've added
+    # a check to ensure that this never enters the try when this is missing from the dict.
     if password_reset_counter != 0 and "password_verification_token" in respondent:
         try:
             email = verification.decode_email_token(

--- a/frontstage/views/passwords/reset_password.py
+++ b/frontstage/views/passwords/reset_password.py
@@ -115,7 +115,7 @@ def request_password_change(email):
     party_id = str(respondent["id"])
     password_reset_counter = party_controller.get_password_reset_counter(party_id)["counter"]
 
-    if password_reset_counter != 0:
+    if password_reset_counter != 0 and "password_verification_token" in respondent:
         try:
             email = verification.decode_email_token(
                 respondent["password_verification_token"], app.config["PASSWORD_RESET_ATTEMPTS_TIMEOUT"]


### PR DESCRIPTION
# What and why?
When a password verification token was out of date, it is deleted from the DB but the password reset counter is not reset to 0 (it will always be greater than 0). When the user tries to reset their password, the code evaluates an 'if' statement that checks if the reset count is greater than 0 (which it will be) it will then execute the try block within that searches for the deleted token within a dictionary. As it is has been deleted, it is not in the dictionary and so an error is thrown. 

To fix the issue, I have added an additional check to see if token is included as part of the dictionary. If it is not, then a new token will be generated (the reset count will not be affected). The user will then be able to receive the password reset email or will receive the 'tried too many times' message.

# How to test?
Find a user where the password verification token is out of date (so deleted) and the password reset count is greater than 0. Using the 'Forgot password' section, enter the email address of the account and click 'Send reset link'. This will then redirect to the 'Check your email section'.

# Trello
https://trello.com/c/PITGUDj6/1896-expired-email-tokens-will-cause-500-on-password-reminder