### PR TITLE
RAS-739: Add modal to base template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,4 +2,4 @@
 
 # How to test?
 
-# Trello
+# Jira

--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 2.4.59
+version: 2.4.60
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.4.59
+appVersion: 2.4.60

--- a/frontstage/common/session.py
+++ b/frontstage/common/session.py
@@ -80,8 +80,10 @@ class Session(object):
         redis.setex(self.session_key, 3600, self.encoded_jwt_token)
         self.persisted = True
 
-    def get_formatted_expires_in(self):
-        return datetime.fromtimestamp(self.get_expires_in(), tz=timezone.utc).isoformat()
+    def get_formatted_expires_in(self, refresh=None):
+        if refresh:
+            self.refresh_session()
+        return datetime.fromtimestamp((self.get_expires_in() - 3400), tz=timezone.utc).isoformat()
 
 
 def _get_new_timestamp(ttl=3600):

--- a/frontstage/common/session.py
+++ b/frontstage/common/session.py
@@ -81,7 +81,7 @@ class Session(object):
         self.persisted = True
 
     def get_formatted_expires_in(self):
-        return datetime.fromtimestamp((self.get_expires_in() - 3500), tz=timezone.utc).isoformat()
+        return datetime.fromtimestamp(self.get_expires_in(), tz=timezone.utc).isoformat()
 
 
 def _get_new_timestamp(ttl=3600):

--- a/frontstage/common/session.py
+++ b/frontstage/common/session.py
@@ -80,9 +80,7 @@ class Session(object):
         redis.setex(self.session_key, 3600, self.encoded_jwt_token)
         self.persisted = True
 
-    def get_formatted_expires_in(self, refresh=None):
-        if refresh:
-            self.refresh_session()
+    def get_formatted_expires_in(self):
         return datetime.fromtimestamp(self.get_expires_in(), tz=timezone.utc).isoformat()
 
 

--- a/frontstage/common/session.py
+++ b/frontstage/common/session.py
@@ -83,7 +83,7 @@ class Session(object):
     def get_formatted_expires_in(self, refresh=None):
         if refresh:
             self.refresh_session()
-        return datetime.fromtimestamp((self.get_expires_in() - 3400), tz=timezone.utc).isoformat()
+        return datetime.fromtimestamp(self.get_expires_in(), tz=timezone.utc).isoformat()
 
 
 def _get_new_timestamp(ttl=3600):

--- a/frontstage/common/session.py
+++ b/frontstage/common/session.py
@@ -81,7 +81,7 @@ class Session(object):
         self.persisted = True
 
     def get_formatted_expires_in(self):
-        return datetime.fromtimestamp(self.get_expires_in(), tz=timezone.utc).isoformat()
+        return datetime.fromtimestamp((self.get_expires_in() - 3500), tz=timezone.utc).isoformat()
 
 
 def _get_new_timestamp(ttl=3600):

--- a/frontstage/common/session.py
+++ b/frontstage/common/session.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
 from frontstage import jwt, redis
@@ -79,6 +79,9 @@ class Session(object):
     def save(self):
         redis.setex(self.session_key, 3600, self.encoded_jwt_token)
         self.persisted = True
+
+    def get_formatted_expires_in(self):
+        return datetime.fromtimestamp(self.get_expires_in(), tz=timezone.utc).isoformat()
 
 
 def _get_new_timestamp(ttl=3600):

--- a/frontstage/templates/layouts/_base.html
+++ b/frontstage/templates/layouts/_base.html
@@ -76,7 +76,6 @@
 
 {% block preFooter %}
     {% if expires_at %}
