### PR TITLE
set ingress resource to use frontendconfig resource

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 2.4.36
+version: 2.4.37
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.4.36
+appVersion: 2.4.37

--- a/_infra/helm/frontstage/templates/frontendconfig.yaml
+++ b/_infra/helm/frontstage/templates/frontendconfig.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.gke.io/v1beta1
 kind: FrontendConfig
 metadata:
-  name: {{ .Values.ingress.frontendConfigName}}
+  name: {{ .Values.ingress.frontendConfigName }}
 spec:
   sslPolicy: {{ .Values.frontendConfig.sslPolicy }}
 {{- end }}

--- a/_infra/helm/frontstage/templates/frontendconfig.yaml
+++ b/_infra/helm/frontstage/templates/frontendconfig.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.gke.io/v1beta1
 kind: FrontendConfig
 metadata:
-  name: frontstage-frontend-config
+  name: {{ .Values.ingress.frontendConfigName}}
 spec:
   sslPolicy: {{ .Values.frontendConfig.sslPolicy }}
 {{- end }}

--- a/_infra/helm/frontstage/templates/ingress.yaml
+++ b/_infra/helm/frontstage/templates/ingress.yaml
@@ -7,6 +7,7 @@ metadata:
     kubernetes.io/ingress.global-static-ip-name: frontstage-ip
     kubernetes.io/ingress.class: gce
     networking.gke.io/managed-certificates: {{ .Values.ingress.certNameSurveys }}
+    networking.gke.io/v1beta1.FrontendConfig: {{ .Values.ingress.frontendConfigName }}
 
 spec:
   rules:

--- a/_infra/helm/frontstage/values.yaml
+++ b/_infra/helm/frontstage/values.yaml
@@ -23,6 +23,7 @@ ingress:
   enabled: false
   surveysHost: surveys.example.com
   certNameSurveys: surveys-cert
+  frontendConfigName: frontstage-frontend-config
   timeoutSec: 30
 
 frontendConfig:


### PR DESCRIPTION
# What and why?
When I originally attempted to deploy the frontendconfig resource, the ingress didn't pick up the new ssl policy, and I had to set it automatically. This PR should fix this by making it automatic.

# How to test?
Before I merge this in, I'll manually set the ssl policy in preprod back to 1.0, and then, upon merging, it should pick up the new 1.2 policy automatically, without me having to set it manually.

# Trello
[Card](https://trello.com/c/dUS1ubPX)
