### PR TITLE
RAS-765 Update eq payload to V2

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 2.4.59
+version: 2.4.60
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.4.59
+appVersion: 2.4.60

--- a/frontstage/common/eq_payload.py
+++ b/frontstage/common/eq_payload.py
@@ -17,22 +17,20 @@ logger = wrap_logger(logging.getLogger(__name__))
 
 
 class EqPayload(object):
-    def create_payload(self, case, collection_exercise, party_id: str, business_party_id: str, survey) -> dict:
+    def create_payload(self, case, ce, party_id: str, business_party_id: str, survey) -> dict:
         """
         Creates the payload needed to communicate with EQ, built from the Case, Collection Exercise, Party,
         Survey and Collection Instrument services
         :param case: A dict containing information about the case
-        :param collection_exercise: A dict containing information about the collection exercise
+        :param ce: A dict containing information about the collection exercise
         :param party_id: The uuid of the respondent
         :param business_party_id: The uuid of the reporting unit
         :param survey: A dict containing information about the survey
         :returns: Payload for EQ
         """
-
         tx_id = str(uuid.uuid4())
         logger.info("Creating payload for JWT", case_id=case["id"], tx_id=tx_id)
 
-        # Collection Instrument
         ci_id = case["collectionInstrumentId"]
         ci = collection_instrument_controller.get_collection_instrument(
             ci_id, current_app.config["COLLECTION_INSTRUMENT_URL"], current_app.config["BASIC_AUTH"]
@@ -46,71 +44,52 @@ class EqPayload(object):
 
         eq_id = ci["classifiers"]["eq_id"]
         form_type = ci["classifiers"]["form_type"]
-
-        # Collection Exercise
-        collection_exercise_id = collection_exercise["id"]
-        collex_event_dates = self._get_collex_event_dates(collection_exercise_id)
-
-        # Party
+        ce_id = ce["id"]
         party = party_controller.get_party_by_business_id(
             business_party_id,
             current_app.config["PARTY_URL"],
             current_app.config["BASIC_AUTH"],
-            collection_exercise_id=collection_exercise_id,
+            collection_exercise_id=ce_id,
         )
-
-        account_service_url = current_app.config["ACCOUNT_SERVICE_URL"]
-        account_service_log_out_url = current_app.config["ACCOUNT_SERVICE_LOG_OUT_URL"]
-        iat = time.time()
-        exp = time.time() + (5 * 60)
-        response_id = f"{party['sampleUnitRef'] + party['checkletter']}{collection_exercise['id']}{eq_id}{form_type}"
+        ce_events = collection_exercise_controller.get_collection_exercise_events(ce_id)
+        ru_ref = f"{party['sampleUnitRef'] + party['checkletter']}"
+        int_time = int(time.time())
 
         payload = {
+            "exp": int_time + 300,
+            "iat": int_time,
             "jti": str(uuid.uuid4()),
             "tx_id": tx_id,
-            "user_id": party_id,
-            "iat": int(iat),
-            "exp": int(exp),
-            "eq_id": eq_id,
-            "period_str": collection_exercise["userDescription"],
-            "period_id": collection_exercise["exerciseRef"],
-            "form_type": form_type,
-            "collection_exercise_sid": collection_exercise["id"],
-            "ru_ref": party["sampleUnitRef"] + party["checkletter"],
-            "ru_name": party["name"],
-            "survey_id": survey["surveyRef"],
+            "version": "v2",
+            "account_service_url": current_app.config["ACCOUNT_SERVICE_URL"],
             "case_id": case["id"],
-            "case_ref": case["caseRef"],
-            "account_service_url": account_service_url,
-            "account_service_log_out_url": account_service_log_out_url,
-            "trad_as": f"{party['tradstyle1']} {party['tradstyle2']} {party['tradstyle3']}",
-            "response_id": response_id,
+            "collection_exercise_sid": ce_id,
+            "response_id": f"{ru_ref}{ce_id}{eq_id}{form_type}",
+            "response_expires_at": self._find_event_date_by_tag("exercise_end", ce_events, ce_id),
+            "schema_name": f"{eq_id}_{form_type}",
+            "survey_metadata": {
+                "data": {
+                    "case_ref": case["caseRef"],
+                    "form_type": form_type,
+                    "period_id": ce["exerciseRef"],
+                    "period_str": ce["userDescription"],
+                    "ref_p_end_date": self._find_event_date_by_tag("ref_period_start", ce_events, ce_id),
+                    "ref_p_start_date": self._find_event_date_by_tag("ref_period_end", ce_events, ce_id),
+                    "ru_name": party["name"],
+                    "ru_ref": ru_ref,
+                    "trad_as": f"{party['tradstyle1']} {party['tradstyle2']} {party['tradstyle3']}",
+                    "user_id": party_id,
+                    "survey_id": survey["surveyRef"],
+                }
+            },
         }
 
-        # Add any non null event dates that exist for this collection exercise
-        payload.update([(key, value) for key, value in collex_event_dates.items() if value is not None])
-
-        logger.debug(payload)
+        if employment_date := self._find_event_date_by_tag("employment", ce_events, ce_id, False):
+            payload["survey_metadata"]["data"]["employment_date"] = employment_date
 
         return payload
 
-    def _get_collex_event_dates(self, collex_id):
-        """
-        Maps the required collection exercise dates to a dic
-        :param collex_id: The unique UUID references of a collection exercise
-        :return A dict of event dates associate with the Exercise
-        """
-
-        collex_events = collection_exercise_controller.get_collection_exercise_events(collex_id)
-        return {
-            "ref_p_start_date": self._find_event_date_by_tag("ref_period_start", collex_events, collex_id, True),
-            "ref_p_end_date": self._find_event_date_by_tag("ref_period_end", collex_events, collex_id, True),
-            "employment_date": self._find_event_date_by_tag("employment", collex_events, collex_id, False),
-            "return_by": self._find_event_date_by_tag("return_by", collex_events, collex_id, True),
-            "response_expires_at": self._find_event_date_by_tag("exercise_end", collex_events, collex_id, True),
-        }
-
-    def _find_event_date_by_tag(self, search_param, collex_events, collex_id, mandatory):
+    def _find_event_date_by_tag(self, search_param, collex_events, collex_id, mandatory=True):
         """
         Finds the required date from the list of all the events
         :param search_param: the string name of the date searching for

--- a/tests/integration/test_generate_eq.py
+++ b/tests/integration/test_generate_eq.py
@@ -99,6 +99,8 @@ class TestGenerateEqURL(unittest.TestCase):
                 case, collection_exercise, respondent_party["id"], business_party["id"], survey_eq
             )
         # Then the payload is as expected
+        print(payload_created)
+        print(PAYLOAD)
         self.assertTrue(PAYLOAD.items() <= payload_created.items())
         self.assertIn("jti", payload_created)
         self.assertTrue(_is_valid_uuid(payload_created["jti"]))

--- a/tests/integration/test_generate_eq.py
+++ b/tests/integration/test_generate_eq.py
@@ -49,7 +49,6 @@ PAYLOAD = {
     "case_id": "8cdc01f9-656a-4715-a148-ffed0dbe1b04",
     "collection_exercise_sid": "8d990a74-5f07-4765-ac66-df7e1a96505b",
     "response_id": "49900000001F8d990a74-5f07-4765-ac66-df7e1a96505b20001",
-    "response_expires_at": "2023-05-31T01:00:00+01:00",
     "schema_name": "2_0001",
     "survey_metadata": {
         "data": {
@@ -99,8 +98,6 @@ class TestGenerateEqURL(unittest.TestCase):
                 case, collection_exercise, respondent_party["id"], business_party["id"], survey_eq
             )
         # Then the payload is as expected
-        print(payload_created)
-        print(PAYLOAD)
         self.assertTrue(PAYLOAD.items() <= payload_created.items())
         self.assertIn("jti", payload_created)
         self.assertTrue(_is_valid_uuid(payload_created["jti"]))

--- a/tests/integration/test_generate_eq.py
+++ b/tests/integration/test_generate_eq.py
@@ -1,8 +1,11 @@
 import json
 import unittest
+import uuid
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 import requests_mock
+from freezegun import freeze_time
 
 from frontstage import app
 from frontstage.common.eq_payload import EqPayload
@@ -33,6 +36,38 @@ encoded_jwt_token = (
     "jc2NzQwMDAuMH0.m94R50EPIKTJmE6gf6PvCmCq8ZpYwwV8PHSqsJh5fnI"
 )
 
+with open("tests/test_data/collection_instrument/collection_instrument_eq.json") as json_data:
+    collection_instrument_eq = json.load(json_data)
+
+TIME_TO_FREEZE = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+PAYLOAD = {
+    "exp": 1672574700,
+    "iat": 1672574400,
+    "version": "v2",
+    "account_service_url": "http://frontstage-url/surveys",
+    "case_id": "8cdc01f9-656a-4715-a148-ffed0dbe1b04",
+    "collection_exercise_sid": "8d990a74-5f07-4765-ac66-df7e1a96505b",
+    "response_id": "49900000001F8d990a74-5f07-4765-ac66-df7e1a96505b20001",
+    "response_expires_at": "2023-05-31T01:00:00+01:00",
+    "schema_name": "2_0001",
+    "survey_metadata": {
+        "data": {
+            "case_ref": "1000000000000016",
+            "form_type": "0001",
+            "period_id": "204901",
+            "period_str": "test_exercise",
+            "ref_p_end_date": "2018-04-10",
+            "ref_p_start_date": "2020-05-31",
+            "ru_name": "RUNAME1_COMPANY1 RUNNAME2_COMPANY1",
+            "ru_ref": "49900000001F",
+            "trad_as": "  ",
+            "user_id": "f956e8ae-6e0f-4414-b0cf-a07c1aa3e37b",
+            "survey_id": "139",
+        }
+    },
+}
+
 
 class TestGenerateEqURL(unittest.TestCase):
     def setUp(self):
@@ -49,6 +84,56 @@ class TestGenerateEqURL(unittest.TestCase):
 
     def tearDown(self):
         self.patcher.stop()
+
+    @freeze_time(TIME_TO_FREEZE)
+    @requests_mock.mock()
+    def test_create_payload_without_employment_date(self, mock_request):
+        # Given a collection exercise without an employment date event
+        mock_request.get(url_get_collection_exercise_events, json=collection_exercise_events)
+        mock_request.get(url_get_business_party, json=business_party)
+        mock_request.get(url_get_ci, json=collection_instrument_eq)
+
+        # When a payload is created
+        with app.app_context():
+            payload_created = EqPayload().create_payload(
+                case, collection_exercise, respondent_party["id"], business_party["id"], survey_eq
+            )
+        # Then the payload is as expected
+        self.assertTrue(PAYLOAD.items() <= payload_created.items())
+        self.assertIn("jti", payload_created)
+        self.assertTrue(_is_valid_uuid(payload_created["jti"]))
+        self.assertIn("tx_id", payload_created)
+        self.assertTrue(_is_valid_uuid(payload_created["tx_id"]))
+        self.assertNotIn("employment_date", payload_created)
+
+    @freeze_time(TIME_TO_FREEZE)
+    @requests_mock.mock()
+    def test_create_payload_with_employment_date(self, mock_request):
+        # Given a collection exercise with an employment date event
+        collection_exercise_event_employment_date = {
+            "id": "5629d715-ec3e-4ca2-9232-be5c1d56cf32",
+            "collectionExerciseId": "df634637-2aac-487f-9d2f-eb56615ed80e",
+            "tag": "employment",
+            "timestamp": "2023-05-31T00:00:00.000Z",
+        }
+        collection_exercise_events.append(collection_exercise_event_employment_date)
+        PAYLOAD["survey_metadata"]["data"]["employment_date"] = "2023-05-31"
+        mock_request.get(url_get_collection_exercise_events, json=collection_exercise_events)
+        mock_request.get(url_get_business_party, json=business_party)
+        mock_request.get(url_get_ci, json=collection_instrument_eq)
+
+        # When a payload is created
+        with app.app_context():
+            payload_created = EqPayload().create_payload(
+                case, collection_exercise, respondent_party["id"], business_party["id"], survey_eq
+            )
+
+        # Then the payload is as expected
+        self.assertTrue(PAYLOAD.items() <= payload_created.items())
+        self.assertTrue("jti" in payload_created)
+        self.assertTrue(_is_valid_uuid(payload_created["jti"]))
+        self.assertTrue("tx_id" in payload_created)
+        self.assertTrue(_is_valid_uuid(payload_created["tx_id"]))
 
     @requests_mock.mock()
     def test_generate_eq_url_seft(self, mock_request):
@@ -254,3 +339,11 @@ class TestGenerateEqURL(unittest.TestCase):
 
         response = EqPayload()._find_event_date_by_tag("employment", collex_events_dates, "123", False)
         self.assertEqual(response, "2018-04-03")
+
+
+def _is_valid_uuid(uuid_string: str) -> bool:
+    try:
+        uuid.UUID(uuid_string, version=4)
+    except ValueError:
+        return False
+    return True


### PR DESCRIPTION
# What and why?
This PR updates the payload sent to eQ to v2. It also adds much needed payload tests, which were lacking and should really have been there before
# How to test?
The best way is to expose the payload and then validate it against https://github.com/ONSdigital/ons-schema-definitions#json-schema-validation. 

N.B There is some strange config differences when using response_expires with different timezones being used. I will raise another card for this, but considering we didn't test anything before, this is a large step in the right direction


# Trello