-        <p>Test if true</p>
         {{
             onsTimeoutModal ({
                     "showModalTimeInSeconds": 55,

--- a/frontstage/templates/layouts/_base.html
+++ b/frontstage/templates/layouts/_base.html
@@ -1,5 +1,6 @@
 {% extends "layout/_template.njk" %}
 {% from "components/cookies-banner/_macro.njk" import onsCookiesBanner %}
+{% from "components/timeout-modal/_macro.njk" import onsTimeoutModal %}
 
 {% block head %}
     {% set css_theme = "css"~_theme~"/theme.css" %}
@@ -71,4 +72,28 @@
 {% endblock pageContent -%}
 
 {% block bodyEnd %}
+{% endblock %}
+
+{% block preFooter %}
+    {% if expires_at %}
+        <p>Test if true</p>
+        {{
+            onsTimeoutModal ({
+                    "showModalTimeInSeconds": 55,
+                    "redirectUrl": url_for("sign_in_bp.login"),
+                    "sessionExpiresAt": expires_at,
+                    "serverSessionExpiryEndpoint": url_for("session.session_expires_at"),
+                    "title": "You will be signed out soon",
+                    "textFirstLine": "It appears you have been inactive for a while.",
+                    "countdownText": "To protect your information, your progress will be saved and you will be signed out in",
+                    "countdownExpiredText": "You are being signed out.",
+                    "btnText": "Continue survey",
+                    "minutesTextSingular": "minute",
+                    "minutesTextPlural": "minutes",
+                    "secondsTextSingular": "second",
+                    "secondsTextPlural": "seconds",
+                    "endWithFullStop": true
+            })
+        }}
+    {% endif %}
 {% endblock %}

--- a/frontstage/templates/layouts/_base.html
+++ b/frontstage/templates/layouts/_base.html
@@ -78,7 +78,7 @@
     {% if expires_at %}
         {{
             onsTimeoutModal ({
-                    "showModalTimeInSeconds": 55,
+                    "showModalTimeInSeconds": 60,
                     "redirectUrl": url_for("sign_in_bp.login"),
                     "sessionExpiresAt": expires_at,
                     "serverSessionExpiryEndpoint": url_for("session.session_expires_at"),

--- a/frontstage/templates/layouts/_base.html
+++ b/frontstage/templates/layouts/_base.html
@@ -79,7 +79,7 @@
         {{
             onsTimeoutModal ({
                     "showModalTimeInSeconds": 60,
-                    "redirectUrl": url_for("sign_in_bp.login"),
+                    "redirectUrl": url_for("session.session_expired"),
                     "sessionExpiresAt": expires_at,
                     "serverSessionExpiryEndpoint": url_for("session.session_expires_at"),
                     "title": "You will be signed out soon",

--- a/frontstage/templates/layouts/_base.html
+++ b/frontstage/templates/layouts/_base.html
@@ -79,7 +79,7 @@
         {{
             onsTimeoutModal ({
                     "showModalTimeInSeconds": 60,
-                    "redirectUrl": url_for("session.session_expired"),
+                    "redirectUrl": url_for("sign_in_bp.logout"),
                     "sessionExpiresAt": expires_at,
                     "serverSessionExpiryEndpoint": url_for("session.session_expires_at"),
                     "title": "You will be signed out soon",

--- a/frontstage/views/account/account.py
+++ b/frontstage/views/account/account.py
@@ -1,6 +1,5 @@
 import json
 import logging
-from datetime import datetime, timezone
 
 from flask import flash, render_template, request, url_for
 from markupsafe import Markup
@@ -54,8 +53,13 @@ def account(session):
     else:
         form = OptionsForm()
 
-    return render_template("account/account.html", form=form, respondent=respondent_details, page_title=page_title,
-                           expires_at=session.get_formatted_expires_in())
+    return render_template(
+        "account/account.html",
+        form=form,
+        respondent=respondent_details,
+        page_title=page_title,
+        expires_at=session.get_formatted_expires_in(),
+    )
 
 
 @account_bp.route("/change-password", methods=["GET", "POST"])
@@ -163,8 +167,11 @@ def change_account_details(session):
         return redirect(url_for("surveys_bp.get_survey_list", tag="todo"))
     else:
         return render_template(
-            "account/account-contact-detail-change.html", form=form, errors=form.errors, respondent=respondent_details,
-            expires_at=expires_at
+            "account/account-contact-detail-change.html",
+            form=form,
+            errors=form.errors,
+            respondent=respondent_details,
+            expires_at=expires_at,
         )
 
 
@@ -172,8 +179,11 @@ def change_account_details(session):
 @jwt_authorization(request)
 def something_else(session):
     """Gets the something else once the option is selected"""
-    return render_template("account/account-something-else.html", form=SecureMessagingForm(),
-                           expires_at=session.get_formatted_expires_in(),)
+    return render_template(
+        "account/account-something-else.html",
+        form=SecureMessagingForm(),
+        expires_at=session.get_formatted_expires_in(),
+    )
 
 
 @account_bp.route("/something-else", methods=["POST"])

--- a/frontstage/views/account/account.py
+++ b/frontstage/views/account/account.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from datetime import datetime, timezone
 
 from flask import flash, render_template, request, url_for
 from markupsafe import Markup
@@ -53,7 +54,8 @@ def account(session):
     else:
         form = OptionsForm()
 
-    return render_template("account/account.html", form=form, respondent=respondent_details, page_title=page_title)
+    return render_template("account/account.html", form=form, respondent=respondent_details, page_title=page_title,
+                           expires_at=session.get_formatted_expires_in())
 
 
 @account_bp.route("/change-password", methods=["GET", "POST"])
@@ -62,6 +64,7 @@ def change_password(session):
     form = ChangePasswordFrom(request.values)
     party_id = session.get_party_id()
     respondent_details = party_controller.get_respondent_party_by_id(party_id)
+    expires_at = session.get_formatted_expires_in()
     if request.method == "POST" and form.validate():
         username = respondent_details["emailAddress"]
         password = request.form.get("password")
@@ -71,6 +74,7 @@ def change_password(session):
                 "account/account-change-password.html",
                 form=form,
                 errors={"new_password": ["Your new password is the same as your old password"]},
+                expires_at=expires_at,
             )
         bound_logger = logger.bind(email=obfuscate_email(username))
         bound_logger.info("Attempting to find user in auth service")
@@ -90,11 +94,12 @@ def change_password(session):
                     "account/account-change-password.html",
                     form=form,
                     errors={"password": ["Incorrect current password"]},
+                    expires_at=expires_at,
                 )
     else:
         errors = form.errors
 
-    return render_template("account/account-change-password.html", form=form, errors=errors)
+    return render_template("account/account-change-password.html", form=form, errors=errors, expires_at=expires_at)
 
 
 @account_bp.route("/change-account-email-address", methods=["POST"])
@@ -107,6 +112,7 @@ def change_email_address(session):
     respondent_details["new_email_address"] = form["email_address"].data
     respondent_details["change_requested_by_respondent"] = True
     logger.info("Attempting to update email address changes on the account", party_id=party_id)
+    expires_at = session.get_formatted_expires_in()
     try:
         party_controller.update_account(respondent_details)
 
@@ -114,11 +120,11 @@ def change_email_address(session):
         logger.error("Failed to updated email on account", status=exc.status_code, party_id=party_id)
         if exc.status_code == 409:
             logger.info("The email requested already registered in our system. Request denied", party_id=party_id)
-            return render_template("account/account-change-email-address-conflict.html")
+            return render_template("account/account-change-email-address-conflict.html", expires_at=expires_at)
         else:
             raise exc
     logger.info("Successfully updated email on account", party_id=party_id)
-    return render_template("account/account-change-email-address-almost-done.html")
+    return render_template("account/account-change-email-address-almost-done.html", expires_at=expires_at)
 
 
 @account_bp.route("/change-account-details", methods=["GET", "POST"])
@@ -129,6 +135,7 @@ def change_account_details(session):
     respondent_details = party_controller.get_respondent_party_by_id(party_id)
     is_contact_details_update_required = False
     attributes_changed = []
+    expires_at = session.get_formatted_expires_in()
     if request.method == "POST" and form.validate():
         logger.info("Attempting to update contact details changes on the account", party_id=party_id)
         # check_attribute changes also magically updates the respondent_details as a side effect of running this
@@ -151,11 +158,13 @@ def change_account_details(session):
                 "account/account-change-email-address.html",
                 new_email=form["email_address"].data,
                 form=ConfirmEmailChangeForm(),
+                expires_at=expires_at,
             )
         return redirect(url_for("surveys_bp.get_survey_list", tag="todo"))
     else:
         return render_template(
-            "account/account-contact-detail-change.html", form=form, errors=form.errors, respondent=respondent_details
+            "account/account-contact-detail-change.html", form=form, errors=form.errors, respondent=respondent_details,
+            expires_at=expires_at
         )
 
 
@@ -163,7 +172,8 @@ def change_account_details(session):
 @jwt_authorization(request)
 def something_else(session):
     """Gets the something else once the option is selected"""
-    return render_template("account/account-something-else.html", form=SecureMessagingForm())
+    return render_template("account/account-something-else.html", form=SecureMessagingForm(),
+                           expires_at=session.get_formatted_expires_in(),)
 
 
 @account_bp.route("/something-else", methods=["POST"])

--- a/frontstage/views/account/account_survey_share.py
+++ b/frontstage/views/account/account_survey_share.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from datetime import datetime, timezone
 
 from flask import flash, render_template, request
 from flask import session as flask_session
@@ -40,7 +41,7 @@ def share_survey_overview(session):
     flask_session.pop("validation_failure_share_surveys_list", None)
     # 'share_surveys_selected_list' holds list of surveys selected by user so that its checked in case of any error
     flask_session.pop("share_surveys_selected_list", None)
-    return render_template("surveys/surveys-share/overview.html")
+    return render_template("surveys/surveys-share/overview.html", expires_at=session.get_formatted_expires_in())
 
 
 @account_bp.route("/share-surveys/business-selection", methods=["GET"])
@@ -52,7 +53,8 @@ def share_survey_business_select(session):
     form = AccountSurveySelectBusinessForm(request.values)
     party_id = session.get_party_id()
     businesses = get_list_of_business_for_party(party_id)
-    return render_template("surveys/surveys-share/business-select.html", businesses=businesses, form=form)
+    return render_template("surveys/surveys-share/business-select.html", businesses=businesses, form=form,
+                           expires_at=session.get_formatted_expires_in(),)
 
 
 @account_bp.route("/share-surveys/business-selection", methods=["POST"])
@@ -88,6 +90,7 @@ def share_survey_survey_select(session):
         error=error,
         failed_surveys_list=failed_surveys_list if failed_surveys_list is not None else [],
         selected_survey_list=selected_survey_list if selected_survey_list is not None else [],
+        expires_at=session.get_formatted_expires_in(),
     )
 
 
@@ -207,7 +210,8 @@ def share_survey_post_survey_select(session):
 def share_survey_email_entry(session):
     form = AccountSurveyShareRecipientEmailForm(request.values)
     flask_session["share_survey_recipient_email_address"] = None
-    return render_template("surveys/surveys-share/recipient-email-address.html", form=form, errors=form.errors)
+    return render_template("surveys/surveys-share/recipient-email-address.html", form=form, errors=form.errors,
+                           expires_at=session.get_formatted_expires_in())
 
 
 @account_bp.route("/share-surveys/recipient-email-address", methods=["POST"])
@@ -216,14 +220,17 @@ def share_survey_post_email_entry(session):
     form = AccountSurveyShareRecipientEmailForm(request.values)
     party_id = session.get_party_id()
     respondent_details = party_controller.get_respondent_party_by_id(party_id)
+    expires_at = session.get_formatted_expires_in()
     if not form.validate():
         errors = form.errors
-        return render_template("surveys/surveys-share/recipient-email-address.html", form=form, errors=errors)
+        return render_template("surveys/surveys-share/recipient-email-address.html", form=form, errors=errors,
+                               expires_at=expires_at)
 
     if "emailAddress" in respondent_details:
         if respondent_details["emailAddress"].lower() == form.data["email_address"].lower():
             errors = {"email_address": ["You can not share surveys with yourself."]}
-            return render_template("surveys/surveys-share/recipient-email-address.html", form=form, errors=errors)
+            return render_template("surveys/surveys-share/recipient-email-address.html", form=form, errors=errors,
+                                   expires_at=expires_at)
     flask_session["share_survey_recipient_email_address"] = form.data["email_address"]
     return redirect(url_for("account_bp.send_instruction_get"))
 
@@ -247,6 +254,7 @@ def send_instruction_get(session):
         email=email,
         share_dict=share_dict,
         form=ConfirmEmailChangeForm(),
+        expires_at=session.get_formatted_expires_in(),
     )
 
 
@@ -304,7 +312,7 @@ def send_instruction(session):
             "contact us.",
         )
         return redirect(url_for("account_bp.send_instruction_get"))
-    return render_template("surveys/surveys-share/almost-done.html")
+    return render_template("surveys/surveys-share/almost-done.html", expires_at=session.get_formatted_expires_in(),)
 
 
 @account_bp.route("/share-surveys/done", methods=["GET"])

--- a/frontstage/views/account/account_survey_share.py
+++ b/frontstage/views/account/account_survey_share.py
@@ -1,6 +1,5 @@
 import json
 import logging
-from datetime import datetime, timezone
 
 from flask import flash, render_template, request
 from flask import session as flask_session
@@ -53,8 +52,12 @@ def share_survey_business_select(session):
     form = AccountSurveySelectBusinessForm(request.values)
     party_id = session.get_party_id()
     businesses = get_list_of_business_for_party(party_id)
-    return render_template("surveys/surveys-share/business-select.html", businesses=businesses, form=form,
-                           expires_at=session.get_formatted_expires_in(),)
+    return render_template(
+        "surveys/surveys-share/business-select.html",
+        businesses=businesses,
+        form=form,
+        expires_at=session.get_formatted_expires_in(),
+    )
 
 
 @account_bp.route("/share-surveys/business-selection", methods=["POST"])
@@ -210,8 +213,12 @@ def share_survey_post_survey_select(session):
 def share_survey_email_entry(session):
     form = AccountSurveyShareRecipientEmailForm(request.values)
     flask_session["share_survey_recipient_email_address"] = None
-    return render_template("surveys/surveys-share/recipient-email-address.html", form=form, errors=form.errors,
-                           expires_at=session.get_formatted_expires_in())
+    return render_template(
+        "surveys/surveys-share/recipient-email-address.html",
+        form=form,
+        errors=form.errors,
+        expires_at=session.get_formatted_expires_in(),
+    )
 
 
 @account_bp.route("/share-surveys/recipient-email-address", methods=["POST"])
@@ -223,14 +230,16 @@ def share_survey_post_email_entry(session):
     expires_at = session.get_formatted_expires_in()
     if not form.validate():
         errors = form.errors
-        return render_template("surveys/surveys-share/recipient-email-address.html", form=form, errors=errors,
-                               expires_at=expires_at)
+        return render_template(
+            "surveys/surveys-share/recipient-email-address.html", form=form, errors=errors, expires_at=expires_at
+        )
 
     if "emailAddress" in respondent_details:
         if respondent_details["emailAddress"].lower() == form.data["email_address"].lower():
             errors = {"email_address": ["You can not share surveys with yourself."]}
-            return render_template("surveys/surveys-share/recipient-email-address.html", form=form, errors=errors,
-                                   expires_at=expires_at)
+            return render_template(
+                "surveys/surveys-share/recipient-email-address.html", form=form, errors=errors, expires_at=expires_at
+            )
     flask_session["share_survey_recipient_email_address"] = form.data["email_address"]
     return redirect(url_for("account_bp.send_instruction_get"))
 
@@ -312,7 +321,10 @@ def send_instruction(session):
             "contact us.",
         )
         return redirect(url_for("account_bp.send_instruction_get"))
-    return render_template("surveys/surveys-share/almost-done.html", expires_at=session.get_formatted_expires_in(),)
+    return render_template(
+        "surveys/surveys-share/almost-done.html",
+        expires_at=session.get_formatted_expires_in(),
+    )
 
 
 @account_bp.route("/share-surveys/done", methods=["GET"])

--- a/frontstage/views/account/account_transfer_survey.py
+++ b/frontstage/views/account/account_transfer_survey.py
@@ -1,6 +1,5 @@
 import json
 import logging
-from datetime import datetime, timezone
 
 from flask import flash, render_template, request
 from flask import session as flask_session
@@ -53,8 +52,12 @@ def transfer_survey_business_select(session):
     form = AccountSurveySelectBusinessForm(request.values)
     party_id = session.get_party_id()
     businesses = get_list_of_business_for_party(party_id)
-    return render_template("surveys/surveys-transfer/business-select.html", businesses=businesses, form=form,
-                           expires_at=session.get_formatted_expires_in())
+    return render_template(
+        "surveys/surveys-transfer/business-select.html",
+        businesses=businesses,
+        form=form,
+        expires_at=session.get_formatted_expires_in(),
+    )
 
 
 @account_bp.route("/transfer-surveys/business-selection", methods=["POST"])
@@ -212,8 +215,12 @@ def transfer_survey_post_survey_select(session):
 def transfer_survey_email_entry(session):
     form = AccountSurveyShareRecipientEmailForm(request.values)
     flask_session["transfer_survey_recipient_email_address"] = None
-    return render_template("surveys/surveys-transfer/recipient-email-address.html", form=form, errors=form.errors,
-                           expires_at=session.get_formatted_expires_in())
+    return render_template(
+        "surveys/surveys-transfer/recipient-email-address.html",
+        form=form,
+        errors=form.errors,
+        expires_at=session.get_formatted_expires_in(),
+    )
 
 
 @account_bp.route("/transfer-surveys/recipient-email-address", methods=["POST"])
@@ -225,14 +232,16 @@ def transfer_survey_post_email_entry(session):
     expires_at = session.get_formatted_expires_in()
     if not form.validate():
         errors = form.errors
-        return render_template("surveys/surveys-transfer/recipient-email-address.html", form=form, errors=errors,
-                               expires_at=expires_at)
+        return render_template(
+            "surveys/surveys-transfer/recipient-email-address.html", form=form, errors=errors, expires_at=expires_at
+        )
 
     if "emailAddress" in respondent_details:
         if respondent_details["emailAddress"].lower() == form.data["email_address"].lower():
             errors = {"email_address": ["You can not transfer surveys to yourself."]}
-            return render_template("surveys/surveys-transfer/recipient-email-address.html", form=form, errors=errors,
-                                   expires_at=expires_at)
+            return render_template(
+                "surveys/surveys-transfer/recipient-email-address.html", form=form, errors=errors, expires_at=expires_at
+            )
     flask_session["transfer_survey_recipient_email_address"] = form.data["email_address"]
     return redirect(url_for("account_bp.send_transfer_instruction_get"))
 
@@ -313,7 +322,10 @@ def send_transfer_instruction(session):
             "contact us.",
         )
         return redirect(url_for("account_bp.send_transfer_instruction_get"))
-    return render_template("surveys/surveys-transfer/almost-done.html", expires_at=session.get_formatted_expires_in(),)
+    return render_template(
+        "surveys/surveys-transfer/almost-done.html",
+        expires_at=session.get_formatted_expires_in(),
+    )
 
 
 @account_bp.route("/transfer-surveys/done", methods=["GET"])

--- a/frontstage/views/account/account_transfer_survey.py
+++ b/frontstage/views/account/account_transfer_survey.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from datetime import datetime, timezone
 
 from flask import flash, render_template, request
 from flask import session as flask_session
@@ -40,7 +41,7 @@ def transfer_survey_overview(session):
     flask_session.pop("validation_failure_transfer_surveys_list", None)
     # 'transfer_surveys_selected_list' holds list of surveys selected by user so that its checked in case of any error
     flask_session.pop("transfer_surveys_selected_list", None)
-    return render_template("surveys/surveys-transfer/overview.html")
+    return render_template("surveys/surveys-transfer/overview.html", expires_at=session.get_formatted_expires_in())
 
 
 @account_bp.route("/transfer-surveys/business-selection", methods=["GET"])
@@ -52,7 +53,8 @@ def transfer_survey_business_select(session):
     form = AccountSurveySelectBusinessForm(request.values)
     party_id = session.get_party_id()
     businesses = get_list_of_business_for_party(party_id)
-    return render_template("surveys/surveys-transfer/business-select.html", businesses=businesses, form=form)
+    return render_template("surveys/surveys-transfer/business-select.html", businesses=businesses, form=form,
+                           expires_at=session.get_formatted_expires_in())
 
 
 @account_bp.route("/transfer-surveys/business-selection", methods=["POST"])
@@ -88,6 +90,7 @@ def transfer_survey_survey_select(session):
         error=error,
         failed_surveys_list=failed_surveys_list if failed_surveys_list is not None else [],
         selected_survey_list=selected_survey_list if selected_survey_list is not None else [],
+        expires_at=session.get_formatted_expires_in(),
     )
 
 
@@ -209,7 +212,8 @@ def transfer_survey_post_survey_select(session):
 def transfer_survey_email_entry(session):
     form = AccountSurveyShareRecipientEmailForm(request.values)
     flask_session["transfer_survey_recipient_email_address"] = None
-    return render_template("surveys/surveys-transfer/recipient-email-address.html", form=form, errors=form.errors)
+    return render_template("surveys/surveys-transfer/recipient-email-address.html", form=form, errors=form.errors,
+                           expires_at=session.get_formatted_expires_in())
 
 
 @account_bp.route("/transfer-surveys/recipient-email-address", methods=["POST"])
@@ -218,14 +222,17 @@ def transfer_survey_post_email_entry(session):
     form = AccountSurveyShareRecipientEmailForm(request.values)
     party_id = session.get_party_id()
     respondent_details = party_controller.get_respondent_party_by_id(party_id)
+    expires_at = session.get_formatted_expires_in()
     if not form.validate():
         errors = form.errors
-        return render_template("surveys/surveys-transfer/recipient-email-address.html", form=form, errors=errors)
+        return render_template("surveys/surveys-transfer/recipient-email-address.html", form=form, errors=errors,
+                               expires_at=expires_at)
 
     if "emailAddress" in respondent_details:
         if respondent_details["emailAddress"].lower() == form.data["email_address"].lower():
             errors = {"email_address": ["You can not transfer surveys to yourself."]}
-            return render_template("surveys/surveys-transfer/recipient-email-address.html", form=form, errors=errors)
+            return render_template("surveys/surveys-transfer/recipient-email-address.html", form=form, errors=errors,
+                                   expires_at=expires_at)
     flask_session["transfer_survey_recipient_email_address"] = form.data["email_address"]
     return redirect(url_for("account_bp.send_transfer_instruction_get"))
 
@@ -249,6 +256,7 @@ def send_transfer_instruction_get(session):
         email=email,
         share_dict=share_dict,
         form=ConfirmEmailChangeForm(),
+        expires_at=session.get_formatted_expires_in(),
     )
 
 
@@ -305,7 +313,7 @@ def send_transfer_instruction(session):
             "contact us.",
         )
         return redirect(url_for("account_bp.send_transfer_instruction_get"))
-    return render_template("surveys/surveys-transfer/almost-done.html")
+    return render_template("surveys/surveys-transfer/almost-done.html", expires_at=session.get_formatted_expires_in(),)
 
 
 @account_bp.route("/transfer-surveys/done", methods=["GET"])

--- a/frontstage/views/secure_messaging/create_message.py
+++ b/frontstage/views/secure_messaging/create_message.py
@@ -1,6 +1,5 @@
 import json
 import logging
-from datetime import datetime, timezone
 
 from flask import Markup, flash, redirect, render_template, request, url_for
 from structlog import wrap_logger

--- a/frontstage/views/secure_messaging/create_message.py
+++ b/frontstage/views/secure_messaging/create_message.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from datetime import datetime, timezone
 
 from flask import Markup, flash, redirect, render_template, request, url_for
 from structlog import wrap_logger
@@ -39,6 +40,7 @@ def create_message(session):
             errors=form.errors,
             message={},
             unread_message_count=unread_message_count,
+            expires_at=session.get_formatted_expires_in(),
         )
 
 

--- a/frontstage/views/secure_messaging/message_get.py
+++ b/frontstage/views/secure_messaging/message_get.py
@@ -1,8 +1,6 @@
 import logging
 from distutils.util import strtobool
 
-from datetime import datetime, timezone
-
 from flask import Markup, flash, json, redirect, render_template, request, url_for
 from structlog import wrap_logger
 
@@ -113,7 +111,6 @@ def view_conversation_list(session):
         raise
     logger.info("Retrieving and refining conversation successful", party_id=party_id)
     unread_message_count = {"unread_message_count": try_message_count_from_session(session)}
-
 
     return render_template(
         "secure-messages/conversation-list.html",

--- a/frontstage/views/secure_messaging/message_get.py
+++ b/frontstage/views/secure_messaging/message_get.py
@@ -1,6 +1,8 @@
 import logging
 from distutils.util import strtobool
 
+from datetime import datetime, timezone
+
 from flask import Markup, flash, json, redirect, render_template, request, url_for
 from structlog import wrap_logger
 
@@ -90,6 +92,7 @@ def view_conversation(session, thread_id):
         survey_name=survey_name,
         business_name=business_name,
         category=category,
+        expires_at=session.get_formatted_expires_in(),
     )
 
 
@@ -110,11 +113,14 @@ def view_conversation_list(session):
         raise
     logger.info("Retrieving and refining conversation successful", party_id=party_id)
     unread_message_count = {"unread_message_count": try_message_count_from_session(session)}
+
+
     return render_template(
         "secure-messages/conversation-list.html",
         messages=refined_conversation,
         is_closed=strtobool(is_closed),
         unread_message_count=unread_message_count,
+        expires_at=session.get_formatted_expires_in(),
     )
 
 

--- a/frontstage/views/secure_messaging/message_get.py
+++ b/frontstage/views/secure_messaging/message_get.py
@@ -111,7 +111,6 @@ def view_conversation_list(session):
         raise
     logger.info("Retrieving and refining conversation successful", party_id=party_id)
     unread_message_count = {"unread_message_count": try_message_count_from_session(session)}
-
     return render_template(
         "secure-messages/conversation-list.html",
         messages=refined_conversation,

--- a/frontstage/views/session.py
+++ b/frontstage/views/session.py
@@ -1,7 +1,6 @@
-from flask import Blueprint, jsonify, make_response, redirect, request, session, url_for
+from flask import Blueprint, jsonify, request
 
 from frontstage.common.authorisation import jwt_authorization
-from frontstage.common.session import Session
 
 session_bp = Blueprint("session", __name__)
 

--- a/frontstage/views/session.py
+++ b/frontstage/views/session.py
@@ -1,13 +1,28 @@
-from datetime import datetime, timezone
-
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, jsonify, make_response, redirect, request, session, url_for
 
 from frontstage.common.authorisation import jwt_authorization
+from frontstage.common.session import Session
 
 session_bp = Blueprint("session", __name__)
 
 
 @session_bp.route("/expires-at", methods=["GET", "PATCH"])
 @jwt_authorization(request, refresh_session=False)
-def session_expires_at(session):
-    return jsonify(expires_at=datetime.fromtimestamp(session.get_expires_in(), tz=timezone.utc).isoformat())
+def session_expires_at(expiry_session):
+    return jsonify(expires_at=expiry_session.get_formatted_expires_in())
+
+
+@session_bp.route("/session-expired", methods=["GET"])
+def session_expired():
+    # Delete user session in redis
+    session_key = request.cookies.get("authorization")
+    current_session = Session.from_session_key(session_key)
+    current_session.delete_session()
+    # We need to remove the next value from the flask session otherwise, user is redirected to the expiry end point and
+    # Not the survey list page
+    if session.get("next"):
+        session.pop("next")
+    # Delete session cookie
+    response = make_response(redirect(url_for("sign_in_bp.login")))
+    response.delete_cookie("authorization")
+    return response

--- a/frontstage/views/session.py
+++ b/frontstage/views/session.py
@@ -1,4 +1,13 @@
-from flask import Blueprint, jsonify, make_response, redirect, request, session, url_for
+from flask import (
+    Blueprint,
+    Response,
+    jsonify,
+    make_response,
+    redirect,
+    request,
+    session,
+    url_for,
+)
 
 from frontstage.common.authorisation import jwt_authorization
 from frontstage.common.session import Session
@@ -8,8 +17,11 @@ session_bp = Blueprint("session", __name__)
 
 @session_bp.route("/expires-at", methods=["GET", "PATCH"])
 @jwt_authorization(request, refresh_session=False)
-def session_expires_at(expiry_session):
-    return jsonify(expires_at=expiry_session.get_formatted_expires_in())
+def session_expires_at(expires_at):
+    refresh = None
+    if request.method == "PATCH":
+        refresh = True
+    return jsonify(expires_at=expires_at.get_formatted_expires_in(refresh))
 
 
 @session_bp.route("/session-expired", methods=["GET"])

--- a/frontstage/views/session.py
+++ b/frontstage/views/session.py
@@ -16,19 +16,3 @@ def session_expires_at(expires_at):
 @jwt_authorization(request)
 def session_refresh_expires_at(expires_at):
     return jsonify(expires_at=expires_at.get_formatted_expires_in())
-
-
-@session_bp.route("/session-expired", methods=["GET"])
-def session_expired():
-    # Delete user session in redis
-    session_key = request.cookies.get("authorization")
-    current_session = Session.from_session_key(session_key)
-    current_session.delete_session()
-    # We need to remove the next value from the flask session otherwise, user is redirected to the expiry end point and
-    # Not the survey list page
-    if session.get("next"):
-        session.pop("next")
-    # Delete session cookie
-    response = make_response(redirect(url_for("sign_in_bp.login")))
-    response.delete_cookie("authorization")
-    return response

--- a/frontstage/views/session.py
+++ b/frontstage/views/session.py
@@ -6,13 +6,16 @@ from frontstage.common.session import Session
 session_bp = Blueprint("session", __name__)
 
 
-@session_bp.route("/expires-at", methods=["GET", "PATCH"])
+@session_bp.route("/expires-at", methods=["GET"])
 @jwt_authorization(request, refresh_session=False)
 def session_expires_at(expires_at):
-    refresh = None
-    if request.method == "PATCH":
-        refresh = True
-    return jsonify(expires_at=expires_at.get_formatted_expires_in(refresh))
+    return jsonify(expires_at=expires_at.get_formatted_expires_in())
+
+
+@session_bp.route("/expires-at", methods=["PATCH"])
+@jwt_authorization(request)
+def session_refresh_expires_at(expires_at):
+    return jsonify(expires_at=expires_at.get_formatted_expires_in())
 
 
 @session_bp.route("/session-expired", methods=["GET"])

--- a/frontstage/views/session.py
+++ b/frontstage/views/session.py
@@ -7,8 +7,7 @@ from frontstage.common.authorisation import jwt_authorization
 session_bp = Blueprint("session", __name__)
 
 
-@session_bp.route("/expires-at", methods=["GET"])
+@session_bp.route("/expires-at", methods=["GET", "PATCH"])
 @jwt_authorization(request, refresh_session=False)
 def session_expires_at(session):
-    expires_at = session.get_expires_in()
-    return jsonify(expires_at=datetime.fromtimestamp(expires_at, tz=timezone.utc).isoformat())
+    return jsonify(expires_at=datetime.fromtimestamp(session.get_expires_in(), tz=timezone.utc).isoformat())

--- a/frontstage/views/session.py
+++ b/frontstage/views/session.py
@@ -1,6 +1,5 @@
 from flask import (
     Blueprint,
-    Response,
     jsonify,
     make_response,
     redirect,

--- a/frontstage/views/session.py
+++ b/frontstage/views/session.py
@@ -1,12 +1,4 @@
-from flask import (
-    Blueprint,
-    jsonify,
-    make_response,
-    redirect,
-    request,
-    session,
-    url_for,
-)
+from flask import Blueprint, jsonify, make_response, redirect, request, session, url_for
 
 from frontstage.common.authorisation import jwt_authorization
 from frontstage.common.session import Session

--- a/frontstage/views/surveys/add_survey.py
+++ b/frontstage/views/surveys/add_survey.py
@@ -31,7 +31,6 @@ def add_survey(session):
                 logger.info(
                     "Enrolment code not found when attempting to add survey",
                     enrolment_code=enrolment_code,
-                    expires_at=expires_at,
                 )
                 template_data = {"error": {"type": "failed"}}
                 return (
@@ -42,7 +41,6 @@ def add_survey(session):
                 logger.info(
                     "Enrolment code not active when attempting to add survey",
                     enrolment_code=enrolment_code,
-                    expires_at=expires_at,
                 )
                 template_data = {"error": {"type": "failed"}}
                 return render_template(

--- a/frontstage/views/surveys/add_survey.py
+++ b/frontstage/views/surveys/add_survey.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import datetime, timezone
 from os import getenv
 
 from flask import redirect, render_template, request, url_for
@@ -29,17 +28,29 @@ def add_survey(session):
         try:
             iac = iac_controller.get_iac_from_enrolment(enrolment_code)
             if iac is None:
-                logger.info("Enrolment code not found when attempting to add survey", enrolment_code=enrolment_code,
-                            expires_at=expires_at)
+                logger.info(
+                    "Enrolment code not found when attempting to add survey",
+                    enrolment_code=enrolment_code,
+                    expires_at=expires_at,
+                )
                 template_data = {"error": {"type": "failed"}}
-                return render_template("surveys/surveys-add.html", form=form, data=template_data,
-                                       expires_at=expires_at), 200
+                return (
+                    render_template("surveys/surveys-add.html", form=form, data=template_data, expires_at=expires_at),
+                    200,
+                )
             if not iac["active"]:
-                logger.info("Enrolment code not active when attempting to add survey", enrolment_code=enrolment_code,
-                            expires_at=expires_at)
+                logger.info(
+                    "Enrolment code not active when attempting to add survey",
+                    enrolment_code=enrolment_code,
+                    expires_at=expires_at,
+                )
                 template_data = {"error": {"type": "failed"}}
-                return render_template("surveys/surveys-add.html", form=form, data=template_data,
-                                       expires_at=expires_at,)
+                return render_template(
+                    "surveys/surveys-add.html",
+                    form=form,
+                    data=template_data,
+                    expires_at=expires_at,
+                )
         except ApiError as exc:
             if exc.status_code == 400:
                 logger.info(
@@ -48,8 +59,12 @@ def add_survey(session):
                     enrolment_code=enrolment_code,
                 )
                 template_data = {"error": {"type": "failed"}}
-                return render_template("surveys/surveys-add.html", form=form, data=template_data,
-                                       expires_at=expires_at,)
+                return render_template(
+                    "surveys/surveys-add.html",
+                    form=form,
+                    data=template_data,
+                    expires_at=expires_at,
+                )
             else:
                 logger.error(
                     "Failed to submit enrolment code when attempting to add survey",
@@ -75,6 +90,16 @@ def add_survey(session):
     elif request.method == "POST" and not form.validate():
         logger.info("Invalid character length, must be 12 characters")
         template_data = {"error": {"type": "failed"}}
-        return render_template("surveys/surveys-add.html", form=form, data=template_data, expires_at=expires_at,)
+        return render_template(
+            "surveys/surveys-add.html",
+            form=form,
+            data=template_data,
+            expires_at=expires_at,
+        )
 
-    return render_template("surveys/surveys-add.html", form=form, data={"error": {}}, expires_at=expires_at,)
+    return render_template(
+        "surveys/surveys-add.html",
+        form=form,
+        data={"error": {}},
+        expires_at=expires_at,
+    )

--- a/frontstage/views/surveys/add_survey_confirm_organisation_survey.py
+++ b/frontstage/views/surveys/add_survey_confirm_organisation_survey.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import datetime, timezone
 
 from flask import current_app as app
 from flask import render_template, request
@@ -75,5 +74,8 @@ def survey_confirm_organisation(session):
         enrolment_code=enrolment_code,
     )
 
-    return render_template("surveys/surveys-confirm-organisation.html", context=business_context,
-                           expires_at=session.get_formatted_expires_in(),)
+    return render_template(
+        "surveys/surveys-confirm-organisation.html",
+        context=business_context,
+        expires_at=session.get_formatted_expires_in(),
+    )

--- a/frontstage/views/surveys/add_survey_confirm_organisation_survey.py
+++ b/frontstage/views/surveys/add_survey_confirm_organisation_survey.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime, timezone
 
 from flask import current_app as app
 from flask import render_template, request
@@ -21,7 +22,7 @@ logger = wrap_logger(logging.getLogger(__name__))
 
 @surveys_bp.route("/add-survey/confirm-organisation-survey", methods=["GET"])
 @jwt_authorization(request)
-def survey_confirm_organisation(_):
+def survey_confirm_organisation(session):
     # Get and decrypt enrolment code
     cryptographer = Cryptographer()
     encrypted_enrolment_code = request.args.get("encrypted_enrolment_code", None)
@@ -74,4 +75,5 @@ def survey_confirm_organisation(_):
         enrolment_code=enrolment_code,
     )
 
-    return render_template("surveys/surveys-confirm-organisation.html", context=business_context)
+    return render_template("surveys/surveys-confirm-organisation.html", context=business_context,
+                           expires_at=session.get_formatted_expires_in(),)

--- a/frontstage/views/surveys/add_survey_submit.py
+++ b/frontstage/views/surveys/add_survey_submit.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime, timezone
 
 from flask import abort
 from flask import current_app as app
@@ -86,6 +87,7 @@ def add_survey_submit(session):
         party_id=party_id,
         enrolment_code=enrolment_code,
     )
+
     return redirect(
         url_for(
             "surveys_bp.get_survey_list",
@@ -95,6 +97,7 @@ def add_survey_submit(session):
             survey_id=added_survey_id,
             tag="todo",
             already_enrolled=already_enrolled,
+            expires_at=session.get_formatted_expires_in(),
         )
     )
 

--- a/frontstage/views/surveys/add_survey_submit.py
+++ b/frontstage/views/surveys/add_survey_submit.py
@@ -86,7 +86,6 @@ def add_survey_submit(session):
         party_id=party_id,
         enrolment_code=enrolment_code,
     )
-
     return redirect(
         url_for(
             "surveys_bp.get_survey_list",

--- a/frontstage/views/surveys/add_survey_submit.py
+++ b/frontstage/views/surveys/add_survey_submit.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import datetime, timezone
 
 from flask import abort
 from flask import current_app as app

--- a/frontstage/views/surveys/help/surveys_help.py
+++ b/frontstage/views/surveys/help/surveys_help.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from datetime import datetime, timezone
 
 from flask import abort, flash, render_template, request
 from flask import session as flask_session
@@ -157,6 +158,7 @@ def help_page(session):
         survey_ref=survey_ref,
         ru_ref=ru_ref,
         page_title=page_title,
+        expires_at=session.get_formatted_expires_in(),
     )
 
 
@@ -212,6 +214,7 @@ def help_option_select(session, option: str):
     else:
         if template == "Invalid template":
             abort(404)
+
     return render_template(
         template,
         short_name=short_name,
@@ -222,6 +225,7 @@ def help_option_select(session, option: str):
         survey_ref=survey_ref,
         ru_ref=ru_ref,
         page_title=page_title,
+        expires_at=session.get_formatted_expires_in(),
     )
 
 
@@ -236,6 +240,7 @@ def get_help_option_sub_option_select(session, option, sub_option):
     if template == "Invalid template":
         abort(404)
     else:
+
         return render_template(
             template,
             short_name=short_name,
@@ -248,6 +253,7 @@ def get_help_option_sub_option_select(session, option, sub_option):
             ru_ref=ru_ref,
             is_survey_help_page=True,  # currently used by survey not listed.
             page_title=page_title,
+            expires_at=session.get_formatted_expires_in(),
         )
 
 
@@ -297,6 +303,7 @@ def send_help_message(session, option, sub_option):
         survey_ref=survey_ref,
         ru_ref=ru_ref,
         page_title=page_title,
+        expires_at=session.get_formatted_expires_in(),
     )
 
 

--- a/frontstage/views/surveys/help/surveys_help.py
+++ b/frontstage/views/surveys/help/surveys_help.py
@@ -1,6 +1,5 @@
 import json
 import logging
-from datetime import datetime, timezone
 
 from flask import abort, flash, render_template, request
 from flask import session as flask_session
@@ -240,7 +239,6 @@ def get_help_option_sub_option_select(session, option, sub_option):
     if template == "Invalid template":
         abort(404)
     else:
-
         return render_template(
             template,
             short_name=short_name,

--- a/frontstage/views/surveys/help/technical_help.py
+++ b/frontstage/views/surveys/help/technical_help.py
@@ -1,6 +1,5 @@
 import json
 import logging
-from datetime import datetime, timezone
 
 from flask import flash, render_template, request, url_for
 from markupsafe import Markup

--- a/frontstage/views/surveys/help/technical_help.py
+++ b/frontstage/views/surveys/help/technical_help.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from datetime import datetime, timezone
 
 from flask import flash, render_template, request, url_for
 from markupsafe import Markup
@@ -44,6 +45,7 @@ def get_send_help_technical_message_page(session):
         option=option,
         subject=subject,
         breadcrumbs=breadcrumbs,
+        expires_at=session.get_formatted_expires_in(),
     )
 
 

--- a/frontstage/views/surveys/surveys_list.py
+++ b/frontstage/views/surveys/surveys_list.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 
 from flask import make_response, render_template, request
 from flask import session as flask_session
@@ -52,6 +52,8 @@ def get_survey_list(session, tag):
         tag=tag,
     )
 
+    expires_at = session.get_formatted_expires_in()
+
     unread_message_count = {"unread_message_count": conversation_controller.try_message_count_from_session(session)}
     if tag == "todo":
         added_survey = True if business_id and survey_id and not already_enrolled else None
@@ -63,6 +65,7 @@ def get_survey_list(session, tag):
                 already_enrolled=already_enrolled,
                 unread_message_count=unread_message_count,
                 delete_option_allowed=delete_option_allowed,
+                expires_at=expires_at,
             )
         )
 
@@ -76,6 +79,7 @@ def get_survey_list(session, tag):
             sorted_surveys_list=sorted_survey_list,
             history=True,
             unread_message_count=unread_message_count,
+            expires_at=expires_at,
         )
 
 

--- a/frontstage/views/surveys/surveys_list.py
+++ b/frontstage/views/surveys/surveys_list.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timezone
+from datetime import datetime
 
 from flask import make_response, render_template, request
 from flask import session as flask_session

--- a/frontstage/views/surveys/upload_survey.py
+++ b/frontstage/views/surveys/upload_survey.py
@@ -26,6 +26,7 @@ def upload_survey(session):
     business_party_id = request.args["business_party_id"]
     survey_short_name = request.args["survey_short_name"]
     logger.info("Attempting to upload collection instrument", case_id=case_id, party_id=party_id)
+    expires_at = session.get_formatted_expires_in()
 
     if request.content_length > app.config["MAX_UPLOAD_LENGTH"]:
         return redirect(
@@ -36,6 +37,7 @@ def upload_survey(session):
                 business_party_id=business_party_id,
                 survey_short_name=survey_short_name,
                 error_info="size",
+                expires_at=expires_at,
             )
         )
 
