### PR TITLE
Remove eq version code

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -34,11 +34,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:0d9c601124e5a6ba9712dbc60d9c53c21e34f5f641fe83002317394311bdce14",
-                "sha256:90c1a32f1d68f940488354e36370f6cca89f0f106db09518524c88d6ed83f382"
+                "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3",
+                "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2022.9.24"
+            "version": "==2022.12.7"
         },
         "cffi": {
             "hashes": [
@@ -186,7 +186,7 @@
                 "sha256:190348041559e21b22a1d65cee485282ca11a6f81d503fddb84d5017e9ed1e49",
                 "sha256:80600258e7ed2f16b9aa1d7c295bd70194109ad5a30fdee0eaeefef1d4c559dd"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.18.0"
         },
         "email-validator": {
@@ -284,19 +284,19 @@
                 "grpc"
             ],
             "hashes": [
-                "sha256:10c06f7739fe57781f87523375e8e1a3a4674bf6392cd6131a3222182b971320",
-                "sha256:34f24bd1d5f72a8c4519773d99ca6bf080a6c4e041b4e9f024fe230191dda62e"
+                "sha256:4b9bb5d5a380a0befa0573b302651b8a9a89262c1730e37bf423cec511804c22",
+                "sha256:ce222e27b0de0d7bc63eb043b956996d6dccab14cc3b690aaea91c9cc99dc16e"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.10.2"
+            "version": "==2.11.0"
         },
         "google-auth": {
             "hashes": [
-                "sha256:ccaa901f31ad5cbb562615eb8b664b3dd0bf5404a67618e642307f00613eda4d",
-                "sha256:f5d8701633bebc12e0deea4df8abd8aff31c28b355360597f7f2ee60f2e4d016"
+                "sha256:6897b93556d8d807ad70701bb89f000183aea366ca7ed94680828b37437a4994",
+                "sha256:72f12a6cfc968d754d7bdab369c5c5c16032106e52d32c6dfd8484e4c01a6d1f"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==2.14.1"
+            "version": "==2.15.0"
         },
         "google-cloud-core": {
             "hashes": [
@@ -316,11 +316,11 @@
         },
         "google-cloud-storage": {
             "hashes": [
-                "sha256:104ca28ae61243b637f2f01455cc8a05e8f15a2a18ced96cb587241cdd3820f5",
-                "sha256:4ad0415ff61abdd8bb2ae81c1f8f7ec7d91a1011613f2db87c614c550f97bfe9"
+                "sha256:1ac2d58d2d693cb1341ebc48659a3527be778d9e2d8989697a2746025928ff17",
+                "sha256:f78a63525e72dd46406b255bbdf858a22c43d6bad8dc5bdeb7851a42967e95a1"
             ],
             "index": "pypi",
-            "version": "==2.6.0"
+            "version": "==2.7.0"
         },
         "google-crc32c": {
             "hashes": [
@@ -488,62 +488,62 @@
         },
         "grpcio": {
             "hashes": [
-                "sha256:05f7c248e440f538aaad13eee78ef35f0541e73498dd6f832fe284542ac4b298",
-                "sha256:080b66253f29e1646ac53ef288c12944b131a2829488ac3bac8f52abb4413c0d",
-                "sha256:12b479839a5e753580b5e6053571de14006157f2ef9b71f38c56dc9b23b95ad6",
-                "sha256:156f8009e36780fab48c979c5605eda646065d4695deea4cfcbcfdd06627ddb6",
-                "sha256:15f9e6d7f564e8f0776770e6ef32dac172c6f9960c478616c366862933fa08b4",
-                "sha256:177afaa7dba3ab5bfc211a71b90da1b887d441df33732e94e26860b3321434d9",
-                "sha256:1a4cd8cb09d1bc70b3ea37802be484c5ae5a576108bad14728f2516279165dd7",
-                "sha256:1d8d02dbb616c0a9260ce587eb751c9c7dc689bc39efa6a88cc4fa3e9c138a7b",
-                "sha256:2b71916fa8f9eb2abd93151fafe12e18cebb302686b924bd4ec39266211da525",
-                "sha256:2d9fd6e38b16c4d286a01e1776fdf6c7a4123d99ae8d6b3f0b4a03a34bf6ce45",
-                "sha256:3b611b3de3dfd2c47549ca01abfa9bbb95937eb0ea546ea1d762a335739887be",
-                "sha256:3e4244c09cc1b65c286d709658c061f12c61c814be0b7030a2d9966ff02611e0",
-                "sha256:40838061e24f960b853d7bce85086c8e1b81c6342b1f4c47ff0edd44bbae2722",
-                "sha256:4b123fbb7a777a2fedec684ca0b723d85e1d2379b6032a9a9b7851829ed3ca9a",
-                "sha256:531f8b46f3d3db91d9ef285191825d108090856b3bc86a75b7c3930f16ce432f",
-                "sha256:67dd41a31f6fc5c7db097a5c14a3fa588af54736ffc174af4411d34c4f306f68",
-                "sha256:7489dbb901f4fdf7aec8d3753eadd40839c9085967737606d2c35b43074eea24",
-                "sha256:8d4c8e73bf20fb53fe5a7318e768b9734cf122fe671fcce75654b98ba12dfb75",
-                "sha256:8e69aa4e9b7f065f01d3fdcecbe0397895a772d99954bb82eefbb1682d274518",
-                "sha256:8e8999a097ad89b30d584c034929f7c0be280cd7851ac23e9067111167dcbf55",
-                "sha256:906f4d1beb83b3496be91684c47a5d870ee628715227d5d7c54b04a8de802974",
-                "sha256:92d7635d1059d40d2ec29c8bf5ec58900120b3ce5150ef7414119430a4b2dd5c",
-                "sha256:931e746d0f75b2a5cff0a1197d21827a3a2f400c06bace036762110f19d3d507",
-                "sha256:95ce51f7a09491fb3da8cf3935005bff19983b77c4e9437ef77235d787b06842",
-                "sha256:9eea18a878cffc804506d39c6682d71f6b42ec1c151d21865a95fae743fda500",
-                "sha256:a23d47f2fc7111869f0ff547f771733661ff2818562b04b9ed674fa208e261f4",
-                "sha256:a4c23e54f58e016761b576976da6a34d876420b993f45f66a2bfb00363ecc1f9",
-                "sha256:a50a1be449b9e238b9bd43d3857d40edf65df9416dea988929891d92a9f8a778",
-                "sha256:ab5d0e3590f0a16cb88de4a3fa78d10eb66a84ca80901eb2c17c1d2c308c230f",
-                "sha256:ae23daa7eda93c1c49a9ecc316e027ceb99adbad750fbd3a56fa9e4a2ffd5ae0",
-                "sha256:af98d49e56605a2912cf330b4627e5286243242706c3a9fa0bcec6e6f68646fc",
-                "sha256:b2f77a90ba7b85bfb31329f8eab9d9540da2cf8a302128fb1241d7ea239a5469",
-                "sha256:baab51dcc4f2aecabf4ed1e2f57bceab240987c8b03533f1cef90890e6502067",
-                "sha256:ca8a2254ab88482936ce941485c1c20cdeaef0efa71a61dbad171ab6758ec998",
-                "sha256:cb11464f480e6103c59d558a3875bd84eed6723f0921290325ebe97262ae1347",
-                "sha256:ce8513aee0af9c159319692bfbf488b718d1793d764798c3d5cff827a09e25ef",
-                "sha256:cf151f97f5f381163912e8952eb5b3afe89dec9ed723d1561d59cabf1e219a35",
-                "sha256:d144ad10eeca4c1d1ce930faa105899f86f5d99cecfe0d7224f3c4c76265c15e",
-                "sha256:d534d169673dd5e6e12fb57cc67664c2641361e1a0885545495e65a7b761b0f4",
-                "sha256:d75061367a69808ab2e84c960e9dce54749bcc1e44ad3f85deee3a6c75b4ede9",
-                "sha256:d84d04dec64cc4ed726d07c5d17b73c343c8ddcd6b59c7199c801d6bbb9d9ed1",
-                "sha256:de411d2b030134b642c092e986d21aefb9d26a28bf5a18c47dd08ded411a3bc5",
-                "sha256:e07fe0d7ae395897981d16be61f0db9791f482f03fee7d1851fe20ddb4f69c03",
-                "sha256:ea8ccf95e4c7e20419b7827aa5b6da6f02720270686ac63bd3493a651830235c",
-                "sha256:f7025930039a011ed7d7e7ef95a1cb5f516e23c5a6ecc7947259b67bea8e06ca"
+                "sha256:094e64236253590d9d4075665c77b329d707b6fca864dd62b144255e199b4f87",
+                "sha256:0dc5354e38e5adf2498312f7241b14c7ce3484eefa0082db4297189dcbe272e6",
+                "sha256:0e1a9e1b4a23808f1132aa35f968cd8e659f60af3ffd6fb00bcf9a65e7db279f",
+                "sha256:0fb93051331acbb75b49a2a0fd9239c6ba9528f6bdc1dd400ad1cb66cf864292",
+                "sha256:16c71740640ba3a882f50b01bf58154681d44b51f09a5728180a8fdc66c67bd5",
+                "sha256:172405ca6bdfedd6054c74c62085946e45ad4d9cec9f3c42b4c9a02546c4c7e9",
+                "sha256:17ec9b13cec4a286b9e606b48191e560ca2f3bbdf3986f91e480a95d1582e1a7",
+                "sha256:22b011674090594f1f3245960ced7386f6af35485a38901f8afee8ad01541dbd",
+                "sha256:24ac1154c4b2ab4a0c5326a76161547e70664cd2c39ba75f00fc8a2170964ea2",
+                "sha256:257478300735ce3c98d65a930bbda3db172bd4e00968ba743e6a1154ea6edf10",
+                "sha256:29cb97d41a4ead83b7bcad23bdb25bdd170b1e2cba16db6d3acbb090bc2de43c",
+                "sha256:2b170eaf51518275c9b6b22ccb59450537c5a8555326fd96ff7391b5dd75303c",
+                "sha256:31bb6bc7ff145e2771c9baf612f4b9ebbc9605ccdc5f3ff3d5553de7fc0e0d79",
+                "sha256:3c2b3842dcf870912da31a503454a33a697392f60c5e2697c91d133130c2c85d",
+                "sha256:3f9b0023c2c92bebd1be72cdfca23004ea748be1813a66d684d49d67d836adde",
+                "sha256:471d39d3370ca923a316d49c8aac66356cea708a11e647e3bdc3d0b5de4f0a40",
+                "sha256:49d680356a975d9c66a678eb2dde192d5dc427a7994fb977363634e781614f7c",
+                "sha256:4c4423ea38a7825b8fed8934d6d9aeebdf646c97e3c608c3b0bcf23616f33877",
+                "sha256:506b9b7a4cede87d7219bfb31014d7b471cfc77157da9e820a737ec1ea4b0663",
+                "sha256:538d981818e49b6ed1e9c8d5e5adf29f71c4e334e7d459bf47e9b7abb3c30e09",
+                "sha256:59dffade859f157bcc55243714d57b286da6ae16469bf1ac0614d281b5f49b67",
+                "sha256:5a6ebcdef0ef12005d56d38be30f5156d1cb3373b52e96f147f4a24b0ddb3a9d",
+                "sha256:5dca372268c6ab6372d37d6b9f9343e7e5b4bc09779f819f9470cd88b2ece3c3",
+                "sha256:6df3b63538c362312bc5fa95fb965069c65c3ea91d7ce78ad9c47cab57226f54",
+                "sha256:6f0b89967ee11f2b654c23b27086d88ad7bf08c0b3c2a280362f28c3698b2896",
+                "sha256:75e29a90dc319f0ad4d87ba6d20083615a00d8276b51512e04ad7452b5c23b04",
+                "sha256:7942b32a291421460d6a07883033e392167d30724aa84987e6956cd15f1a21b9",
+                "sha256:9235dcd5144a83f9ca6f431bd0eccc46b90e2c22fe27b7f7d77cabb2fb515595",
+                "sha256:97d67983189e2e45550eac194d6234fc38b8c3b5396c153821f2d906ed46e0ce",
+                "sha256:9ff42c5620b4e4530609e11afefa4a62ca91fa0abb045a8957e509ef84e54d30",
+                "sha256:a8a0b77e992c64880e6efbe0086fe54dfc0bbd56f72a92d9e48264dcd2a3db98",
+                "sha256:aacb54f7789ede5cbf1d007637f792d3e87f1c9841f57dd51abf89337d1b8472",
+                "sha256:bc59f7ba87972ab236f8669d8ca7400f02a0eadf273ca00e02af64d588046f02",
+                "sha256:cc2bece1737b44d878cc1510ea04469a8073dbbcdd762175168937ae4742dfb3",
+                "sha256:cd3baccea2bc5c38aeb14e5b00167bd4e2373a373a5e4d8d850bd193edad150c",
+                "sha256:dad6533411d033b77f5369eafe87af8583178efd4039c41d7515d3336c53b4f1",
+                "sha256:e223a9793522680beae44671b9ed8f6d25bbe5ddf8887e66aebad5e0686049ef",
+                "sha256:e473525c28251558337b5c1ad3fa969511e42304524a4e404065e165b084c9e4",
+                "sha256:e4ef09f8997c4be5f3504cefa6b5c6cc3cf648274ce3cede84d4342a35d76db6",
+                "sha256:e6dfc2b6567b1c261739b43d9c59d201c1b89e017afd9e684d85aa7a186c9f7a",
+                "sha256:eacad297ea60c72dd280d3353d93fb1dcca952ec11de6bb3c49d12a572ba31dd",
+                "sha256:f1158bccbb919da42544a4d3af5d9296a3358539ffa01018307337365a9a0c64",
+                "sha256:f1fec3abaf274cdb85bf3878167cfde5ad4a4d97c68421afda95174de85ba813",
+                "sha256:f96ace1540223f26fbe7c4ebbf8a98e3929a6aa0290c8033d12526847b291c0f",
+                "sha256:fbdbe9a849854fe484c00823f45b7baab159bdd4a46075302281998cb8719df5"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.50.0"
+            "version": "==1.51.1"
         },
         "grpcio-status": {
             "hashes": [
-                "sha256:69be81c4317ec77983fb0eab80221a01e86e833e0fcf2f6acea0a62597c84b93",
-                "sha256:6bcf86b1cb1a8929c9cb75c8593ea001a667f5167cf692627f4b3fc1ae0eded4"
+                "sha256:a52cbdc4b18f325bfc13d319ae7c7ae7a0fee07f3d9a005504d6097896d7a495",
+                "sha256:ac2617a3095935ebd785e2228958f24b10a0d527a0c9eb5a0863c784f648a816"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.50.0"
+            "version": "==1.51.1"
         },
         "gunicorn": {
             "hashes": [
@@ -638,21 +638,13 @@
             "markers": "python_version >= '3.7'",
             "version": "==2.1.1"
         },
-        "packaging": {
-            "hashes": [
-                "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
-                "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==21.3"
-        },
         "phonenumbers": {
             "hashes": [
-                "sha256:07a95c2f178687fd1c3f722cf792b3d33e3a225ae71577e500c99b28544cd6d0",
-                "sha256:7cadfe900e833857500b7bafa3e5a7eddc3263eb66b66a767870b33e44665f92"
+                "sha256:0179f688d48c0e7e161eb7b9d86d587940af1f5174f97c1fdfd893c599c0d94a",
+                "sha256:884b26f775205261f4dc861371dce217c1661a4942fb3ec3624e290fb51869bf"
             ],
             "index": "pypi",
-            "version": "==8.13.1"
+            "version": "==8.13.2"
         },
         "proto-plus": {
             "hashes": [
@@ -664,23 +656,23 @@
         },
         "protobuf": {
             "hashes": [
-                "sha256:2c9c2ed7466ad565f18668aa4731c535511c5d9a40c6da39524bccf43e441719",
-                "sha256:48e2cd6b88c6ed3d5877a3ea40df79d08374088e89bedc32557348848dff250b",
-                "sha256:5b0834e61fb38f34ba8840d7dcb2e5a2f03de0c714e0293b3963b79db26de8ce",
-                "sha256:61f21493d96d2a77f9ca84fefa105872550ab5ef71d21c458eb80edcf4885a99",
-                "sha256:6e0be9f09bf9b6cf497b27425487706fa48c6d1632ddd94dab1a5fe11a422392",
-                "sha256:6e312e280fbe3c74ea9e080d9e6080b636798b5e3939242298b591064470b06b",
-                "sha256:7eb8f2cc41a34e9c956c256e3ac766cf4e1a4c9c925dc757a41a01be3e852965",
-                "sha256:84ea107016244dfc1eecae7684f7ce13c788b9a644cd3fca5b77871366556444",
-                "sha256:9227c14010acd9ae7702d6467b4625b6fe853175a6b150e539b21d2b2f2b409c",
-                "sha256:a419cc95fca8694804709b8c4f2326266d29659b126a93befe210f5bbc772536",
-                "sha256:a7d0ea43949d45b836234f4ebb5ba0b22e7432d065394b532cdca8f98415e3cf",
-                "sha256:b5ab0b8918c136345ff045d4b3d5f719b505b7c8af45092d7f45e304f55e50a1",
-                "sha256:e575c57dc8b5b2b2caa436c16d44ef6981f2235eb7179bfc847557886376d740",
-                "sha256:f9eae277dd240ae19bb06ff4e2346e771252b0e619421965504bd1b1bba7c5fa"
+                "sha256:25266bf373ee06d5d66f9eb1ec9d434b243dccce5c32faf151054cfa6f9dcbf1",
+                "sha256:260e346927fd4e6fbb49ab545137b19610c24a1d853dc5f29ddf777ab1987211",
+                "sha256:2c6a4d13732d9b094db31b3841986c38b17ac61a3fe05ee26a779d94c4c3fb43",
+                "sha256:4922e3320ed70e81f05060822da36923d09fd9e04e17f411f2d8d8d0070f9f5c",
+                "sha256:4b75c947289a2e9c1f37d21c593f1ef6fb4fed33977dfb2ac84f799eb29a8ff4",
+                "sha256:4d01ef83517c181d60ea1c6d0b2f644be250ade740d6554a2f5a021b1ad622e3",
+                "sha256:553e35c0878f6855e55f01a14561e6bce6df79b6636a5acf83b9d9ac7eab7922",
+                "sha256:85ccb4753ee21de7dc81a7a68a051f25dbe133ffa01a639ac998427d0b223387",
+                "sha256:a5a14b907a191319e7a58b38c583bbf50deb21e002f723a912c5e4f6969a778e",
+                "sha256:a944dc9550baae276afc7dc8193191d4c2ad660270a1e5ed5a71539817ebe2e2",
+                "sha256:bab4b21a986ded225b9392c07ce21c35d790951f51e1ebfd32e4d443b05c3726",
+                "sha256:c3b9e329b4c247dc3ba5c50f60915a84e08278eb6d9e3fa674d0d04ff816bfd7",
+                "sha256:d91a47c77b33580024b0271b65bb820c4e0264c25eb49151ad01e691de8fa0b6",
+                "sha256:efb16b16fd3eef25357f84d516062753014b76279ce4e0ec4880badd2fba7370"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==4.21.9"
+            "version": "==4.21.11"
         },
         "pyasn1": {
             "hashes": [
@@ -757,20 +749,12 @@
             "index": "pypi",
             "version": "==3.16.0"
         },
-        "pyparsing": {
-            "hashes": [
-                "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb",
-                "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"
-            ],
-            "markers": "python_full_version >= '3.6.8'",
-            "version": "==3.0.9"
-        },
         "python-dateutil": {
             "hashes": [
                 "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
                 "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.8.2"
         },
         "python-gnupg": {
@@ -844,11 +828,11 @@
         },
         "redis": {
             "hashes": [
-                "sha256:30c07511627a4c5c4d970e060000772f323174f75e745a26938319817ead7a12",
-                "sha256:46652271dc7525cd5a9667e5b0ca983c848c75b2b8f7425403395bb8379dcf25"
+                "sha256:7b8c87d19c45d3f1271b124858d2a5c13160c4e74d4835e28273400fa34d5228",
+                "sha256:cae3ee5d1f57d8caf534cd8764edf3163c77e073bdd74b6f54a87ffafdc5e7d9"
             ],
             "index": "pypi",
-            "version": "==4.3.5"
+            "version": "==4.4.0"
         },
         "requests": {
             "hashes": [
@@ -894,7 +878,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "structlog": {
@@ -1060,38 +1044,29 @@
         },
         "black": {
             "hashes": [
-                "sha256:14ff67aec0a47c424bc99b71005202045dc09270da44a27848d534600ac64fc7",
-                "sha256:197df8509263b0b8614e1df1756b1dd41be6738eed2ba9e9769f3880c2b9d7b6",
-                "sha256:1e464456d24e23d11fced2bc8c47ef66d471f845c7b7a42f3bd77bf3d1789650",
-                "sha256:2039230db3c6c639bd84efe3292ec7b06e9214a2992cd9beb293d639c6402edb",
-                "sha256:21199526696b8f09c3997e2b4db8d0b108d801a348414264d2eb8eb2532e540d",
-                "sha256:2644b5d63633702bc2c5f3754b1b475378fbbfb481f62319388235d0cd104c2d",
-                "sha256:432247333090c8c5366e69627ccb363bc58514ae3e63f7fc75c54b1ea80fa7de",
-                "sha256:444ebfb4e441254e87bad00c661fe32df9969b2bf224373a448d8aca2132b395",
-                "sha256:5b9b29da4f564ba8787c119f37d174f2b69cdfdf9015b7d8c5c16121ddc054ae",
-                "sha256:5cc42ca67989e9c3cf859e84c2bf014f6633db63d1cbdf8fdb666dcd9e77e3fa",
-                "sha256:5d8f74030e67087b219b032aa33a919fae8806d49c867846bfacde57f43972ef",
-                "sha256:72ef3925f30e12a184889aac03d77d031056860ccae8a1e519f6cbb742736383",
-                "sha256:819dc789f4498ecc91438a7de64427c73b45035e2e3680c92e18795a839ebb66",
-                "sha256:915ace4ff03fdfff953962fa672d44be269deb2eaf88499a0f8805221bc68c87",
-                "sha256:9311e99228ae10023300ecac05be5a296f60d2fd10fff31cf5c1fa4ca4b1988d",
-                "sha256:974308c58d057a651d182208a484ce80a26dac0caef2895836a92dd6ebd725e0",
-                "sha256:b8b49776299fece66bffaafe357d929ca9451450f5466e997a7285ab0fe28e3b",
-                "sha256:c957b2b4ea88587b46cf49d1dc17681c1e672864fd7af32fc1e9664d572b3458",
-                "sha256:e41a86c6c650bcecc6633ee3180d80a025db041a8e2398dcc059b3afa8382cd4",
-                "sha256:f513588da599943e0cde4e32cc9879e825d58720d6557062d1098c5ad80080e1",
-                "sha256:fba8a281e570adafb79f7755ac8721b6cf1bbf691186a287e990c7929c7692ff"
+                "sha256:101c69b23df9b44247bd88e1d7e90154336ac4992502d4197bdac35dd7ee3320",
+                "sha256:159a46a4947f73387b4d83e87ea006dbb2337eab6c879620a3ba52699b1f4351",
+                "sha256:1f58cbe16dfe8c12b7434e50ff889fa479072096d79f0a7f25e4ab8e94cd8350",
+                "sha256:229351e5a18ca30f447bf724d007f890f97e13af070bb6ad4c0a441cd7596a2f",
+                "sha256:436cc9167dd28040ad90d3b404aec22cedf24a6e4d7de221bec2730ec0c97bcf",
+                "sha256:559c7a1ba9a006226f09e4916060982fd27334ae1998e7a38b3f33a37f7a2148",
+                "sha256:7412e75863aa5c5411886804678b7d083c7c28421210180d67dfd8cf1221e1f4",
+                "sha256:77d86c9f3db9b1bf6761244bc0b3572a546f5fe37917a044e02f3166d5aafa7d",
+                "sha256:82d9fe8fee3401e02e79767016b4907820a7dc28d70d137eb397b92ef3cc5bfc",
+                "sha256:9eedd20838bd5d75b80c9f5487dbcb06836a43833a37846cf1d8c1cc01cef59d",
+                "sha256:c116eed0efb9ff870ded8b62fe9f28dd61ef6e9ddd28d83d7d264a38417dcee2",
+                "sha256:d30b212bffeb1e252b31dd269dfae69dd17e06d92b87ad26e23890f3efea366f"
             ],
             "index": "pypi",
-            "version": "==22.10.0"
+            "version": "==22.12.0"
         },
         "certifi": {
             "hashes": [
-                "sha256:0d9c601124e5a6ba9712dbc60d9c53c21e34f5f641fe83002317394311bdce14",
-                "sha256:90c1a32f1d68f940488354e36370f6cca89f0f106db09518524c88d6ed83f382"
+                "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3",
+                "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2022.9.24"
+            "version": "==2022.12.7"
         },
         "charset-normalizer": {
             "hashes": [
@@ -1243,11 +1218,11 @@
         },
         "isort": {
             "hashes": [
-                "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7",
-                "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"
+                "sha256:7c5bd998504826b6f1e6f2f98b533976b066baba29b8bae83fdeefd0b89c6b70",
+                "sha256:bf02c95f1fe615ebbe13a619cfed1619ddfe8941274c9e3de3143adca406cb02"
             ],
             "index": "pypi",
-            "version": "==5.10.1"
+            "version": "==5.11.1"
         },
         "jsbeautifier": {
             "hashes": [
@@ -1272,27 +1247,27 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
-                "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
+                "sha256:2198ec20bd4c017b8f9717e00f0c8714076fc2fd93816750ab48e2c41de2cfd3",
+                "sha256:957e2148ba0e1a3b282772e791ef1d8083648bc131c8ab0c1feba110ce1146c3"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==21.3"
+            "markers": "python_version >= '3.7'",
+            "version": "==22.0"
         },
         "pathspec": {
             "hashes": [
-                "sha256:88c2606f2c1e818b978540f73ecc908e13999c6c3a383daf3705652ae79807a5",
-                "sha256:8f6bf73e5758fd365ef5d58ce09ac7c27d2833a8d7da51712eac6e27e35141b0"
+                "sha256:3c95343af8b756205e2aba76e843ba9520a24dd84f68c22b9f93251507509dd6",
+                "sha256:56200de4077d9d0791465aa9095a01d421861e405b5096955051deefd697d6f6"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==0.10.2"
+            "version": "==0.10.3"
         },
         "platformdirs": {
             "hashes": [
-                "sha256:1006647646d80f16130f052404c6b901e80ee4ed6bef6792e1f238a8969106f7",
-                "sha256:af0276409f9a02373d540bf8480021a048711d572745aef4b7842dad245eba10"
+                "sha256:1a89a12377800c81983db6be069ec068eee989748799b946cce2a6e80dcc54ca",
+                "sha256:b46ffafa316e6b83b47489d240ce17173f123a9b9c83282141c3daf26ad9ac2e"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.5.4"
+            "version": "==2.6.0"
         },
         "pluggy": {
             "hashes": [
@@ -1317,14 +1292,6 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==3.0.1"
-        },
-        "pyparsing": {
-            "hashes": [
-                "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb",
-                "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"
-            ],
-            "markers": "python_full_version >= '3.6.8'",
-            "version": "==3.0.9"
         },
         "pytest": {
             "hashes": [
@@ -1511,7 +1478,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "toml": {
@@ -1519,7 +1486,7 @@
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.10.2"
         },
         "tqdm": {

--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 2.4.52
+version: 2.4.53
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.4.52
+appVersion: 2.4.53

--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 2.4.51
+version: 2.4.52
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.4.51
+appVersion: 2.4.52

--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 2.4.54
+version: 2.4.55
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.4.54
+appVersion: 2.4.55

--- a/frontstage/common/eq_payload.py
+++ b/frontstage/common/eq_payload.py
@@ -17,9 +17,7 @@ logger = wrap_logger(logging.getLogger(__name__))
 
 
 class EqPayload(object):
-    def create_payload(
-        self, case, collection_exercise, party_id: str, business_party_id: str, survey, version: str
-    ) -> dict:
+    def create_payload(self, case, collection_exercise, party_id: str, business_party_id: str, survey) -> dict:
         """
         Creates the payload needed to communicate with EQ, built from the Case, Collection Exercise, Party,
         Survey and Collection Instrument services
@@ -28,7 +26,6 @@ class EqPayload(object):
         :param party_id: The uuid of the respondent
         :param business_party_id: The uuid of the reporting unit
         :param survey: A dict containing information about the survey
-        :param version: EQ version
         :returns: Payload for EQ
         """
 
@@ -66,6 +63,7 @@ class EqPayload(object):
         account_service_log_out_url = current_app.config["ACCOUNT_SERVICE_LOG_OUT_URL"]
         iat = time.time()
         exp = time.time() + (5 * 60)
+        response_id = f"{party['sampleUnitRef'] + party['checkletter']}{collection_exercise['id']}{eq_id}{form_type}"
 
         payload = {
             "jti": str(uuid.uuid4()),
@@ -86,19 +84,11 @@ class EqPayload(object):
             "account_service_url": account_service_url,
             "account_service_log_out_url": account_service_log_out_url,
             "trad_as": f"{party['tradstyle1']} {party['tradstyle2']} {party['tradstyle3']}",
+            "response_id": response_id,
         }
 
         # Add any non null event dates that exist for this collection exercise
         payload.update([(key, value) for key, value in collex_event_dates.items() if value is not None])
-
-        # Add response_id for v3
-        if version == "v3":
-            payload.update(
-                {
-                    "response_id": f"{party['sampleUnitRef'] + party['checkletter']}"
-                    f"{collection_exercise['id']}{eq_id}{form_type}"
-                }
-            )
 
         logger.debug(payload)
 

--- a/frontstage/controllers/case_controller.py
+++ b/frontstage/controllers/case_controller.py
@@ -143,18 +143,9 @@ def get_cases_by_party_id(party_id, case_url, case_auth, case_events=False, iac=
     return response.json()
 
 
-def get_eq_url(version, case, collection_exercise, party_id, business_party_id, survey_short_name):
+def get_eq_url(case, collection_exercise, party_id, business_party_id, survey_short_name):
     case_id = case["id"]
-    logger.info("Attempting to generate EQ URL", case_id=case_id, party_id=party_id, version=version)
-
-    if version not in ["v2", "v3"]:
-        # EQ collection exercises created before the concept of versions might have a null value for the version.
-        # If this is the case, we can safely assume it's v2 as that was the only one availible at the time.
-        if version is None:
-            logger.info("EQ version not set, assuming v2", case_id=case_id, party_id=party_id, version=version)
-            version = "v2"
-        else:
-            raise ValueError(f"The eq version [{version}] is not supported")
+    logger.info("Attempting to generate EQ URL", case_id=case_id, party_id=party_id)
 
     if case["caseGroup"]["caseGroupStatus"] in ("COMPLETE", "COMPLETEDBYPHONE", "NOLONGERREQUIRED"):
         logger.info("The case group status is complete, opening an EQ is forbidden", case_id=case_id, party_id=party_id)
@@ -164,17 +155,13 @@ def get_eq_url(version, case, collection_exercise, party_id, business_party_id, 
     if not party_controller.is_respondent_enrolled(party_id, business_party_id, survey):
         raise NoSurveyPermission(party_id, case_id)
 
-    payload = EqPayload().create_payload(case, collection_exercise, party_id, business_party_id, survey, version)
+    payload = EqPayload().create_payload(case, collection_exercise, party_id, business_party_id, survey)
 
     json_secret_keys = app.config["JSON_SECRET_KEYS"]
     encrypter = Encrypter(json_secret_keys)
 
-    if version == "v2":
-        token = encrypter.encrypt(payload, "eq")
-        eq_url = app.config["EQ_URL"] + token
-    elif version == "v3":
-        token = encrypter.encrypt(payload, "eq_v3")
-        eq_url = app.config["EQ_V3_URL"] + token
+    token = encrypter.encrypt(payload, "eq_v3")
+    eq_url = app.config["EQ_V3_URL"] + token
 
     category = "EQ_LAUNCH"
     ci_id = case["collectionInstrumentId"]
@@ -193,7 +180,6 @@ def get_eq_url(version, case, collection_exercise, party_id, business_party_id, 
         business_party_id=business_party_id,
         survey_short_name=survey_short_name,
         tx_id=payload["tx_id"],
-        version=version,
     )
     return eq_url
 

--- a/frontstage/views/surveys/access_survey.py
+++ b/frontstage/views/surveys/access_survey.py
@@ -29,11 +29,8 @@ def access_survey(session):
         collection_exercise = collection_exercise_controller.get_collection_exercise(
             case["caseGroup"]["collectionExerciseId"]
         )
-        eq_version = collection_exercise["eqVersion"]
         return redirect(
-            case_controller.get_eq_url(
-                eq_version, case, collection_exercise, party_id, business_party_id, survey_short_name
-            )
+            case_controller.get_eq_url(case, collection_exercise, party_id, business_party_id, survey_short_name)
         )
 
     logger.info("Retrieving case data", party_id=party_id, case_id=case_id)

--- a/tests/integration/test_generate_eq.py
+++ b/tests/integration/test_generate_eq.py
@@ -70,7 +70,6 @@ class TestGenerateEqURL(unittest.TestCase):
                     party_id=respondent_party["id"],
                     business_party_id=business_party["id"],
                     survey=survey_eq,
-                    version=None,
                 )
         self.assertEqual(
             e.exception.message, "Collection instrument 68ad4018-2ddd-4894-89e7-33f0135887a2 type is not EQ"
@@ -95,7 +94,6 @@ class TestGenerateEqURL(unittest.TestCase):
                     party_id=respondent_party["id"],
                     business_party_id=business_party["id"],
                     survey=survey_eq,
-                    version=None,
                 )
         self.assertEqual(
             e.exception.message,
@@ -103,7 +101,7 @@ class TestGenerateEqURL(unittest.TestCase):
         )
 
     @requests_mock.mock()
-    def test_generate_eq_url_contains_response_id_for_v3(self, mock_request):
+    def test_generate_eq_url_contains_response_id(self, mock_request):
         # Given all external services are mocked and we have an EQ collection instrument without an EQ ID
         mock_request.get(url_get_collection_exercise_events, json=collection_exercise_events)
         mock_request.get(url_get_business_party, json=business_party)
@@ -122,34 +120,9 @@ class TestGenerateEqURL(unittest.TestCase):
                 party_id=respondent_party["id"],
                 business_party_id=business_party["id"],
                 survey=survey_eq,
-                version="v3",
             )
         self.assertTrue("response_id" in payload)
         self.assertEqual("49900000001F8d990a74-5f07-4765-ac66-df7e1a96505b20001", payload["response_id"])
-
-    @requests_mock.mock()
-    def test_generate_eq_url_for_response_id_for_v2(self, mock_request):
-        # Given all external services are mocked and we have an EQ collection instrument without an EQ ID
-        mock_request.get(url_get_collection_exercise_events, json=collection_exercise_events)
-        mock_request.get(url_get_business_party, json=business_party)
-        with open("tests/test_data/collection_instrument/collection_instrument_eq.json") as json_data:
-            collection_instrument_eq = json.load(json_data)
-
-        mock_request.get(url_get_ci, json=collection_instrument_eq)
-        mock_request.get(url_banner_api, status_code=404)
-
-        # When create_payload is called
-        # Then an InvalidEqPayLoad is raised
-        with app.app_context():
-            payload = EqPayload().create_payload(
-                case,
-                collection_exercise,
-                party_id=respondent_party["id"],
-                business_party_id=business_party["id"],
-                survey=survey_eq,
-                version="v2",
-            )
-        self.assertFalse("response_id" in payload)
 
     @requests_mock.mock()
     def test_generate_eq_url_no_form_type(self, mock_request):
@@ -170,7 +143,6 @@ class TestGenerateEqURL(unittest.TestCase):
                     party_id=respondent_party["id"],
                     business_party_id=business_party["id"],
                     survey=survey_eq,
-                    version=None,
                 )
         self.assertEqual(
             e.exception.message,

--- a/tests/integration/test_passwords.py
+++ b/tests/integration/test_passwords.py
@@ -362,9 +362,9 @@ class TestPasswords(unittest.TestCase):
             response.data,
         )
 
-    # This takes 10 minutes locally
     @requests_mock.mock()
-    def test_reset_password_reset_counter(self, mock_request):
+    @patch("frontstage.controllers.notify_controller.NotifyGateway.request_to_notify")
+    def test_reset_password_reset_counter(self, mock_request, mock_notify):
         token = "InRlc3RAZW1haWwuY29tIg.YlARnw.8hj0e_lcI_Wq5y0iHYbvDxHnio0"
         mock_request.get(url_banner_api, status_code=404)
         mock_request.post(url_reset_password_request, status_code=200)
@@ -388,6 +388,7 @@ class TestPasswords(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("Check your email".encode(), response.data)
+        mock_notify.assert_called_once()
 
     @requests_mock.mock()
     def test_reset_password_reset_counter_party_fail(self, mock_request):

--- a/tests/integration/views/surveys/test_access_survey.py
+++ b/tests/integration/views/surveys/test_access_survey.py
@@ -193,31 +193,7 @@ class TestAccessSurvey(unittest.TestCase):
         self.assertTrue("An error has occurred".encode() in response.data)
 
     def test_generate_eq_url(self, mock_request):
-        # Given all external services are mocked and we have an EQ collection instrument
-        mock_request.get(url_get_case, json=case)
-        mock_request.get(url_get_collection_exercise, json=collection_exercise)
-        mock_request.get(url_get_collection_exercise_events, json=collection_exercise_events)
-        mock_request.get(url_get_business_party, json=business_party)
-        mock_request.get(url_get_survey_by_short_name_eq, json=survey_eq)
-        mock_request.get(url_get_ci, json=collection_instrument_eq)
-        mock_request.get(url_get_case_categories, json=categories)
-        mock_request.post(url_post_case_event_uuid, status_code=201)
-        mock_request.get(url_get_respondent_party, status_code=200, json=respondent_party)
-        mock_request.get(url_banner_api, status_code=404)
-
-        # When the generate-eq-url is called
-        response = self.app.get(
-            f"/surveys/access-survey?case_id={case['id']}&business_party_id={business_party['id']}"
-            f"&survey_short_name={survey_eq['shortName']}&ci_type=EQ",
-            headers=self.headers,
-        )
-
-        # An eq url is generated
-        self.assertEqual(response.status_code, 302)
-        self.assertIn("https://eq-test/session?token=", response.location)
-
-    def test_generate_eq_url_v3(self, mock_request):
-        # Given all external services are mocked and we have an EQ collection instrument
+        # Given all external services are mocked, and we have an EQ collection instrument
         mock_request.get(url_get_case, json=case)
         mock_request.get(url_get_collection_exercise, json=collection_exercise_v3)
         mock_request.get(url_get_collection_exercise_events, json=collection_exercise_events)

--- a/tests/unit/controllers/test_case_controllers.py
+++ b/tests/unit/controllers/test_case_controllers.py
@@ -139,7 +139,6 @@ class TestCaseControllers(unittest.TestCase):
             rsps.add(rsps.GET, url_get_survey_by_short_name_eq, json=survey_eq, status=200)
             with app.app_context():
                 eq_url = case_controller.get_eq_url(
-                    "v2",
                     case,
                     collection_exercise,
                     respondent_party["id"],
@@ -160,7 +159,6 @@ class TestCaseControllers(unittest.TestCase):
             rsps.add(rsps.GET, url_get_survey_by_short_name_eq, json=survey_eq, status=200)
             with app.app_context():
                 eq_url = case_controller.get_eq_url(
-                    "v3",
                     case,
                     collection_exercise,
                     respondent_party["id"],
@@ -171,27 +169,6 @@ class TestCaseControllers(unittest.TestCase):
                 self.assertIn("https://eq-test/v3/session?token=", eq_url)
 
     @patch("frontstage.controllers.party_controller.is_respondent_enrolled")
-    @patch("frontstage.controllers.case_controller.post_case_event")
-    @patch("frontstage.common.eq_payload.EqPayload.create_payload")
-    @patch("frontstage.controllers.case_controller.get_case_by_case_id")
-    def test_get_eq_url_blank_eq_version_redirects_to_v2(self, get_case_by_id, create_eq_payload, *_):
-        get_case_by_id.return_value = case
-        create_eq_payload.return_value = eq_payload
-        with responses.RequestsMock() as rsps:
-            rsps.add(rsps.GET, url_get_survey_by_short_name_eq, json=survey_eq, status=200)
-            with app.app_context():
-                eq_url = case_controller.get_eq_url(
-                    None,
-                    case,
-                    collection_exercise,
-                    respondent_party["id"],
-                    business_party["id"],
-                    survey_eq["shortName"],
-                )
-
-                self.assertIn("https://eq-test/session?token=", eq_url)
-
-    @patch("frontstage.controllers.party_controller.is_respondent_enrolled")
     @patch("frontstage.controllers.case_controller.get_case_by_case_id")
     def test_get_eq_url_when_caseGroupStatus_is_complete(self, get_case_by_id, _):
         case_copy = deepcopy(case)
@@ -200,7 +177,6 @@ class TestCaseControllers(unittest.TestCase):
         with app.app_context():
             with self.assertRaises(Forbidden):
                 case_controller.get_eq_url(
-                    "v2",
                     case_copy,
                     collection_exercise,
                     respondent_party["id"],
@@ -217,7 +193,6 @@ class TestCaseControllers(unittest.TestCase):
         with app.app_context():
             with self.assertRaises(Forbidden):
                 case_controller.get_eq_url(
-                    "v2",
                     case_copy,
                     collection_exercise,
                     respondent_party["id"],
@@ -234,7 +209,6 @@ class TestCaseControllers(unittest.TestCase):
         with app.app_context():
             with self.assertRaises(Forbidden):
                 case_controller.get_eq_url(
-                    "v2",
                     case_copy,
                     collection_exercise,
                     respondent_party["id"],
@@ -253,27 +227,12 @@ class TestCaseControllers(unittest.TestCase):
             with app.app_context():
                 with self.assertRaises(NoSurveyPermission):
                     case_controller.get_eq_url(
-                        "v2",
                         case,
                         collection_exercise,
                         respondent_party["id"],
                         business_party["id"],
                         survey_eq["shortName"],
                     )
-
-    def test_get_eq_url_unsupported_version(self):
-        with app.app_context():
-            with self.assertRaises(ValueError) as e:
-                case_controller.get_eq_url(
-                    "v1234",
-                    case,
-                    collection_exercise,
-                    respondent_party["id"],
-                    business_party["id"],
-                    survey_eq["shortName"],
-                )
-
-            self.assertEqual(str(e.exception), "The eq version [v1234] is not supported")
 
     @patch("frontstage.controllers.case_controller.validate_case_category")
     def test_post_case_event_success(self, _):

--- a/tests/unit/controllers/test_case_controllers.py
+++ b/tests/unit/controllers/test_case_controllers.py
@@ -146,7 +146,7 @@ class TestCaseControllers(unittest.TestCase):
                     survey_eq["shortName"],
                 )
 
-                self.assertIn("https://eq-test/session?token=", eq_url)
+                self.assertIn("https://eq-test/v3/session?token=", eq_url)
 
     @patch("frontstage.controllers.party_controller.is_respondent_enrolled")
     @patch("frontstage.controllers.case_controller.post_case_event")

--- a/tests/unit/controllers/test_collection_exercise_controller.py
+++ b/tests/unit/controllers/test_collection_exercise_controller.py
@@ -50,6 +50,19 @@ class TestCollectionExerciseController(unittest.TestCase):
                         self.app_config["BASIC_AUTH"],
                     )
 
+    def test_get_collection_exercises_for_survey_no_exercises(self):
+        with responses.RequestsMock() as rsps:
+            rsps.add(rsps.GET, url_get_collection_exercises_by_survey, status=204)
+
+            with app.app_context():
+                collection_exercises = collection_exercise_controller.get_collection_exercises_for_survey(
+                    collection_exercise["surveyId"],
+                    self.app_config["COLLECTION_EXERCISE_URL"],
+                    self.app_config["BASIC_AUTH"],
+                )
+
+                self.assertListEqual(collection_exercises, [])
+
     def test_convert_events_to_new_format_successful(self):
         formatted_events = collection_exercise_controller.convert_events_to_new_format(collection_exercise["events"])
 


### PR DESCRIPTION
# What and why?

Now that no exercises are using EQ v2 anymore, we can start removing all mentions of the old platform.  This PR ignores the version of EQ that the collection exercise states (which should be v3 anyway, but it's in theory still possible for v2 ones to be made) and just creates a v3 payload and goes to v3 regardless.

# How to test?

- Create exercise (manually or via acceptance tests)
- Set exercise to v2 (via UI or database)
- Have it go live and enrol for it
- Launch it, it should take you to the v3 endpoint in mock-eq.  You can also double check here that the eqVersion for the exercise is v2 to make sure.

# Trello
