### PR TITLE
Reroute 'something else' message to survey teams

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 2.4.40
+version: 2.4.41
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.4.40
+appVersion: 2.4.41

--- a/frontstage/views/surveys/help/surveys_help.py
+++ b/frontstage/views/surveys/help/surveys_help.py
@@ -280,7 +280,7 @@ def send_help_message(session, option, sub_option):
         business_id = business_id
         logger.info("Form validation successful", party_id=party_id)
         category = "SURVEY"
-        if option == "info-about-the-ons" or option == "something-else":
+        if option == "info-about-the-ons":
             category = "TECHNICAL"
         sent_message = _send_new_message(subject, party_id, survey["id"], business_id, category)
         thread_url = (


### PR DESCRIPTION
# What and why?
This pr reroutes any message that is sent through the path 'Get help with this survey -> something else -> something else' from the general `Technical` inbox to survey specific inboxes.
# How to test?
- Run the acceptance tests
- Send a message using this path
    - The message should appear in the `Technical` inbox
- Deploy pr into your environment
- Send another message using this path
    - The message should appear in the survey's inbox
# Trello
https://trello.com/c/60uegL1J/1998-rops-secure-messaging-reroute-something-else-to-survey-teams