@@ -82,6 +84,7 @@ def upload_survey(session):
                 business_party_id=business_party_id,
                 survey_short_name=survey_short_name,
                 error_info=error_type,
+                expires_at=expires_at,
             )
         )
 
@@ -91,6 +94,7 @@ def upload_survey(session):
         "surveys/surveys-upload-success.html",
         upload_filename=upload_file.filename,
         unread_message_count=unread_message_count,
+        expires_at=expires_at,
     )
 
 

--- a/frontstage/views/surveys/upload_survey_failed.py
+++ b/frontstage/views/surveys/upload_survey_failed.py
@@ -53,4 +53,5 @@ def upload_failed(session):
         error_info=error_info,
         case_id=case_id,
         unread_message_count=unread_message_count,
+        expires_at=session.get_formatted_expires_in(),
     )

--- a/tests/integration/views/test_session.py
+++ b/tests/integration/views/test_session.py
@@ -1,69 +1,69 @@
-import json
-import unittest
-from datetime import datetime, timedelta, timezone
-from unittest.mock import patch
-
-from freezegun import freeze_time
-
-from frontstage import app
-from frontstage.common.session import Session
-
-SESSION_TIMEOUT_SECONDS = 3600
-SESSION_KEY = "d06ce641-ab91-4f30-a78a-2098f8297768"
-TIME_TO_FREEZE = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
-PARTY_ID = "f49e945d-f992-49ac-ab7f-3c0fb953775e"
-
-
-class TestSession(unittest.TestCase):
-    @freeze_time(TIME_TO_FREEZE)
-    def setUp(self):
-        self.app = app.test_client()
-        self.app.set_cookie(server_name="localhost", key="authorization", value=SESSION_KEY)
-        session = Session.from_party_id(PARTY_ID)
-        self.encoded_jwt_token = session.encoded_jwt_token
-
-    @freeze_time(TIME_TO_FREEZE)
-    @patch("redis.StrictRedis.get")
-    def test_expires_at_current_time(self, mock_redis):
-        # Given a user has a valid jwt_token set to expire in 60 minutes
-        mock_redis.return_value = self.encoded_jwt_token
-        # When the expires-at end point is called
-        with freeze_time(TIME_TO_FREEZE):
-            response = self.app.get("/session/expires-at")
-            expected_expires_at = (TIME_TO_FREEZE + timedelta(seconds=SESSION_TIMEOUT_SECONDS)).isoformat()
-            parsed_json = json.loads(response.data)
-
-        # Then the expiration time is in 60 minutes
-        self.assertEqual(expected_expires_at, parsed_json["expires_at"])
-        self.assertEqual((TIME_TO_FREEZE + timedelta(minutes=60)).isoformat(), expected_expires_at)
-
-    @freeze_time(TIME_TO_FREEZE)
-    @patch("redis.StrictRedis.get")
-    def test_expires_at_future_time(self, mock_redis):
-        # Given a user has a valid jwt_token set to expire in 60 minutes
-        mock_redis.return_value = self.encoded_jwt_token
-        # When the expires-at end point is called 20 minutes after it was set
-        future_time = TIME_TO_FREEZE + timedelta(minutes=20)
-        with freeze_time(future_time):
-            response = self.app.get("/session/expires-at")
-            expected_expires_at = (TIME_TO_FREEZE + timedelta(seconds=SESSION_TIMEOUT_SECONDS)).isoformat()
-            parsed_json = json.loads(response.data)
-
-        # Then the expiration time is in 40 minutes as calling expires-at doesn't extend the session
-        self.assertEqual(expected_expires_at, parsed_json["expires_at"])
-        self.assertEqual((future_time + timedelta(minutes=40)).isoformat(), expected_expires_at)
-
-    @freeze_time(TIME_TO_FREEZE)
-    @patch("redis.StrictRedis.get")
-    def test_patch_expires_at_current_time(self, mock_redis):
-        # Given a user has a valid jwt_token set to expire in 60 minutes
-        mock_redis.return_value = self.encoded_jwt_token
-        # When the expires-at end point is patched we receive an updated expires-at value
-        request_time = TIME_TO_FREEZE + timedelta(minutes=20)
-        with freeze_time(request_time):
-            response = self.app.patch("/session/expires-at")
-            parsed_json = json.loads(response.data)
-            expected_expires_at = (request_time + timedelta(seconds=SESSION_TIMEOUT_SECONDS)).isoformat()
-
-        # Then the expires value is 20 minutes greater than it was
-        self.assertEqual(parsed_json["expires_at"], expected_expires_at)
+# import json
+# import unittest
+# from datetime import datetime, timedelta, timezone
+# from unittest.mock import patch
+#
+# from freezegun import freeze_time
+#
+# from frontstage import app
+# from frontstage.common.session import Session
+#
+# SESSION_TIMEOUT_SECONDS = 3600
+# SESSION_KEY = "d06ce641-ab91-4f30-a78a-2098f8297768"
+# TIME_TO_FREEZE = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+# PARTY_ID = "f49e945d-f992-49ac-ab7f-3c0fb953775e"
+#
+#
+# class TestSession(unittest.TestCase):
+#     @freeze_time(TIME_TO_FREEZE)
+#     def setUp(self):
+#         self.app = app.test_client()
+#         self.app.set_cookie(server_name="localhost", key="authorization", value=SESSION_KEY)
+#         session = Session.from_party_id(PARTY_ID)
+#         self.encoded_jwt_token = session.encoded_jwt_token
+#
+#     @freeze_time(TIME_TO_FREEZE)
+#     @patch("redis.StrictRedis.get")
+#     def test_expires_at_current_time(self, mock_redis):
+#         # Given a user has a valid jwt_token set to expire in 60 minutes
+#         mock_redis.return_value = self.encoded_jwt_token
+#         # When the expires-at end point is called
+#         with freeze_time(TIME_TO_FREEZE):
+#             response = self.app.get("/session/expires-at")
+#             expected_expires_at = (TIME_TO_FREEZE + timedelta(seconds=SESSION_TIMEOUT_SECONDS)).isoformat()
+#             parsed_json = json.loads(response.data)
+#
+#         # Then the expiration time is in 60 minutes
+#         self.assertEqual(expected_expires_at, parsed_json["expires_at"])
+#         self.assertEqual((TIME_TO_FREEZE + timedelta(minutes=60)).isoformat(), expected_expires_at)
+#
+#     @freeze_time(TIME_TO_FREEZE)
+#     @patch("redis.StrictRedis.get")
+#     def test_expires_at_future_time(self, mock_redis):
+#         # Given a user has a valid jwt_token set to expire in 60 minutes
+#         mock_redis.return_value = self.encoded_jwt_token
+#         # When the expires-at end point is called 20 minutes after it was set
+#         future_time = TIME_TO_FREEZE + timedelta(minutes=20)
+#         with freeze_time(future_time):
+#             response = self.app.get("/session/expires-at")
+#             expected_expires_at = (TIME_TO_FREEZE + timedelta(seconds=SESSION_TIMEOUT_SECONDS)).isoformat()
+#             parsed_json = json.loads(response.data)
+#
+#         # Then the expiration time is in 40 minutes as calling expires-at doesn't extend the session
+#         self.assertEqual(expected_expires_at, parsed_json["expires_at"])
+#         self.assertEqual((future_time + timedelta(minutes=40)).isoformat(), expected_expires_at)
+#
+#     @freeze_time(TIME_TO_FREEZE)
+#     @patch("redis.StrictRedis.get")
+#     def test_expire_at_patch_extends_session(self, mock_redis):
+#         # Given a user has a valid jwt_token set to expire in 60 minutes
+#         mock_redis.return_value = self.encoded_jwt_token
+#         # When the expires-at end point is patched we receive an updated expires-at value
+#         request_time = TIME_TO_FREEZE + timedelta(minutes=20)
+#         with freeze_time(request_time):
+#             response = self.app.patch("/session/expires-at")
+#             parsed_json = json.loads(response.data)
+#             expected_expires_at = (request_time + timedelta(seconds=SESSION_TIMEOUT_SECONDS)).isoformat()
+#
+#         # Then the expires value is 60 minutes greater than it was
+#         self.assertEqual(parsed_json["expires_at"], expected_expires_at)

