### PR TITLE
DAC report - Error handing and surfacing

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 2.4.49
+version: 2.4.50
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.4.49
+appVersion: 2.4.50

--- a/frontstage/templates/account/account-change-password.html
+++ b/frontstage/templates/account/account-change-password.html
@@ -162,7 +162,7 @@
             {{
                 onsButton({
                     "id": "btn-help-this-survey-option-cancel",
-                    "url": url_for('account_bp.get_account'),
+                    "url": url_for('account_bp.account'),
                     "text": 'Cancel',
                     "variants": 'secondary',
                     "noIcon": true

--- a/frontstage/templates/account/account-contact-detail-change.html
+++ b/frontstage/templates/account/account-contact-detail-change.html
@@ -147,7 +147,7 @@
             {{
                 onsButton({
                     "id": "btn-account-change-detail-cancel",
-                    "url": url_for('account_bp.get_account'),
+                    "url": url_for('account_bp.account'),
                     "text": 'Cancel',
                     "variants": 'secondary',
                     "noIcon": true

--- a/frontstage/templates/account/account-something-else.html
+++ b/frontstage/templates/account/account-something-else.html
@@ -96,7 +96,7 @@
                 {{
                     onsButton({
                         "id": "btn-option-cancel",
-                        "url": url_for('account_bp.get_account'),
+                        "url": url_for('account_bp.account'),
                         "text": 'Cancel',
                         "variants": 'secondary',
                         "noIcon": true

--- a/frontstage/templates/account/account.html
+++ b/frontstage/templates/account/account.html
@@ -4,7 +4,8 @@
 {% from "components/radios/_macro.njk" import onsRadios %}
 {% from "components/button/_macro.njk" import onsButton %}
 
-{% set page_title = "Account details" %}
+{% set ns = namespace() %}
+{% set page_title = 'Error: Account details' if ns.optionError else 'Account details hello' %}
 {% set breadcrumbsData = [
     {
         "text": "Surveys",
@@ -23,7 +24,6 @@
 {% endblock breadcrumbs %}
 
 {% block main %}
-    {% set ns = namespace() %}
     {% include "radio-option-select-error-panel.html" %}
     <h1 class="ons-u-fs-xl">Account details</h1>
     <dl class="ons-metadata ons-metadata__list ons-grid ons-grid--gutterless ons-u-cf ons-u-mb-l" title="" aria-label="">

--- a/frontstage/templates/account/account.html
+++ b/frontstage/templates/account/account.html
@@ -4,8 +4,6 @@
 {% from "components/radios/_macro.njk" import onsRadios %}
 {% from "components/button/_macro.njk" import onsButton %}
 
-{% set ns = namespace() %}
-{% set page_title = 'Error: Account details' if ns.optionError else 'Account details hello' %}
 {% set breadcrumbsData = [
     {
         "text": "Surveys",
@@ -24,6 +22,7 @@
 {% endblock breadcrumbs %}
 
 {% block main %}
+    {% set ns = namespace() %}
     {% include "radio-option-select-error-panel.html" %}
     <h1 class="ons-u-fs-xl">Account details</h1>
     <dl class="ons-metadata ons-metadata__list ons-grid ons-grid--gutterless ons-u-cf ons-u-mb-l" title="" aria-label="">
@@ -36,7 +35,7 @@
     </dl>
         <hr class="ons-u-mb-l"/>
     <h1 class="ons-u-fs-xl">Help with your account</h1>
-    <form action="{{ url_for('account_bp.update_account')}}" method="post">
+    <form action="{{ url_for('account_bp.account')}}" method="post">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
             {% if ns.optionError %}
                 {% set errorOption = { "text": ns.optionErrorMessage,  "id": 'option_error' } %}

--- a/frontstage/templates/help/help-info-ons.html
+++ b/frontstage/templates/help/help-info-ons.html
@@ -75,7 +75,7 @@
                         "submitType": "timer"
                     })
                 }}
-                <a href="{{ url_for('help_bp.help_get') }}"
+                <a href="{{ url_for('help_bp.help_page') }}"
                     role="button" class="ons-btn ons-btn--link ons-btn--secondary" id="btn-who-ons-option-cancel"><span class="ons-btn__inner">Cancel</span></a>
             </div>
         </div>

--- a/frontstage/templates/help/help-info-ons.html
+++ b/frontstage/templates/help/help-info-ons.html
@@ -3,7 +3,6 @@
 {% from "components/fieldset/_macro.njk" import onsFieldset %}
 {% from "components/radios/_macro.njk" import onsRadios %}
 {% from "components/button/_macro.njk" import onsButton %}
-{% set page_title = "Help info ONS" %}
 {% set breadcrumbsData = [
     {
         "text": "Sign in",

--- a/frontstage/templates/help/help-info-ons.html
+++ b/frontstage/templates/help/help-info-ons.html
@@ -30,7 +30,7 @@
 
     <h1 class="ons-u-fs-xl">Information about the Office for National Statistics (ONS)</h1>
 
-    <form action="{{ url_for('help_bp.info_ons_submit')}}" method="post">
+    <form action="{{ url_for('help_bp.info_ons_page')}}" method="post">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
         {% if ns.optionError %}
             {% set errorOption = { "text": ns.optionErrorMessage,  "id": 'option_error' } %}

--- a/frontstage/templates/help/help-with-password.html
+++ b/frontstage/templates/help/help-with-password.html
@@ -3,7 +3,6 @@
 {% from "components/fieldset/_macro.njk" import onsFieldset %}
 {% from "components/radios/_macro.njk" import onsRadios %}
 {% from "components/button/_macro.njk" import onsButton %}
-{% set page_title = "Help with my password" %}
 {% set breadcrumbsData = [
     {
         "text": "Sign in",

--- a/frontstage/templates/help/help-with-password.html
+++ b/frontstage/templates/help/help-with-password.html
@@ -30,7 +30,7 @@
 
     <h1 class="ons-u-fs-xl">Help with my password</h1>
 
-    <form action="{{ url_for('help_bp.help_with_password_submit')}}" method="post">
+    <form action="{{ url_for('help_bp.help_with_password_page')}}" method="post">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
         {% if ns.optionError %}
             {% set errorOption = { "text": ns.optionErrorMessage,  "id": 'option_error' } %}
@@ -82,7 +82,7 @@
                         "submitType": "timer"
                     })
                 }}
-                <a href="{{ url_for('help_bp.help_get') }}"
+                <a href="{{ url_for('help_bp.help_page') }}"
                     role="button" class="ons-btn ons-btn--link ons-btn--secondary" id="btn-who-ons-option-cancel"><span class="ons-btn__inner">Cancel</span></a>
             </div>
         </div>

--- a/frontstage/templates/help/help.html
+++ b/frontstage/templates/help/help.html
@@ -3,7 +3,6 @@
 {% from "components/fieldset/_macro.njk" import onsFieldset %}
 {% from "components/radios/_macro.njk" import onsRadios %}
 {% from "components/button/_macro.njk" import onsButton %}
-{% set page_title = "Help" %}
 {% set breadcrumbsData = [
     {
         "text": "Sign in",

--- a/frontstage/templates/help/help.html
+++ b/frontstage/templates/help/help.html
@@ -26,7 +26,7 @@
 
     <h1 class="ons-u-fs-xl">Help</h1>
 
-    <form action="{{ url_for('help_bp.help_submit')}}" method="post">
+    <form action="{{ url_for('help_bp.help_page')}}" method="post">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
         {% if ns.optionError %}
             {% set errorOption = { "text": ns.optionErrorMessage,  "id": 'option_error' } %}

--- a/frontstage/templates/radio-option-select-error-panel.html
+++ b/frontstage/templates/radio-option-select-error-panel.html
@@ -10,7 +10,7 @@
             {% set ns.optionError = true %}
             {% if not ns.optionErrorMessage %}
                 {% if not ns.checkbox %}
-                    {% set ns.optionErrorMessage = 'You need to choose an option' %}
+                    {% set ns.optionErrorMessage = '<span class="ons-panel__assistive-text ons-u-vh">Error: </span>You need to choose an option' %}
                 {% else %}
                     {% set ns.optionErrorMessage = 'You need to choose at least one option' %}
                 {% endif %}

--- a/frontstage/templates/secure-messages/conversation-view.html
+++ b/frontstage/templates/secure-messages/conversation-view.html
@@ -101,7 +101,7 @@
                     <p>You can now make changes to your name and telephone number
                         in <a href="/my-account" class="ons-u-fs-r--b">your account</a>.</p>
                     {% if form.errors %}
-                        {% set form_error = { "text": ns.errorMessage, "id": 'form_error' } %}
+                        {% set form_error = { "text": '<span class="ons-panel__assistive-text ons-u-vh">Error: </span> ' + ns.errorMessage, "id": 'form_error' } %}
                     {% endif %}
                     <div>
                         <form action="{{ url_for('secure_message_bp.view_conversation', thread_id=conversation[0].thread_id) }}" method="post" id="create-message-form">

--- a/frontstage/templates/secure-messages/help/secure-message-send-messages-view.html
+++ b/frontstage/templates/secure-messages/help/secure-message-send-messages-view.html
@@ -5,7 +5,7 @@
 {% from "components/panel/_macro.njk" import onsPanel %}
 {% from "components/textarea/_macro.njk" import onsTextarea %}
 
-{% set page_title = "Send a message" %}
+{% set page_title = page_title + "Send a message" %}
 {% set breadcrumbsData = [
     {
         "text": "Surveys",
@@ -125,7 +125,7 @@
                     {{
                         onsButton({
                             "id": "btn-option-cancel",
-                            "url": url_for('surveys_bp.get_help_option_select', option=option),
+                            "url": url_for('surveys_bp.help_option_select', option=option),
                             "text": 'Cancel',
                             "variants": 'secondary',
                             "noIcon": true

--- a/frontstage/templates/secure-messages/help/secure-message-send-messages-view.html
+++ b/frontstage/templates/secure-messages/help/secure-message-send-messages-view.html
@@ -5,7 +5,6 @@
 {% from "components/panel/_macro.njk" import onsPanel %}
 {% from "components/textarea/_macro.njk" import onsTextarea %}
 
-{% set page_title = page_title + "Send a message" %}
 {% set breadcrumbsData = [
     {
         "text": "Surveys",

--- a/frontstage/templates/surveys/help/surveys-help-completing-this-survey.html
+++ b/frontstage/templates/surveys/help/surveys-help-completing-this-survey.html
@@ -4,7 +4,7 @@
 {% from "components/radios/_macro.njk" import onsRadios %}
 {% from "components/button/_macro.njk" import onsButton %}
 
-{% set page_title = "Help completing this survey" %}
+{% set page_title = page_title + "Help completing this survey" %}
 {% set breadcrumbsData = [
     {
         "text": "Surveys",
@@ -35,7 +35,7 @@
     {% set ns = namespace() %}
     {% include "radio-option-select-error-panel.html" %}
     <h1 class="ons-u-fs-xl">Help completing the {{ survey_name }}</h1>
-    <form action="{{ url_for('surveys_bp.post_help_option_select', short_name=short_name, business_id=business_id, option=option, survey_ref=survey_ref, ru_ref=ru_ref)}}" method="post">
+    <form action="{{ url_for('surveys_bp.help_option_select', short_name=short_name, business_id=business_id, option=option, survey_ref=survey_ref, ru_ref=ru_ref)}}" method="post">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
         {% if ns.optionError %}
             {% set errorOption = { "text": ns.optionErrorMessage,  "id": 'option_error' } %}

--- a/frontstage/templates/surveys/help/surveys-help-completing-this-survey.html
+++ b/frontstage/templates/surveys/help/surveys-help-completing-this-survey.html
@@ -4,7 +4,6 @@
 {% from "components/radios/_macro.njk" import onsRadios %}
 {% from "components/button/_macro.njk" import onsButton %}
 
-{% set page_title = page_title + "Help completing this survey" %}
 {% set breadcrumbsData = [
     {
         "text": "Surveys",

--- a/frontstage/templates/surveys/help/surveys-help-exemption-completing-survey.html
+++ b/frontstage/templates/surveys/help/surveys-help-exemption-completing-survey.html
@@ -2,7 +2,6 @@
 {% from "components/breadcrumbs/_macro.njk" import onsBreadcrumbs %}
 {% from "components/button/_macro.njk" import onsButton %}
 
-{% set page_title = "Help with exemption completing survey" %}
 {% set breadcrumbsData = [
     {
         "text": "Surveys",

--- a/frontstage/templates/surveys/help/surveys-help-exemption-completing-survey.html
+++ b/frontstage/templates/surveys/help/surveys-help-exemption-completing-survey.html
@@ -47,7 +47,7 @@
     <a href="{{ url_for('surveys_bp.get_survey_list', tag='todo') }}" role="button" class="ons-btn ons-btn--link ons-js-submit-btn">
         <span class="ons-btn__inner">Yes</span>
     </a>
-    <a href="{{ url_for('surveys_bp.get_send_help_message_page', option=option, sub_option='exemption-completing-survey') }}" role="button" class="ons-btn ons-btn--link ons-btn--secondary">
+    <a href="{{ url_for('surveys_bp.send_help_message', option=option, sub_option='exemption-completing-survey') }}" role="button" class="ons-btn ons-btn--link ons-btn--secondary">
         <span class="ons-btn__inner">No</span>
     </a>
 {% endblock main %}

--- a/frontstage/templates/surveys/help/surveys-help-how-long-selected-for.html
+++ b/frontstage/templates/surveys/help/surveys-help-how-long-selected-for.html
@@ -2,7 +2,6 @@
 {% from "components/breadcrumbs/_macro.njk" import onsBreadcrumbs %}
 {% from "components/button/_macro.njk" import onsButton %}
 
-{% set page_title = "Help with how long selected for" %}
 {% set breadcrumbsData = [
     {
         "text": "Surveys",

--- a/frontstage/templates/surveys/help/surveys-help-how-long-selected-for.html
+++ b/frontstage/templates/surveys/help/surveys-help-how-long-selected-for.html
@@ -42,7 +42,7 @@
     <a href="{{ url_for('surveys_bp.get_survey_list', tag='todo') }}" role="button" class="ons-btn ons-btn--link ons-js-submit-btn">
         <span class="ons-btn__inner">Yes</span>
     </a>
-    <a href="{{ url_for('surveys_bp.get_send_help_message_page', option=option, sub_option='how-long-selected-for') }}" role="button" class="ons-btn ons-btn--link ons-btn--secondary">
+    <a href="{{ url_for('surveys_bp.send_help_message', option=option, sub_option='how-long-selected-for') }}" role="button" class="ons-btn ons-btn--link ons-btn--secondary">
         <span class="ons-btn__inner">No</span>
     </a>
 {% endblock main %}

--- a/frontstage/templates/surveys/help/surveys-help-how-safe-is-my-data.html
+++ b/frontstage/templates/surveys/help/surveys-help-how-safe-is-my-data.html
@@ -3,7 +3,6 @@
 {% from "components/button/_macro.njk" import onsButton %}
 {% from "components/lists/_macro.njk" import onsList %}
 
-{% set page_title = "Help with how long selected for" %}
 {% set breadcrumbsData = [
     {
         "text": "Surveys",

--- a/frontstage/templates/surveys/help/surveys-help-how-safe-is-my-data.html
+++ b/frontstage/templates/surveys/help/surveys-help-how-safe-is-my-data.html
@@ -57,7 +57,7 @@
     <a href="{{ url_for('surveys_bp.get_survey_list', tag='todo') }}" role="button" class="ons-btn ons-btn--link ons-js-submit-btn">
         <span class="ons-btn__inner">Yes</span>
     </a>
-    <a href="{{ url_for('surveys_bp.get_send_help_message_page', option=option, sub_option='how-safe-is-my-data') }}" role="button" class="ons-btn ons-btn--link ons-btn--secondary">
+    <a href="{{ url_for('surveys_bp.send_help_message', option=option, sub_option='how-safe-is-my-data') }}" role="button" class="ons-btn ons-btn--link ons-btn--secondary">
         <span class="ons-btn__inner">No</span>
     </a>
 {% endblock main %}

--- a/frontstage/templates/surveys/help/surveys-help-info-about-the-ons.html
+++ b/frontstage/templates/surveys/help/surveys-help-info-about-the-ons.html
@@ -4,7 +4,6 @@
 {% from "components/radios/_macro.njk" import onsRadios %}
 {% from "components/button/_macro.njk" import onsButton %}
 
-{% set page_title = "Help Information about the ONS" %}
 {% set breadcrumbsData = [
     {
         "text": "Surveys",

--- a/frontstage/templates/surveys/help/surveys-help-info-about-the-ons.html
+++ b/frontstage/templates/surveys/help/surveys-help-info-about-the-ons.html
@@ -31,7 +31,7 @@
     {% set ns = namespace() %}
     {% include "radio-option-select-error-panel.html" %}
     <h1 class="ons-u-fs-xl">Information about the ONS</h1>
-    <form action="{{ url_for('surveys_bp.post_help_option_select', short_name=short_name, business_id=business_id, option=option, survey_ref=survey_ref, ru_ref=ru_ref)}}" method="post">
+    <form action="{{ url_for('surveys_bp.help_option_select', short_name=short_name, business_id=business_id, option=option, survey_ref=survey_ref, ru_ref=ru_ref)}}" method="post">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
         {% if ns.optionError %}
             {% set errorOption = { "text": ns.optionErrorMessage,  "id": 'option_error' } %}

--- a/frontstage/templates/surveys/help/surveys-help-info-about-this-survey.html
+++ b/frontstage/templates/surveys/help/surveys-help-info-about-this-survey.html
@@ -32,7 +32,7 @@
     {% set ns = namespace() %}
     {% include "radio-option-select-error-panel.html" %}
     <h1 class="ons-u-fs-xl">Information about the {{ survey_name }}</h1>
-    <form action="{{ url_for('surveys_bp.post_help_option_select', short_name=short_name, business_id=business_id, option=option, survey_ref=survey_ref, ru_ref=ru_ref)}}" method="post">
+    <form action="{{ url_for('surveys_bp.help_option_select', short_name=short_name, business_id=business_id, option=option, survey_ref=survey_ref, ru_ref=ru_ref)}}" method="post">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
         {% if ns.optionError %}
             {% set errorOption = { "text": ns.optionErrorMessage,  "id": 'option_error' } %}

--- a/frontstage/templates/surveys/help/surveys-help-info-about-this-survey.html
+++ b/frontstage/templates/surveys/help/surveys-help-info-about-this-survey.html
@@ -4,7 +4,6 @@
 {% from "components/radios/_macro.njk" import onsRadios %}
 {% from "components/button/_macro.njk" import onsButton %}
 
-{% set page_title = "Help Information about this survey" %}
 {% set breadcrumbsData = [
     {
         "text": "Surveys",

--- a/frontstage/templates/surveys/help/surveys-help-info-something-else.html
+++ b/frontstage/templates/surveys/help/surveys-help-info-something-else.html
@@ -2,7 +2,6 @@
 {% from "components/breadcrumbs/_macro.njk" import onsBreadcrumbs %}
 {% from "components/button/_macro.njk" import onsButton %}
 
-{% set page_title = "Help survey info something else" %}
 {% set breadcrumbsData = [
     {
         "text": "Surveys",

--- a/frontstage/templates/surveys/help/surveys-help-info-something-else.html
+++ b/frontstage/templates/surveys/help/surveys-help-info-something-else.html
@@ -44,7 +44,7 @@
     <a href="{{ url_for('surveys_bp.get_survey_list', tag='todo') }}" role="button" class="ons-btn ons-btn--link ons-js-submit-btn">
         <span class="ons-btn__inner">Yes</span>
     </a>
-    <a href="{{ url_for('surveys_bp.get_send_help_message_page', option=option, sub_option='info-something-else') }}" role="button" class="ons-btn ons-btn--link ons-btn--secondary">
+    <a href="{{ url_for('surveys_bp.send_help_message', option=option, sub_option='info-something-else') }}" role="button" class="ons-btn ons-btn--link ons-btn--secondary">
         <span class="ons-btn__inner">No</span>
     </a>
 {% endblock main %}

--- a/frontstage/templates/surveys/help/surveys-help-my-survey-is-not-listed.html
+++ b/frontstage/templates/surveys/help/surveys-help-my-survey-is-not-listed.html
@@ -2,7 +2,6 @@
 {% from "components/breadcrumbs/_macro.njk" import onsBreadcrumbs %}
 {% from "components/button/_macro.njk" import onsButton %}
 
-{% set page_title = "Help with how long selected for" %}
 {% set breadcrumbsData = [
     {
         "text": "Surveys",

--- a/frontstage/templates/surveys/help/surveys-help-my-survey-is-not-listed.html
+++ b/frontstage/templates/surveys/help/surveys-help-my-survey-is-not-listed.html
@@ -40,7 +40,7 @@
         You should <a href="{{ url_for('surveys_bp.add_survey') }}">add the new survey to your account</a> using the code in the letter.</p>
     <p>
         {% if is_survey_help_page is defined and  is_survey_help_page %}
-        <a href="{{ url_for('surveys_bp.get_send_help_message_page', option=option, sub_option='my-survey-is-not-listed') }}"> Send us a message</a>
+        <a href="{{ url_for('surveys_bp.send_help_message', option=option, sub_option='my-survey-is-not-listed') }}"> Send us a message</a>
         {% else %}
         <a href="{{ url_for('surveys_bp.get_send_help_technical_message_page', option=option) }}"> Send us a message</a>
         {% endif %} if you have not received the enrolment letter.</p>
@@ -51,7 +51,7 @@
         <span class="ons-btn__inner">Yes</span>
     </a>
     {% if is_survey_help_page is defined and is_survey_help_page %}
-        <a href="{{ url_for('surveys_bp.get_send_help_message_page', option=option, sub_option='my-survey-is-not-listed') }}" role="button" class="ons-btn ons-btn--link ons-btn--secondary">
+        <a href="{{ url_for('surveys_bp.send_help_message', option=option, sub_option='my-survey-is-not-listed') }}" role="button" class="ons-btn ons-btn--link ons-btn--secondary">
             <span class="ons-btn__inner">No</span>
         </a>
     {% else %}

--- a/frontstage/templates/surveys/help/surveys-help-penalties.html
+++ b/frontstage/templates/surveys/help/surveys-help-penalties.html
@@ -2,7 +2,6 @@
 {% from "components/breadcrumbs/_macro.njk" import onsBreadcrumbs %}
 {% from "components/button/_macro.njk" import onsButton %}
 
-{% set page_title = "Help with penalties" %}
 {% set breadcrumbsData = [
     {
         "text": "Surveys",

--- a/frontstage/templates/surveys/help/surveys-help-penalties.html
+++ b/frontstage/templates/surveys/help/surveys-help-penalties.html
@@ -33,18 +33,18 @@
 {% block main %}
     <h1 class="ons-u-fs-xl">Are there penalties for not completing this survey?</h1>
     {% if inside_legal_basis %}
-        <p>You are required by law to complete it. We want to work with you to help you meet this legal requirement. <a href="{{ url_for('surveys_bp.get_send_help_message_page', short_name=short_name, option=option, sub_option='penalties', business_id=business_id, survey_ref=survey_ref, ru_ref=ru_ref) }}">Send us a message</a> and we can advise.</p>
+        <p>You are required by law to complete it. We want to work with you to help you meet this legal requirement. <a href="{{ url_for('surveys_bp.send_help_message', short_name=short_name, option=option, sub_option='penalties', business_id=business_id, survey_ref=survey_ref, ru_ref=ru_ref) }}">Send us a message</a> and we can advise.</p>
         <p>If you do not contact us or complete and return by the deadline, penalties may be incurred resulting in a fine of up to £2,500 (under section 4 of the Statistics of Trade Act 1947, last updated by section 17 of the Criminal Justice Act 1991).</p>
         <p>You will still need to complete the survey.</p>
     {% else %}
         <p>Your information is crucial to make sure we produce statistics that best reflect the status of the UK economy. There is no legal obligation to complete this survey, however your participation ensures your industry, and businesses like yours, are represented in the statistics we produce.</p>
-        <p><a href="{{ url_for('surveys_bp.get_send_help_message_page', short_name=short_name, option=option, sub_option='penalties', business_id=business_id, survey_ref=survey_ref, ru_ref=ru_ref) }}">Send us a message</a> if you need further information.</p>
+        <p><a href="{{ url_for('surveys_bp.send_help_message', short_name=short_name, option=option, sub_option='penalties', business_id=business_id, survey_ref=survey_ref, ru_ref=ru_ref) }}">Send us a message</a> if you need further information.</p>
     {% endif %}
     <h2>Did this answer your question?</h2>
     <a href="{{ url_for('surveys_bp.get_survey_list', tag='todo') }}" role="button" class="ons-btn ons-btn--link ons-js-submit-btn">
         <span class="ons-btn__inner">Yes</span>
     </a>
-    <a href="{{ url_for('surveys_bp.get_send_help_message_page', option=option, sub_option='penalties') }}" role="button" class="ons-btn ons-btn--link ons-btn--secondary">
+    <a href="{{ url_for('surveys_bp.send_help_message', option=option, sub_option='penalties') }}" role="button" class="ons-btn ons-btn--link ons-btn--secondary">
         <span class="ons-btn__inner">No</span>
     </a>
 {% endblock main %}

--- a/frontstage/templates/surveys/help/surveys-help-return-data-by-deadline.html
+++ b/frontstage/templates/surveys/help/surveys-help-return-data-by-deadline.html
@@ -2,7 +2,6 @@
 {% from "components/breadcrumbs/_macro.njk" import onsBreadcrumbs %}
 {% from "components/button/_macro.njk" import onsButton %}
 
-{% set page_title = "Help with deadline" %}
 {% set breadcrumbsData = [
     {
         "text": "Surveys",

--- a/frontstage/templates/surveys/help/surveys-help-return-data-by-deadline.html
+++ b/frontstage/templates/surveys/help/surveys-help-return-data-by-deadline.html
@@ -34,18 +34,18 @@
 {% block main %}
     <h1 class="ons-u-fs-xl">What if I cannot return the survey by the deadline?</h1>
     {% if inside_legal_basis %}
-        <p><a href="{{ url_for('surveys_bp.get_send_help_message_page', short_name=short_name, option=option, sub_option='unable-to-return-by-deadline', business_id=business_id, survey_ref=survey_ref, ru_ref=ru_ref) }}">Send us a message</a> if you cannot complete and return by the deadline and we will be able to advise.</p>
+        <p><a href="{{ url_for('surveys_bp.send_help_message', short_name=short_name, option=option, sub_option='unable-to-return-by-deadline', business_id=business_id, survey_ref=survey_ref, ru_ref=ru_ref) }}">Send us a message</a> if you cannot complete and return by the deadline and we will be able to advise.</p>
         <p>If you do not contact us to discuss alternative arrangements or do not complete and return the survey, penalties may be incurred resulting in a fine of up to £2,500 (under section 4 of the Statistics of Trade Act 1947, last updated by section 17 of the Criminal Justice Act 1991).</p>
         <p>You will still need to complete the survey.</p>
     {% else %}
-        <p><a href="{{ url_for('surveys_bp.get_send_help_message_page', short_name=short_name, option=option, sub_option='unable-to-return-by-deadline', business_id=business_id, survey_ref=survey_ref, ru_ref=ru_ref) }}">Send us a message</a> if you cannot complete and return this survey by the deadline and we will be able to advise.</p>
+        <p><a href="{{ url_for('surveys_bp.send_help_message', short_name=short_name, option=option, sub_option='unable-to-return-by-deadline', business_id=business_id, survey_ref=survey_ref, ru_ref=ru_ref) }}">Send us a message</a> if you cannot complete and return this survey by the deadline and we will be able to advise.</p>
     {% endif %}
 
     <h2>Did this answer your question?</h2>
     <a href="{{ url_for('surveys_bp.get_survey_list', tag='todo') }}" role="button" class="ons-btn ons-btn--link ons-js-submit-btn">
         <span class="ons-btn__inner">Yes</span>
     </a>
-    <a href="{{ url_for('surveys_bp.get_send_help_message_page', option=option, sub_option='unable-to-return-by-deadline') }}" role="button" class="ons-btn ons-btn--link ons-btn--secondary">
+    <a href="{{ url_for('surveys_bp.send_help_message', option=option, sub_option='unable-to-return-by-deadline') }}" role="button" class="ons-btn ons-btn--link ons-btn--secondary">
         <span class="ons-btn__inner">No</span>
     </a>
 {% endblock main %}

--- a/frontstage/templates/surveys/help/surveys-help-something-else.html
+++ b/frontstage/templates/surveys/help/surveys-help-something-else.html
@@ -4,7 +4,6 @@
 {% from "components/radios/_macro.njk" import onsRadios %}
 {% from "components/button/_macro.njk" import onsButton %}
 
-{% set page_title = page_title + "Help Information about the ONS" %}
 {% set breadcrumbsData = [
     {
         "text": "Surveys",

--- a/frontstage/templates/surveys/help/surveys-help-something-else.html
+++ b/frontstage/templates/surveys/help/surveys-help-something-else.html
@@ -4,7 +4,7 @@
 {% from "components/radios/_macro.njk" import onsRadios %}
 {% from "components/button/_macro.njk" import onsButton %}
 
-{% set page_title = "Help Information about the ONS" %}
+{% set page_title = page_title + "Help Information about the ONS" %}
 {% set breadcrumbsData = [
     {
         "text": "Surveys",
@@ -31,7 +31,7 @@
     {% set ns = namespace() %}
     {% include "radio-option-select-error-panel.html" %}
     <h1 class="ons-u-fs-xl">Something else</h1>
-    <form action="{{ url_for('surveys_bp.post_help_option_select', short_name=short_name, business_id=business_id, option=option, survey_ref=survey_ref, ru_ref=ru_ref)}}" method="post">
+    <form action="{{ url_for('surveys_bp.help_option_select', short_name=short_name, business_id=business_id, option=option, survey_ref=survey_ref, ru_ref=ru_ref)}}" method="post">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
         {% if ns.optionError %}
             {% set errorOption = { "text": ns.optionErrorMessage,  "id": 'option_error' } %}

--- a/frontstage/templates/surveys/help/surveys-help-specific-figure-for-response.html
+++ b/frontstage/templates/surveys/help/surveys-help-specific-figure-for-response.html
@@ -41,7 +41,7 @@
     <a href="{{ url_for('surveys_bp.get_survey_list', tag='todo') }}" role="button" class="ons-btn ons-btn--link ons-js-submit-btn">
         <span class="ons-btn__inner">Yes</span>
     </a>
-    <a href="{{ url_for('surveys_bp.get_send_help_message_page', option=option, sub_option='do-not-have-specific-figures') }}" role="button" class="ons-btn ons-btn--link ons-btn--secondary">
+    <a href="{{ url_for('surveys_bp.send_help_message', option=option, sub_option='do-not-have-specific-figures') }}" role="button" class="ons-btn ons-btn--link ons-btn--secondary">
         <span class="ons-btn__inner">No</span>
     </a>
 {% endblock main %}

--- a/frontstage/templates/surveys/help/surveys-help-specific-figure-for-response.html
+++ b/frontstage/templates/surveys/help/surveys-help-specific-figure-for-response.html
@@ -2,7 +2,6 @@
 {% from "components/breadcrumbs/_macro.njk" import onsBreadcrumbs %}
 {% from "components/button/_macro.njk" import onsButton %}
 
-{% set page_title = "Help with specific figures" %}
 {% set breadcrumbsData = [
     {
         "text": "Surveys",

--- a/frontstage/templates/surveys/help/surveys-help-time-to-complete.html
+++ b/frontstage/templates/surveys/help/surveys-help-time-to-complete.html
@@ -2,7 +2,6 @@
 {% from "components/breadcrumbs/_macro.njk" import onsBreadcrumbs %}
 {% from "components/button/_macro.njk" import onsButton %}
 
-{% set page_title = "Help with time to complete" %}
 {% set breadcrumbsData = [
     {
         "text": "Surveys",

--- a/frontstage/templates/surveys/help/surveys-help-time-to-complete.html
+++ b/frontstage/templates/surveys/help/surveys-help-time-to-complete.html
@@ -42,7 +42,7 @@
     <a href="{{ url_for('surveys_bp.get_survey_list', tag='todo') }}" role="button" class="ons-btn ons-btn--link ons-js-submit-btn">
         <span class="ons-btn__inner">Yes</span>
     </a>
-    <a href="{{ url_for('surveys_bp.get_send_help_message_page', option=option, sub_option='time-to-complete') }}" role="button" class="ons-btn ons-btn--link ons-btn--secondary">
+    <a href="{{ url_for('surveys_bp.send_help_message', option=option, sub_option='time-to-complete') }}" role="button" class="ons-btn ons-btn--link ons-btn--secondary">
         <span class="ons-btn__inner">No</span>
     </a>
 {% endblock main %}

--- a/frontstage/templates/surveys/help/surveys-help-who-is-the-ons.html
+++ b/frontstage/templates/surveys/help/surveys-help-who-is-the-ons.html
@@ -2,7 +2,6 @@
 {% from "components/breadcrumbs/_macro.njk" import onsBreadcrumbs %}
 {% from "components/button/_macro.njk" import onsButton %}
 
-{% set page_title = "Help with how long selected for" %}
 {% set breadcrumbsData = [
     {
         "text": "Surveys",

--- a/frontstage/templates/surveys/help/surveys-help-who-is-the-ons.html
+++ b/frontstage/templates/surveys/help/surveys-help-who-is-the-ons.html
@@ -46,7 +46,7 @@
     <a href="{{ url_for('surveys_bp.get_survey_list', tag='todo') }}" role="button" class="ons-btn ons-btn--link ons-js-submit-btn">
         <span class="ons-btn__inner">Yes</span>
     </a>
-    <a href="{{ url_for('surveys_bp.get_send_help_message_page', option=option, sub_option='who-is-the-ons') }}" role="button" class="ons-btn ons-btn--link ons-btn--secondary">
+    <a href="{{ url_for('surveys_bp.send_help_message', option=option, sub_option='who-is-the-ons') }}" role="button" class="ons-btn ons-btn--link ons-btn--secondary">
         <span class="ons-btn__inner">No</span>
     </a>
 {% endblock main %}

--- a/frontstage/templates/surveys/help/surveys-help-why-selected.html
+++ b/frontstage/templates/surveys/help/surveys-help-why-selected.html
@@ -2,7 +2,6 @@
 {% from "components/breadcrumbs/_macro.njk" import onsBreadcrumbs %}
 {% from "components/button/_macro.njk" import onsButton %}
 
-{% set page_title = "Help with why business selected" %}
 {% set breadcrumbsData = [
     {
         "text": "Surveys",

--- a/frontstage/templates/surveys/help/surveys-help-why-selected.html
+++ b/frontstage/templates/surveys/help/surveys-help-why-selected.html
@@ -45,7 +45,7 @@
     <a href="{{ url_for('surveys_bp.get_survey_list', tag='todo') }}" role="button" class="ons-btn ons-btn--link ons-js-submit-btn">
         <span class="ons-btn__inner">Yes</span>
     </a>
-    <a href="{{ url_for('surveys_bp.get_send_help_message_page', option=option, sub_option='why-selected') }}" role="button" class="ons-btn ons-btn--link ons-btn--secondary">
+    <a href="{{ url_for('surveys_bp.send_help_message', option=option, sub_option='why-selected') }}" role="button" class="ons-btn ons-btn--link ons-btn--secondary">
         <span class="ons-btn__inner">No</span>
     </a>
 {% endblock main %}

--- a/frontstage/templates/surveys/help/surveys-help.html
+++ b/frontstage/templates/surveys/help/surveys-help.html
@@ -3,7 +3,8 @@
 {% from "components/fieldset/_macro.njk" import onsFieldset %}
 {% from "components/radios/_macro.njk" import onsRadios %}
 {% from "components/button/_macro.njk" import onsButton %}
-{% set ns = namespace() %}
+
+{% set page_title = page_title + "Help" %}
 
 {% set breadcrumbsData = [
     {
@@ -24,6 +25,7 @@
 {% endblock breadcrumbs %}
 
 {% block main %}
+    {% set ns = namespace() %}
     {% include "radio-option-select-error-panel.html" %}
 
     <h1 class="ons-u-fs-xl">Help</h1>

--- a/frontstage/templates/surveys/help/surveys-help.html
+++ b/frontstage/templates/surveys/help/surveys-help.html
@@ -4,8 +4,6 @@
 {% from "components/radios/_macro.njk" import onsRadios %}
 {% from "components/button/_macro.njk" import onsButton %}
 
-{% set page_title = page_title + "Help" %}
-
 {% set breadcrumbsData = [
     {
         "text": "Surveys",

--- a/frontstage/templates/surveys/help/surveys-help.html
+++ b/frontstage/templates/surveys/help/surveys-help.html
@@ -3,8 +3,7 @@
 {% from "components/fieldset/_macro.njk" import onsFieldset %}
 {% from "components/radios/_macro.njk" import onsRadios %}
 {% from "components/button/_macro.njk" import onsButton %}
-
-{% set page_title = "Help" %}
+{% set ns = namespace() %}
 
 {% set breadcrumbsData = [
     {
@@ -25,12 +24,11 @@
 {% endblock breadcrumbs %}
 
 {% block main %}
-    {% set ns = namespace() %}
     {% include "radio-option-select-error-panel.html" %}
 
     <h1 class="ons-u-fs-xl">Help</h1>
 
-    <form action="{{ url_for('surveys_bp.post_help_page', short_name=short_name, business_id=business_id, survey_ref=survey_ref, ru_ref=ru_ref)}}" method="post">
+    <form action="{{ url_for('surveys_bp.help_page', short_name=short_name, business_id=business_id, survey_ref=survey_ref, ru_ref=ru_ref)}}" method="post">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
         {% if ns.optionError %}
             {% set errorOption = { "text": ns.optionErrorMessage,  "id": 'option_error' } %}

--- a/frontstage/templates/surveys/surveys-share/overview.html
+++ b/frontstage/templates/surveys/surveys-share/overview.html
@@ -64,7 +64,7 @@
         }}
         {{
             onsButton({
-                "url": url_for('account_bp.get_account'),
+                "url": url_for('account_bp.account'),
                 "text": 'Cancel',
                 "variants": 'secondary',
                 "noIcon": true

--- a/frontstage/templates/surveys/surveys-transfer/overview.html
+++ b/frontstage/templates/surveys/surveys-transfer/overview.html
@@ -64,7 +64,7 @@
         }}
         {{
             onsButton({
-                "url": url_for('account_bp.get_account'),
+                "url": url_for('account_bp.account'),
                 "text": 'Cancel',
                 "variants": 'secondary',
                 "noIcon": true

--- a/frontstage/templates/surveys/surveys-upload-failure.html
+++ b/frontstage/templates/surveys/surveys-upload-failure.html
@@ -11,7 +11,7 @@
         })
     %}
 
-        <p>{{ error_info.body }}</p>
+        <p><span class="ons-panel__assistive-text ons-u-vh">Error: </span> {{ error_info.body }}</p>
         <div>
             {% include "surveys/surveys-upload-file-picker.html" %}
         </div>

--- a/frontstage/views/account/account.py
+++ b/frontstage/views/account/account.py
@@ -35,25 +35,25 @@ form_redirect_mapper = {
 }
 
 
-@account_bp.route("/", methods=["GET"])
+@account_bp.route("/", methods=["GET", "POST"])
 @jwt_authorization(request)
-def get_account(session):
-    form = OptionsForm()
+def account(session):
+    page_title = "Account details"
     party_id = session.get_party_id()
     respondent_details = party_controller.get_respondent_party_by_id(party_id)
-    return render_template("account/account.html", form=form, respondent=respondent_details)
 
-
-@account_bp.route("/", methods=["POST"])
-@jwt_authorization(request)
-def update_account(session):
-    form = OptionsForm()
-    form_valid = form.validate()
-    if not form_valid:
-        flash("You need to choose an option")
-        return redirect(url_for("account_bp.get_account"))
+    if request.method == "POST":
+        form = OptionsForm()
+        form_valid = form.validate()
+        if not form_valid:
+            flash("You need to choose an option")
+            page_title = "Error: " + page_title
+        else:
+            return redirect(url_for(form_redirect_mapper.get(form.data["option"])))
     else:
-        return redirect(url_for(form_redirect_mapper.get(form.data["option"])))
+        form = OptionsForm()
+
+    return render_template("account/account.html", form=form, respondent=respondent_details, page_title=page_title)
 
 
 @account_bp.route("/change-password", methods=["GET", "POST"])

--- a/frontstage/views/help.py
+++ b/frontstage/views/help.py
@@ -33,45 +33,44 @@ def help():
 
 @help_bp.route("/", methods=["GET", "POST"])
 def help_page():
+    page_title = "Help"
     form = HelpForm(request.values)
     if request.method == "POST":
         if form.validate():
             return redirect(url_for(form_redirect_mapper.get(form.data["option"])))
         else:
             flash("At least one option should be selected.")
-            return render_template("help/help.html", form=HelpForm(), page_title="Error: Help")
-    else:
-        return render_template("help/help.html", form=HelpForm(), page_title="Help")
+            page_title = "Error: " + page_title
+
+    return render_template("help/help.html", form=HelpForm(), page_title=page_title)
 
 
 @help_bp.route("/info-ons", methods=["GET", "POST"])
-def info_ons_submit():
+def info_ons_page():
+    page_title = "Help info ONS"
     form = HelpInfoOnsForm(request.values)
     if request.method == "POST":
         if form.validate():
             return render_template(form_render_page_mapper.get(form.data["option"]))
         else:
             flash("At least one option should be selected.")
-            return render_template("help/help-info-ons.html", form=HelpInfoOnsForm(), page_title="Error: Help info ONS")
-    else:
-        return render_template("help/help-info-ons.html", form=HelpInfoOnsForm(), page_title="Help info ONS")
+            page_title = "Error: " + page_title
+
+    return render_template("help/help-info-ons.html", form=HelpInfoOnsForm(), page_title=page_title)
 
 
 @help_bp.route("/help-with-my-password", methods=["GET", "POST"])
 def help_with_password_page():
+    page_title = "Help with my password"
     form = HelpPasswordForm(request.values)
     if request.method == "POST":
         if form.validate():
             return render_template(form_render_page_mapper.get(form.data["option"]))
         else:
             flash("At least one option should be selected.")
-            return render_template(
-                "help/help-with-password.html", form=HelpPasswordForm(), page_title="Error: Help with my password"
-            )
-    else:
-        return render_template(
-            "help/help-with-password.html", form=HelpPasswordForm(), page_title="Help with my password"
-        )
+            page_title = "Error: " + page_title
+
+    return render_template("help/help-with-password.html", form=HelpPasswordForm(), page_title=page_title)
 
 
 @help_bp.route("/something-else", methods=["GET"])

--- a/frontstage/views/help.py
+++ b/frontstage/views/help.py
@@ -33,7 +33,7 @@ def help():
 
 @help_bp.route("/", methods=["GET"])
 def help_get():
-    return render_template("help/help.html", form=HelpForm())
+    return render_template("help/help.html", form=HelpForm(), page_title="Help")
 
 
 @help_bp.route("/", methods=["POST"])
@@ -43,12 +43,12 @@ def help_submit():
         return redirect(url_for(form_redirect_mapper.get(form.data["option"])))
     else:
         flash("At least one option should be selected.")
-        return redirect(url_for("help_bp.help_get"))
+        return render_template("help/help.html", form=HelpForm(), page_title="Error: Help")
 
 
 @help_bp.route("/info-ons", methods=["GET"])
 def info_ons_get():
-    return render_template("help/help-info-ons.html", form=HelpInfoOnsForm())
+    return render_template("help/help-info-ons.html", form=HelpInfoOnsForm(), page_title="Help info ONS")
 
 
 @help_bp.route("/info-ons", methods=["POST"])
@@ -58,12 +58,12 @@ def info_ons_submit():
         return render_template(form_render_page_mapper.get(form.data["option"]))
     else:
         flash("At least one option should be selected.")
-        return redirect(url_for("help_bp.info_ons_get"))
+        return render_template("help/help-info-ons.html", form=HelpInfoOnsForm(), page_title="Error: Help info ONS")
 
 
 @help_bp.route("/help-with-my-password", methods=["GET"])
 def help_with_password_get():
-    return render_template("help/help-with-password.html", form=HelpPasswordForm())
+    return render_template("help/help-with-password.html", form=HelpPasswordForm(), page_title="Help with my password")
 
 
 @help_bp.route("/help-with-my-password", methods=["POST"])
@@ -73,7 +73,8 @@ def help_with_password_submit():
         return render_template(form_render_page_mapper.get(form.data["option"]))
     else:
         flash("At least one option should be selected.")
-        return redirect(url_for("help_bp.help_with_password_get"))
+        return render_template("help/help-with-password.html", form=HelpPasswordForm(),
+                               page_title="Error: Help with my password")
 
 
 @help_bp.route("/something-else", methods=["GET"])

--- a/frontstage/views/help.py
+++ b/frontstage/views/help.py
@@ -11,8 +11,8 @@ logger = wrap_logger(logging.getLogger(__name__))
 help_bp = Blueprint("help_bp", __name__, static_folder="static", template_folder="templates")
 
 form_redirect_mapper = {
-    "info-ons": "help_bp.info_ons_get",
-    "password": "help_bp.help_with_password_get",
+    "info-ons": "help_bp.info_ons_page",
+    "password": "help_bp.help_with_password_page",
     "something-else": "help_bp.something_else",
 }
 form_render_page_mapper = {
@@ -31,50 +31,47 @@ def help():
     return render_template("vunerability_disclosure.html")
 
 
-@help_bp.route("/", methods=["GET"])
-def help_get():
-    return render_template("help/help.html", form=HelpForm(), page_title="Help")
-
-
-@help_bp.route("/", methods=["POST"])
-def help_submit():
+@help_bp.route("/", methods=["GET", "POST"])
+def help_page():
     form = HelpForm(request.values)
-    if form.validate():
-        return redirect(url_for(form_redirect_mapper.get(form.data["option"])))
+    if request.method == "POST":
+        if form.validate():
+            return redirect(url_for(form_redirect_mapper.get(form.data["option"])))
+        else:
+            flash("At least one option should be selected.")
+            return render_template("help/help.html", form=HelpForm(), page_title="Error: Help")
     else:
-        flash("At least one option should be selected.")
-        return render_template("help/help.html", form=HelpForm(), page_title="Error: Help")
+        return render_template("help/help.html", form=HelpForm(), page_title="Help")
 
 
-@help_bp.route("/info-ons", methods=["GET"])
-def info_ons_get():
-    return render_template("help/help-info-ons.html", form=HelpInfoOnsForm(), page_title="Help info ONS")
-
-
-@help_bp.route("/info-ons", methods=["POST"])
+@help_bp.route("/info-ons", methods=["GET", "POST"])
 def info_ons_submit():
     form = HelpInfoOnsForm(request.values)
-    if form.validate():
-        return render_template(form_render_page_mapper.get(form.data["option"]))
+    if request.method == "POST":
+        if form.validate():
+            return render_template(form_render_page_mapper.get(form.data["option"]))
+        else:
+            flash("At least one option should be selected.")
+            return render_template("help/help-info-ons.html", form=HelpInfoOnsForm(), page_title="Error: Help info ONS")
     else:
-        flash("At least one option should be selected.")
-        return render_template("help/help-info-ons.html", form=HelpInfoOnsForm(), page_title="Error: Help info ONS")
+        return render_template("help/help-info-ons.html", form=HelpInfoOnsForm(), page_title="Help info ONS")
 
 
-@help_bp.route("/help-with-my-password", methods=["GET"])
-def help_with_password_get():
-    return render_template("help/help-with-password.html", form=HelpPasswordForm(), page_title="Help with my password")
-
-
-@help_bp.route("/help-with-my-password", methods=["POST"])
-def help_with_password_submit():
+@help_bp.route("/help-with-my-password", methods=["GET", "POST"])
+def help_with_password_page():
     form = HelpPasswordForm(request.values)
-    if form.validate():
-        return render_template(form_render_page_mapper.get(form.data["option"]))
+    if request.method == "POST":
+        if form.validate():
+            return render_template(form_render_page_mapper.get(form.data["option"]))
+        else:
+            flash("At least one option should be selected.")
+            return render_template(
+                "help/help-with-password.html", form=HelpPasswordForm(), page_title="Error: Help with my password"
+            )
     else:
-        flash("At least one option should be selected.")
-        return render_template("help/help-with-password.html", form=HelpPasswordForm(),
-                               page_title="Error: Help with my password")
+        return render_template(
+            "help/help-with-password.html", form=HelpPasswordForm(), page_title="Help with my password"
+        )
 
 
 @help_bp.route("/something-else", methods=["GET"])

--- a/frontstage/views/surveys/help/surveys_help.py
+++ b/frontstage/views/surveys/help/surveys_help.py
@@ -39,7 +39,7 @@ option_template_title_mapping = {
     "help-completing-this-survey": "Help completing this survey",
     "info-about-this-survey": "Help information about this survey",
     "info-about-the-ons": "Help information about the ONS",
-    "something-else": "Help something else",
+    "something-else": "Help with something else",
 }
 sub_option_template_url_mapping = {
     "do-not-have-specific-figures": "surveys/help/surveys-help-specific-figure-for-response.html",

--- a/tests/integration/test_passwords.py
+++ b/tests/integration/test_passwords.py
@@ -24,7 +24,6 @@ url_resend_password_email_expired_token = (
 url_password_reset_counter = f"{app.config['PARTY_URL']}/party-api/v1/respondents/123456/password-reset-counter"
 
 
-# noinspection DuplicatedCode
 class TestPasswords(unittest.TestCase):
     def setUp(self):
         app.testing = True

--- a/tests/integration/test_sign_out_help.py
+++ b/tests/integration/test_sign_out_help.py
@@ -12,7 +12,7 @@ class TestSignOutHelp(unittest.TestCase):
         self.app.set_cookie("localhost", "authorization", "session_key")
 
     @requests_mock.mock()
-    def test_sign_out_help_get(self, mock_request):
+    def test_sign_out_help_page(self, mock_request):
         mock_request.get(url_banner_api, status_code=404)
         response = self.app.get("/help")
         self.assertEqual(response.status_code, 200)

--- a/tests/integration/views/account/test_account.py
+++ b/tests/integration/views/account/test_account.py
@@ -59,6 +59,8 @@ class TestSurveyList(unittest.TestCase):
         mock_request.get(url_banner_api, status_code=404)
         get_respondent_party_by_id.return_value = respondent_party
         response = self.app.post("/my-account", data={"option": None}, follow_redirects=True)
+        self.assertIn("Error: ".encode(), response.data)
+        self.assertIn('<span class="ons-panel__assistive-text ons-u-vh">Error: </span>'.encode(), response.data)
         self.assertIn("You need to choose an option".encode(), response.data)
 
     @requests_mock.mock()

--- a/tests/integration/views/surveys/help/test_surveys_help_info_about_the_ons.py
+++ b/tests/integration/views/surveys/help/test_surveys_help_info_about_the_ons.py
@@ -63,6 +63,8 @@ class TestSurveyHelpInfoAboutThisSurvey(unittest.TestCase):
         response = self.app.post("/surveys/help", data=form, follow_redirects=True)
 
         self.assertEqual(response.status_code, 200)
+        self.assertIn("Error: ".encode(), response.data)
+        self.assertIn('<span class="ons-panel__assistive-text ons-u-vh">Error: </span>'.encode(), response.data)
         self.assertIn("There is 1 error on this page".encode(), response.data)
         self.assertIn("You need to choose an option".encode(), response.data)
 
@@ -233,6 +235,8 @@ class TestSurveyHelpInfoAboutThisSurvey(unittest.TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
+        self.assertIn("Error: ".encode(), response.data)
+        self.assertIn('<span class="ons-panel__assistive-text ons-u-vh">Error: </span>'.encode(), response.data)
         self.assertIn("There is 1 error on this page".encode(), response.data)
         self.assertIn("Message is required".encode(), response.data)
         self.assertIn("Send a message".encode(), response.data)

--- a/tests/integration/views/surveys/help/test_surveys_help_info_about_this_survey.py
+++ b/tests/integration/views/surveys/help/test_surveys_help_info_about_this_survey.py
@@ -79,6 +79,8 @@ class TestSurveyHelpInfoAboutThisSurvey(unittest.TestCase):
         response = self.app.post("/surveys/help", data=form, follow_redirects=True)
 
         self.assertEqual(response.status_code, 200)
+        self.assertIn("Error: ".encode(), response.data)
+        self.assertIn('<span class="ons-panel__assistive-text ons-u-vh">Error: </span>'.encode(), response.data)
         self.assertIn("There is 1 error on this page".encode(), response.data)
         self.assertIn("You need to choose an option".encode(), response.data)
 
@@ -418,3 +420,34 @@ class TestSurveyHelpInfoAboutThisSurvey(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("Message sent.".encode(), response.data)
+
+    @requests_mock.mock()
+    @patch("frontstage.controllers.party_controller.get_respondent_party_by_id")
+    @patch("frontstage.controllers.party_controller.get_survey_list_details_for_party")
+    @patch("frontstage.controllers.conversation_controller.send_message")
+    @patch("frontstage.controllers.party_controller.get_business_by_ru_ref")
+    @patch("frontstage.controllers.survey_controller.get_survey_by_survey_ref")
+    def test_create_message_post_failure(
+        self, mock_request, get_survey, get_business, send_message, get_survey_list, get_respondent_party_by_id
+    ):
+        mock_request.get(url_banner_api, status_code=404)
+        get_survey.return_value = survey
+        get_business.return_value = business_party
+        get_survey_list.return_value = survey_list_todo
+        get_respondent_party_by_id.return_value = respondent_party
+        form = {"body": ""}
+        self.set_flask_session()
+        response = self.app.post(
+            "/surveys/help/info-about-this-survey/info-something-else/send-message",
+            data=form,
+            follow_redirects=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Error: ".encode(), response.data)
+        self.assertIn('<span class="ons-panel__assistive-text ons-u-vh">Error: </span>'.encode(), response.data)
+        self.assertIn("There is 1 error on this page".encode(), response.data)
+        self.assertIn("Message is required".encode(), response.data)
+        self.assertIn("Send a message".encode(), response.data)
+        self.assertIn("Describe your issue and we will get back to you.".encode(), response.data)
+        self.assertIn("Information about this survey".encode(), response.data)

--- a/tests/integration/views/surveys/help/test_surveys_help_something_else.py
+++ b/tests/integration/views/surveys/help/test_surveys_help_something_else.py
@@ -62,7 +62,7 @@ class TestSurveyHelpInfoAboutThisSurvey(unittest.TestCase):
         response = self.app.post("/surveys/help", data=form, follow_redirects=True)
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn("Information about the ONS".encode(), response.data)
+        self.assertIn("Help with something else".encode(), response.data)
         self.assertIn("Choose an option".encode(), response.data)
         self.assertIn("My survey is not listed".encode(), response.data)
         self.assertIn("Something else".encode(), response.data)

--- a/tests/integration/views/surveys/help/test_surveys_help_something_else.py
+++ b/tests/integration/views/surveys/help/test_surveys_help_something_else.py
@@ -175,6 +175,8 @@ class TestSurveyHelpInfoAboutThisSurvey(unittest.TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
+        self.assertIn("Error: ".encode(), response.data)
+        self.assertIn('<span class="ons-panel__assistive-text ons-u-vh">Error: </span>'.encode(), response.data)
         self.assertIn("There is 1 error on this page".encode(), response.data)
         self.assertIn("Message is required".encode(), response.data)
         self.assertIn("Send a message".encode(), response.data)

--- a/tests/integration/views/surveys/help/test_surveys_help_something_else.py
+++ b/tests/integration/views/surveys/help/test_surveys_help_something_else.py
@@ -92,6 +92,23 @@ class TestSurveyHelpInfoAboutThisSurvey(unittest.TestCase):
     @requests_mock.mock()
     @patch("frontstage.controllers.party_controller.get_business_by_ru_ref")
     @patch("frontstage.controllers.survey_controller.get_survey_by_survey_ref")
+    def test_survey_help_info_bricks_with_no_option_select(self, mock_request, get_survey, get_business):
+        mock_request.get(url_banner_api, status_code=404)
+        get_survey.return_value = survey
+        get_business.return_value = business_party
+        form = {}
+        self.set_flask_session()
+        response = self.app.post("/surveys/help/something-else", data=form, follow_redirects=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Error: ".encode(), response.data)
+        self.assertIn('<span class="ons-panel__assistive-text ons-u-vh">Error: </span>'.encode(), response.data)
+        self.assertIn("There is 1 error on this page".encode(), response.data)
+        self.assertIn("You need to choose an option".encode(), response.data)
+
+    @requests_mock.mock()
+    @patch("frontstage.controllers.party_controller.get_business_by_ru_ref")
+    @patch("frontstage.controllers.survey_controller.get_survey_by_survey_ref")
     def test_survey_help_info_bricks_with_sub_option_something_else(self, mock_request, get_survey, get_business):
         mock_request.get(url_banner_api, status_code=404)
         get_survey.return_value = survey

--- a/tests/integration/views/surveys/help/test_surveys_help_with_this_survey.py
+++ b/tests/integration/views/surveys/help/test_surveys_help_with_this_survey.py
@@ -89,6 +89,23 @@ class TestSurveyHelpWithThisSurvey(unittest.TestCase):
     @requests_mock.mock()
     @patch("frontstage.controllers.party_controller.get_business_by_ru_ref")
     @patch("frontstage.controllers.survey_controller.get_survey_by_survey_ref")
+    def test_survey_help_for_bricks_with_no_option_select(self, mock_request, get_survey, get_business):
+        mock_request.get(url_banner_api, status_code=404)
+        get_survey.return_value = survey
+        get_business.return_value = business_party
+        form = {"option": ""}
+        self.set_flask_session()
+        response = self.app.post("/surveys/help/help-completing-this-survey", data=form, follow_redirects=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Error: ".encode(), response.data)
+        self.assertIn('<span class="ons-panel__assistive-text ons-u-vh">Error: </span>'.encode(), response.data)
+        self.assertIn("There is 1 error on this page".encode(), response.data)
+        self.assertIn("You need to choose an option".encode(), response.data)
+
+    @requests_mock.mock()
+    @patch("frontstage.controllers.party_controller.get_business_by_ru_ref")
+    @patch("frontstage.controllers.survey_controller.get_survey_by_survey_ref")
     def test_survey_help_for_bricks_with_sub_option_answer_a_survey_question(
         self, mock_request, get_survey, get_business
     ):


### PR DESCRIPTION
# What and why?
This PR addresses the issues raised by the DAC testing since some of the error handling in frontstage does not follow the GOV.UK guidelines. This adds an `Error: ` tag in the page title so screen readers notify of an error immediately. It also adds a hidden `Error` tag for screen readers in the page content.
# How to test?
Make sure that on the required pages seen on the trello card the Error: label comes up in the page title and either using a screen reader or inspecting the page source verify that there is a hidden `Error` tag in the title where the error happened.

<img width="663" alt="image" src="https://user-images.githubusercontent.com/41422777/203978925-8c6924dd-5728-4bff-8378-9bf95d3ed63d.png">

# Trello
https://trello.com/c/8OxuuUlV/2073-dac-report-error-handling-usability