### PR TITLE
Update HPA to v2

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 2.4.58
+version: 2.4.59
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.4.58
+appVersion: 2.4.59

--- a/_infra/helm/frontstage/templates/hpa.yaml
+++ b/_infra/helm/frontstage/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ .Chart.Name }}


### PR DESCRIPTION
# What and why?
Update autoscaling from v2beta2 to v2
# How to test?
The HPA change has already been proven here https://github.com/ONSdigital/ras-party/pull/389, but can be done again if required, just deploy via helm
# Trello