--- a/tests/integration/views/test_session.py
+++ b/tests/integration/views/test_session.py
@@ -52,3 +52,24 @@ class TestSession(unittest.TestCase):
         # Then the expiration time is in 40 minutes as calling expires-at doesn't extend the session
         self.assertEqual(expected_expires_at, parsed_json["expires_at"])
         self.assertEqual((future_time + timedelta(minutes=40)).isoformat(), expected_expires_at)
+
+    @freeze_time(TIME_TO_FREEZE)
+    @patch("redis.StrictRedis.get")
+    def test_patch_expires_at_current_time(self, mock_redis):
+        # Given a user has a valid jwt_token set to expire in 60 minutes
+        mock_redis.return_value = self.encoded_jwt_token
+        # When the expires-at end point is called we retrieve the expires-at value
+        with freeze_time(TIME_TO_FREEZE):
+            expected_response = self.app.get("/session/expires-at")
+            expected_parsed_json = json.loads(expected_response.data)
+        # And the expires-at end point is patched we receive an updated expires-at value
+        current_expiry = TIME_TO_FREEZE + timedelta(minutes=20)
+        with freeze_time(current_expiry):
+            patched_response = self.app.patch("/session/expires-at")
+            patched_parsed_json = json.loads(patched_response.data)
+            patched_expires_at = (current_expiry + timedelta(seconds=SESSION_TIMEOUT_SECONDS)).isoformat()
+
+        # Then the expires value is 20 minutes greater than it was
+        self.assertEqual(patched_parsed_json["expires_at"], patched_expires_at)
+        # And the new expiration time is 20 minutes greater than the original
+        self.assertNotEqual(expected_parsed_json["expires_at"], patched_parsed_json["expires_at"])

--- a/tests/integration/views/test_session.py
+++ b/tests/integration/views/test_session.py
@@ -1,75 +1,75 @@
-import json
-import unittest
-from datetime import datetime, timedelta, timezone
-from unittest.mock import patch
-
-from freezegun import freeze_time
-
-from frontstage import app
-from frontstage.common.session import Session
-
-SESSION_TIMEOUT_SECONDS = 3600
-SESSION_KEY = "d06ce641-ab91-4f30-a78a-2098f8297768"
-TIME_TO_FREEZE = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
-PARTY_ID = "f49e945d-f992-49ac-ab7f-3c0fb953775e"
-
-
-class TestSession(unittest.TestCase):
-    @freeze_time(TIME_TO_FREEZE)
-    def setUp(self):
-        self.app = app.test_client()
-        self.app.set_cookie(server_name="localhost", key="authorization", value=SESSION_KEY)
-        session = Session.from_party_id(PARTY_ID)
-        self.encoded_jwt_token = session.encoded_jwt_token
-
-    @freeze_time(TIME_TO_FREEZE)
-    @patch("redis.StrictRedis.get")
-    def test_expires_at_current_time(self, mock_redis):
-        # Given a user has a valid jwt_token set to expire in 60 minutes
-        mock_redis.return_value = self.encoded_jwt_token
-        # When the expires-at end point is called
-        with freeze_time(TIME_TO_FREEZE):
-            response = self.app.get("/session/expires-at")
-            expected_expires_at = (TIME_TO_FREEZE + timedelta(seconds=SESSION_TIMEOUT_SECONDS)).isoformat()
-            parsed_json = json.loads(response.data)
-
-        # Then the expiration time is in 60 minutes
-        self.assertEqual(expected_expires_at, parsed_json["expires_at"])
-        self.assertEqual((TIME_TO_FREEZE + timedelta(minutes=60)).isoformat(), expected_expires_at)
-
-    @freeze_time(TIME_TO_FREEZE)
-    @patch("redis.StrictRedis.get")
-    def test_expires_at_future_time(self, mock_redis):
-        # Given a user has a valid jwt_token set to expire in 60 minutes
-        mock_redis.return_value = self.encoded_jwt_token
-        # When the expires-at end point is called 20 minutes after it was set
-        future_time = TIME_TO_FREEZE + timedelta(minutes=20)
-        with freeze_time(future_time):
-            response = self.app.get("/session/expires-at")
-            expected_expires_at = (TIME_TO_FREEZE + timedelta(seconds=SESSION_TIMEOUT_SECONDS)).isoformat()
-            parsed_json = json.loads(response.data)
-
-        # Then the expiration time is in 40 minutes as calling expires-at doesn't extend the session
-        self.assertEqual(expected_expires_at, parsed_json["expires_at"])
-        self.assertEqual((future_time + timedelta(minutes=40)).isoformat(), expected_expires_at)
-
-    @freeze_time(TIME_TO_FREEZE)
-    @patch("redis.StrictRedis.get")
-    def test_patch_expires_at_current_time(self, mock_redis):
-        # Given a user has a valid jwt_token set to expire in 60 minutes
-        mock_redis.return_value = self.encoded_jwt_token
-        # When the expires-at end point is called we retrieve the expires-at value
-        with freeze_time(TIME_TO_FREEZE):
-            expected_response = self.app.get("/session/expires-at")
-            expected_parsed_json = json.loads(expected_response.data)
-        # And the expires-at end point is patched we receive an updated expires-at value
-        current_expiry = TIME_TO_FREEZE + timedelta(minutes=20)
-        with freeze_time(current_expiry):
-            patched_response = self.app.patch("/session/expires-at")
-            patched_parsed_json = json.loads(patched_response.data)
-            patched_expires_at = (current_expiry + timedelta(seconds=SESSION_TIMEOUT_SECONDS)).isoformat()
-
-        # Then the expires value is 20 minutes greater than it was
-        self.assertEqual(patched_parsed_json["expires_at"], patched_expires_at)
-        # And the new expiration time is 20 minutes greater than the original
-        self.assertNotEqual(expected_parsed_json["expires_at"], patched_parsed_json["expires_at"])
+# import json
+# import unittest
+# from datetime import datetime, timedelta, timezone
+# from unittest.mock import patch
+#
+# from freezegun import freeze_time
+#
+# from frontstage import app
+# from frontstage.common.session import Session
+#
+# SESSION_TIMEOUT_SECONDS = 3600
+# SESSION_KEY = "d06ce641-ab91-4f30-a78a-2098f8297768"
+# TIME_TO_FREEZE = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+# PARTY_ID = "f49e945d-f992-49ac-ab7f-3c0fb953775e"
+#
+#
+# class TestSession(unittest.TestCase):
+#     @freeze_time(TIME_TO_FREEZE)
+#     def setUp(self):
+#         self.app = app.test_client()
+#         self.app.set_cookie(server_name="localhost", key="authorization", value=SESSION_KEY)
+#         session = Session.from_party_id(PARTY_ID)
+#         self.encoded_jwt_token = session.encoded_jwt_token
+#
+#     @freeze_time(TIME_TO_FREEZE)
+#     @patch("redis.StrictRedis.get")
+#     def test_expires_at_current_time(self, mock_redis):
+#         # Given a user has a valid jwt_token set to expire in 60 minutes
+#         mock_redis.return_value = self.encoded_jwt_token
+#         # When the expires-at end point is called
+#         with freeze_time(TIME_TO_FREEZE):
+#             response = self.app.get("/session/expires-at")
+#             expected_expires_at = (TIME_TO_FREEZE + timedelta(seconds=SESSION_TIMEOUT_SECONDS)).isoformat()
+#             parsed_json = json.loads(response.data)
+#
+#         # Then the expiration time is in 60 minutes
+#         self.assertEqual(expected_expires_at, parsed_json["expires_at"])
+#         self.assertEqual((TIME_TO_FREEZE + timedelta(minutes=60)).isoformat(), expected_expires_at)
+#
+#     @freeze_time(TIME_TO_FREEZE)
+#     @patch("redis.StrictRedis.get")
+#     def test_expires_at_future_time(self, mock_redis):
+#         # Given a user has a valid jwt_token set to expire in 60 minutes
+#         mock_redis.return_value = self.encoded_jwt_token
+#         # When the expires-at end point is called 20 minutes after it was set
+#         future_time = TIME_TO_FREEZE + timedelta(minutes=20)
+#         with freeze_time(future_time):
+#             response = self.app.get("/session/expires-at")
+#             expected_expires_at = (TIME_TO_FREEZE + timedelta(seconds=SESSION_TIMEOUT_SECONDS)).isoformat()
+#             parsed_json = json.loads(response.data)
+#
+#         # Then the expiration time is in 40 minutes as calling expires-at doesn't extend the session
+#         self.assertEqual(expected_expires_at, parsed_json["expires_at"])
+#         self.assertEqual((future_time + timedelta(minutes=40)).isoformat(), expected_expires_at)
+#
+#     @freeze_time(TIME_TO_FREEZE)
+#     @patch("redis.StrictRedis.get")
+#     def test_patch_expires_at_current_time(self, mock_redis):
+#         # Given a user has a valid jwt_token set to expire in 60 minutes
+#         mock_redis.return_value = self.encoded_jwt_token
+#         # When the expires-at end point is called we retrieve the expires-at value
+#         with freeze_time(TIME_TO_FREEZE):
+#             expected_response = self.app.get("/session/expires-at")
+#             expected_parsed_json = json.loads(expected_response.data)
+#         # And the expires-at end point is patched we receive an updated expires-at value
+#         current_expiry = TIME_TO_FREEZE + timedelta(minutes=20)
+#         with freeze_time(current_expiry):
+#             patched_response = self.app.patch("/session/expires-at")
+#             patched_parsed_json = json.loads(patched_response.data)
+#             patched_expires_at = (current_expiry + timedelta(seconds=SESSION_TIMEOUT_SECONDS)).isoformat()
+#
+#         # Then the expires value is 20 minutes greater than it was
+#         self.assertEqual(patched_parsed_json["expires_at"], patched_expires_at)
+#         # And the new expiration time is 20 minutes greater than the original
+#         self.assertNotEqual(expected_parsed_json["expires_at"], patched_parsed_json["expires_at"])

--- a/tests/integration/views/test_session.py
+++ b/tests/integration/views/test_session.py
@@ -1,69 +1,69 @@
-# import json
-# import unittest
-# from datetime import datetime, timedelta, timezone
-# from unittest.mock import patch
-#
-# from freezegun import freeze_time
-#
-# from frontstage import app
-# from frontstage.common.session import Session
-#
-# SESSION_TIMEOUT_SECONDS = 3600
-# SESSION_KEY = "d06ce641-ab91-4f30-a78a-2098f8297768"
-# TIME_TO_FREEZE = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
-# PARTY_ID = "f49e945d-f992-49ac-ab7f-3c0fb953775e"
-#
-#
-# class TestSession(unittest.TestCase):
-#     @freeze_time(TIME_TO_FREEZE)
-#     def setUp(self):
-#         self.app = app.test_client()
-#         self.app.set_cookie(server_name="localhost", key="authorization", value=SESSION_KEY)
-#         session = Session.from_party_id(PARTY_ID)
-#         self.encoded_jwt_token = session.encoded_jwt_token
-#
-#     @freeze_time(TIME_TO_FREEZE)
-#     @patch("redis.StrictRedis.get")
-#     def test_expires_at_current_time(self, mock_redis):
-#         # Given a user has a valid jwt_token set to expire in 60 minutes
-#         mock_redis.return_value = self.encoded_jwt_token
-#         # When the expires-at end point is called
-#         with freeze_time(TIME_TO_FREEZE):
-#             response = self.app.get("/session/expires-at")
-#             expected_expires_at = (TIME_TO_FREEZE + timedelta(seconds=SESSION_TIMEOUT_SECONDS)).isoformat()
-#             parsed_json = json.loads(response.data)
-#
-#         # Then the expiration time is in 60 minutes
-#         self.assertEqual(expected_expires_at, parsed_json["expires_at"])
-#         self.assertEqual((TIME_TO_FREEZE + timedelta(minutes=60)).isoformat(), expected_expires_at)
-#
-#     @freeze_time(TIME_TO_FREEZE)
-#     @patch("redis.StrictRedis.get")
-#     def test_expires_at_future_time(self, mock_redis):
-#         # Given a user has a valid jwt_token set to expire in 60 minutes
-#         mock_redis.return_value = self.encoded_jwt_token
-#         # When the expires-at end point is called 20 minutes after it was set
-#         future_time = TIME_TO_FREEZE + timedelta(minutes=20)
-#         with freeze_time(future_time):
-#             response = self.app.get("/session/expires-at")
-#             expected_expires_at = (TIME_TO_FREEZE + timedelta(seconds=SESSION_TIMEOUT_SECONDS)).isoformat()
-#             parsed_json = json.loads(response.data)
-#
-#         # Then the expiration time is in 40 minutes as calling expires-at doesn't extend the session
-#         self.assertEqual(expected_expires_at, parsed_json["expires_at"])
-#         self.assertEqual((future_time + timedelta(minutes=40)).isoformat(), expected_expires_at)
-#
-#     @freeze_time(TIME_TO_FREEZE)
-#     @patch("redis.StrictRedis.get")
-#     def test_expire_at_patch_extends_session(self, mock_redis):
-#         # Given a user has a valid jwt_token set to expire in 60 minutes
-#         mock_redis.return_value = self.encoded_jwt_token
-#         # When the expires-at end point is patched we receive an updated expires-at value
-#         request_time = TIME_TO_FREEZE + timedelta(minutes=20)
-#         with freeze_time(request_time):
-#             response = self.app.patch("/session/expires-at")
-#             parsed_json = json.loads(response.data)
-#             expected_expires_at = (request_time + timedelta(seconds=SESSION_TIMEOUT_SECONDS)).isoformat()
-#
-#         # Then the expires value is 60 minutes greater than it was
-#         self.assertEqual(parsed_json["expires_at"], expected_expires_at)
+import json
+import unittest
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+from freezegun import freeze_time
+
+from frontstage import app
+from frontstage.common.session import Session
+
+SESSION_TIMEOUT_SECONDS = 3600
+SESSION_KEY = "d06ce641-ab91-4f30-a78a-2098f8297768"
+TIME_TO_FREEZE = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+PARTY_ID = "f49e945d-f992-49ac-ab7f-3c0fb953775e"
+
+
+class TestSession(unittest.TestCase):
+    @freeze_time(TIME_TO_FREEZE)
+    def setUp(self):
+        self.app = app.test_client()
+        self.app.set_cookie(server_name="localhost", key="authorization", value=SESSION_KEY)
+        session = Session.from_party_id(PARTY_ID)
+        self.encoded_jwt_token = session.encoded_jwt_token
+
+    @freeze_time(TIME_TO_FREEZE)
+    @patch("redis.StrictRedis.get")
+    def test_expires_at_current_time(self, mock_redis):
+        # Given a user has a valid jwt_token set to expire in 60 minutes
+        mock_redis.return_value = self.encoded_jwt_token
+        # When the expires-at end point is called
+        with freeze_time(TIME_TO_FREEZE):
+            response = self.app.get("/session/expires-at")
+            expected_expires_at = (TIME_TO_FREEZE + timedelta(seconds=SESSION_TIMEOUT_SECONDS)).isoformat()
+            parsed_json = json.loads(response.data)
+
+        # Then the expiration time is in 60 minutes
+        self.assertEqual(expected_expires_at, parsed_json["expires_at"])
+        self.assertEqual((TIME_TO_FREEZE + timedelta(minutes=60)).isoformat(), expected_expires_at)
+
+    @freeze_time(TIME_TO_FREEZE)
+    @patch("redis.StrictRedis.get")
+    def test_expires_at_future_time(self, mock_redis):
+        # Given a user has a valid jwt_token set to expire in 60 minutes
+        mock_redis.return_value = self.encoded_jwt_token
+        # When the expires-at end point is called 20 minutes after it was set
+        future_time = TIME_TO_FREEZE + timedelta(minutes=20)
+        with freeze_time(future_time):
+            response = self.app.get("/session/expires-at")
+            expected_expires_at = (TIME_TO_FREEZE + timedelta(seconds=SESSION_TIMEOUT_SECONDS)).isoformat()
+            parsed_json = json.loads(response.data)
+
+        # Then the expiration time is in 40 minutes as calling expires-at doesn't extend the session
+        self.assertEqual(expected_expires_at, parsed_json["expires_at"])
+        self.assertEqual((future_time + timedelta(minutes=40)).isoformat(), expected_expires_at)
+
+    @freeze_time(TIME_TO_FREEZE)
+    @patch("redis.StrictRedis.get")
+    def test_expire_at_patch_extends_session(self, mock_redis):
+        # Given a user has a valid jwt_token set to expire in 60 minutes
+        mock_redis.return_value = self.encoded_jwt_token
+        # When the expires-at end point is patched we receive an updated expires-at value
+        request_time = TIME_TO_FREEZE + timedelta(minutes=20)
+        with freeze_time(request_time):
+            response = self.app.patch("/session/expires-at")
+            parsed_json = json.loads(response.data)
+            expected_expires_at = (request_time + timedelta(seconds=SESSION_TIMEOUT_SECONDS)).isoformat()
+
+        # Then the expires value is 60 minutes greater than it was
+        self.assertEqual(parsed_json["expires_at"], expected_expires_at)

--- a/tests/integration/views/test_session.py
+++ b/tests/integration/views/test_session.py
@@ -1,75 +1,75 @@
-# import json
-# import unittest
-# from datetime import datetime, timedelta, timezone
-# from unittest.mock import patch
-#
-# from freezegun import freeze_time
-#
-# from frontstage import app
-# from frontstage.common.session import Session
-#
-# SESSION_TIMEOUT_SECONDS = 3600
-# SESSION_KEY = "d06ce641-ab91-4f30-a78a-2098f8297768"
-# TIME_TO_FREEZE = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
-# PARTY_ID = "f49e945d-f992-49ac-ab7f-3c0fb953775e"
-#
-#
-# class TestSession(unittest.TestCase):
-#     @freeze_time(TIME_TO_FREEZE)
-#     def setUp(self):
-#         self.app = app.test_client()
-#         self.app.set_cookie(server_name="localhost", key="authorization", value=SESSION_KEY)
-#         session = Session.from_party_id(PARTY_ID)
-#         self.encoded_jwt_token = session.encoded_jwt_token
-#
-#     @freeze_time(TIME_TO_FREEZE)
-#     @patch("redis.StrictRedis.get")
-#     def test_expires_at_current_time(self, mock_redis):
-#         # Given a user has a valid jwt_token set to expire in 60 minutes
-#         mock_redis.return_value = self.encoded_jwt_token
-#         # When the expires-at end point is called
-#         with freeze_time(TIME_TO_FREEZE):
-#             response = self.app.get("/session/expires-at")
-#             expected_expires_at = (TIME_TO_FREEZE + timedelta(seconds=SESSION_TIMEOUT_SECONDS)).isoformat()
-#             parsed_json = json.loads(response.data)
-#
-#         # Then the expiration time is in 60 minutes
-#         self.assertEqual(expected_expires_at, parsed_json["expires_at"])
-#         self.assertEqual((TIME_TO_FREEZE + timedelta(minutes=60)).isoformat(), expected_expires_at)
-#
-#     @freeze_time(TIME_TO_FREEZE)
-#     @patch("redis.StrictRedis.get")
-#     def test_expires_at_future_time(self, mock_redis):
-#         # Given a user has a valid jwt_token set to expire in 60 minutes
-#         mock_redis.return_value = self.encoded_jwt_token
-#         # When the expires-at end point is called 20 minutes after it was set
-#         future_time = TIME_TO_FREEZE + timedelta(minutes=20)
-#         with freeze_time(future_time):
-#             response = self.app.get("/session/expires-at")
-#             expected_expires_at = (TIME_TO_FREEZE + timedelta(seconds=SESSION_TIMEOUT_SECONDS)).isoformat()
-#             parsed_json = json.loads(response.data)
-#
-#         # Then the expiration time is in 40 minutes as calling expires-at doesn't extend the session
-#         self.assertEqual(expected_expires_at, parsed_json["expires_at"])
-#         self.assertEqual((future_time + timedelta(minutes=40)).isoformat(), expected_expires_at)
-#
-#     @freeze_time(TIME_TO_FREEZE)
-#     @patch("redis.StrictRedis.get")
-#     def test_patch_expires_at_current_time(self, mock_redis):
-#         # Given a user has a valid jwt_token set to expire in 60 minutes
-#         mock_redis.return_value = self.encoded_jwt_token
-#         # When the expires-at end point is called we retrieve the expires-at value
-#         with freeze_time(TIME_TO_FREEZE):
-#             expected_response = self.app.get("/session/expires-at")
-#             expected_parsed_json = json.loads(expected_response.data)
-#         # And the expires-at end point is patched we receive an updated expires-at value
-#         current_expiry = TIME_TO_FREEZE + timedelta(minutes=20)
-#         with freeze_time(current_expiry):
-#             patched_response = self.app.patch("/session/expires-at")
-#             patched_parsed_json = json.loads(patched_response.data)
-#             patched_expires_at = (current_expiry + timedelta(seconds=SESSION_TIMEOUT_SECONDS)).isoformat()
-#
-#         # Then the expires value is 20 minutes greater than it was
-#         self.assertEqual(patched_parsed_json["expires_at"], patched_expires_at)
-#         # And the new expiration time is 20 minutes greater than the original
-#         self.assertNotEqual(expected_parsed_json["expires_at"], patched_parsed_json["expires_at"])
+import json
+import unittest
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+from freezegun import freeze_time
+
+from frontstage import app
+from frontstage.common.session import Session
+
+SESSION_TIMEOUT_SECONDS = 3600
+SESSION_KEY = "d06ce641-ab91-4f30-a78a-2098f8297768"
+TIME_TO_FREEZE = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+PARTY_ID = "f49e945d-f992-49ac-ab7f-3c0fb953775e"
+
+
+class TestSession(unittest.TestCase):
+    @freeze_time(TIME_TO_FREEZE)
+    def setUp(self):
+        self.app = app.test_client()
+        self.app.set_cookie(server_name="localhost", key="authorization", value=SESSION_KEY)
+        session = Session.from_party_id(PARTY_ID)
+        self.encoded_jwt_token = session.encoded_jwt_token
+
+    @freeze_time(TIME_TO_FREEZE)
+    @patch("redis.StrictRedis.get")
+    def test_expires_at_current_time(self, mock_redis):
+        # Given a user has a valid jwt_token set to expire in 60 minutes
+        mock_redis.return_value = self.encoded_jwt_token
+        # When the expires-at end point is called
+        with freeze_time(TIME_TO_FREEZE):
+            response = self.app.get("/session/expires-at")
+            expected_expires_at = (TIME_TO_FREEZE + timedelta(seconds=SESSION_TIMEOUT_SECONDS)).isoformat()
+            parsed_json = json.loads(response.data)
+
+        # Then the expiration time is in 60 minutes
+        self.assertEqual(expected_expires_at, parsed_json["expires_at"])
+        self.assertEqual((TIME_TO_FREEZE + timedelta(minutes=60)).isoformat(), expected_expires_at)
+
+    @freeze_time(TIME_TO_FREEZE)
+    @patch("redis.StrictRedis.get")
+    def test_expires_at_future_time(self, mock_redis):
+        # Given a user has a valid jwt_token set to expire in 60 minutes
+        mock_redis.return_value = self.encoded_jwt_token
+        # When the expires-at end point is called 20 minutes after it was set
+        future_time = TIME_TO_FREEZE + timedelta(minutes=20)
+        with freeze_time(future_time):
+            response = self.app.get("/session/expires-at")
+            expected_expires_at = (TIME_TO_FREEZE + timedelta(seconds=SESSION_TIMEOUT_SECONDS)).isoformat()
+            parsed_json = json.loads(response.data)
+
+        # Then the expiration time is in 40 minutes as calling expires-at doesn't extend the session
+        self.assertEqual(expected_expires_at, parsed_json["expires_at"])
+        self.assertEqual((future_time + timedelta(minutes=40)).isoformat(), expected_expires_at)
+
+    @freeze_time(TIME_TO_FREEZE)
+    @patch("redis.StrictRedis.get")
+    def test_patch_expires_at_current_time(self, mock_redis):
+        # Given a user has a valid jwt_token set to expire in 60 minutes
+        mock_redis.return_value = self.encoded_jwt_token
+        # When the expires-at end point is called we retrieve the expires-at value
+        with freeze_time(TIME_TO_FREEZE):
+            expected_response = self.app.get("/session/expires-at")
+            expected_parsed_json = json.loads(expected_response.data)
+        # And the expires-at end point is patched we receive an updated expires-at value
+        current_expiry = TIME_TO_FREEZE + timedelta(minutes=20)
+        with freeze_time(current_expiry):
+            patched_response = self.app.patch("/session/expires-at")
+            patched_parsed_json = json.loads(patched_response.data)
+            patched_expires_at = (current_expiry + timedelta(seconds=SESSION_TIMEOUT_SECONDS)).isoformat()
+
+        # Then the expires value is 20 minutes greater than it was
+        self.assertEqual(patched_parsed_json["expires_at"], patched_expires_at)
+        # And the new expiration time is 20 minutes greater than the original
+        self.assertNotEqual(expected_parsed_json["expires_at"], patched_parsed_json["expires_at"])


### PR DESCRIPTION
# What and why?
There is a requirement that people logged into frontstage need to be notified that they will be logged out 60 seconds before their session times out. They can either stay on the page and their timeout counter will be refreshed or they will be redirected to the login screen.

These code changes will achieve this.

# How to test?
1. Sign into frontstage with a user account
2. Once redirected to the todo survey list keep the page loaded and do not navigate anywhere whilst logged in with the above user account
3. After 59 minutes have elapsed, a message will appear on the screen with a counter
4. Test both the following:
- Click the 'Continue survey' button and you should be on the same screen that you you originally opened
-  Click the 'Continue survey' button once the timer has counted down. This will redirect you to the login page

# Jira
https://jira.ons.gov.uk/browse/RAS-739