### PR TITLE
RAS-739 Add modal to base template

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.4.68
+version: 2.4.69
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.4.68
+appVersion: 2.4.69

--- a/frontstage/common/authorisation.py
+++ b/frontstage/common/authorisation.py
@@ -9,7 +9,7 @@ from werkzeug.exceptions import Unauthorized
 
 from frontstage import app
 from frontstage.common.session import Session
-from frontstage.exceptions.exceptions import JWTValidationError
+from frontstage.exceptions.exceptions import JWTTimeoutError, JWTValidationError
 
 logger = wrap_logger(logging.getLogger(__name__))
 
@@ -55,6 +55,6 @@ def _validate_jwt_date(token):
         if datetime.now().timestamp() <= expires_in:
             return
 
-        raise Unauthorized(f"{JWT_DATE_EXPIRED} {token.get('party_id')}")
+        raise JWTTimeoutError(f"{JWT_DATE_EXPIRED} {token.get('party_id')}")
 
     raise JWTValidationError(f"{EXPIRES_IN_MISSING_FROM_PAYLOAD} {token.get('party_id')}")

--- a/frontstage/create_app.py
+++ b/frontstage/create_app.py
@@ -54,7 +54,8 @@ def create_app_object():
     app.jinja_env.filters["file_size_filter"] = file_size_filter
     app.jinja_env.filters["subject_filter"] = subject_filter
 
-    CSRFProtect(app)
+    csrf = CSRFProtect(app)
+    csrf.exempt("frontstage.views.session.session_refresh_expires_at")
 
     @app.after_request
     def apply_headers(response):

--- a/frontstage/error_handlers.py
+++ b/frontstage/error_handlers.py
@@ -1,6 +1,6 @@
 import logging
 
-from flask import flash, render_template, request, session, url_for
+from flask import flash, request, session, url_for
 from flask_wtf.csrf import CSRFError
 from requests.exceptions import ConnectionError
 from structlog import wrap_logger
@@ -15,6 +15,7 @@ from frontstage.exceptions.exceptions import (
     InvalidEqPayLoad,
     JWTValidationError,
 )
+from frontstage.views.template_helper import render_template
 
 logger = wrap_logger(logging.getLogger(__name__))
 

--- a/frontstage/exceptions/exceptions.py
+++ b/frontstage/exceptions/exceptions.py
@@ -46,6 +46,11 @@ class JWTValidationError(Exception):
         self.message = message
 
 
+class JWTTimeoutError(Exception):
+    def __init__(self, message):
+        self.message = message
+
+
 class MissingEnvironmentVariable(Exception):
     def __init__(self, app, logger):
         self.app = app

--- a/frontstage/templates/layouts/_base.html
+++ b/frontstage/templates/layouts/_base.html
@@ -75,11 +75,11 @@
 {% endblock %}
 
 {% block preFooter %}
-    {% if expires_at %}
+    {% if session_expires_at %}
         {{
             onsTimeoutModal ({
                 "showModalTimeInSeconds": 60,
-                "redirectUrl": url_for("sign_in_bp.logout"),
+                "redirectUrl": url_for("sign_in_bp.logout", sign_out_guidance=True),
                 "sessionExpiresAt": session_expires_at,
                 "serverSessionExpiryEndpoint": url_for("session.session_expires_at"),
                 "title": "You will be signed out soon",

--- a/frontstage/templates/layouts/_base.html
+++ b/frontstage/templates/layouts/_base.html
@@ -1,5 +1,6 @@
 {% extends "layout/_template.njk" %}
 {% from "components/cookies-banner/_macro.njk" import onsCookiesBanner %}
+{% from "components/timeout-modal/_macro.njk" import onsTimeoutModal %}
 
 {% block head %}
     {% set css_theme = "css"~_theme~"/theme.css" %}
@@ -71,4 +72,27 @@
 {% endblock pageContent -%}
 
 {% block bodyEnd %}
+{% endblock %}
+
+{% block preFooter %}
+    {% if expires_at %}
+        {{
+            onsTimeoutModal ({
+                "showModalTimeInSeconds": 60,
+                "redirectUrl": url_for("sign_in_bp.logout"),
+                "sessionExpiresAt": session_expires_at,
+                "serverSessionExpiryEndpoint": url_for("session.session_expires_at"),
+                "title": "You will be signed out soon",
+                "textFirstLine": "It appears you have been inactive for a while.",
+                "countdownText": "To protect your information, your progress will be saved and you will be signed out in",
+                "countdownExpiredText": "You are being signed out.",
+                "btnText": "Continue survey",
+                "minutesTextSingular": "minute",
+                "minutesTextPlural": "minutes",
+                "secondsTextSingular": "second",
+                "secondsTextPlural": "seconds",
+                "endWithFullStop": true
+            })
+        }}
+    {% endif %}
 {% endblock %}

--- a/frontstage/views/account/accept_share_survey.py
+++ b/frontstage/views/account/accept_share_survey.py
@@ -1,6 +1,6 @@
 import logging
 
-from flask import flash, render_template, request, url_for
+from flask import flash, request, url_for
 from structlog import wrap_logger
 from werkzeug.utils import redirect
 
@@ -10,6 +10,7 @@ from frontstage.controllers import party_controller, survey_controller
 from frontstage.controllers.party_controller import get_business_by_id
 from frontstage.exceptions.exceptions import ApiError
 from frontstage.views.account import account_bp
+from frontstage.views.template_helper import render_template
 
 logger = wrap_logger(logging.getLogger(__name__))
 
@@ -126,7 +127,7 @@ def accept_share_surveys_existing_account(session, batch):
         logger.error("Failed to confirm share survey for existing account", status=exc.status_code, batch_number=batch)
         raise exc
     logger.info("Successfully completed share survey for existing account", batch_number=batch)
-    return render_template("surveys/surveys-share/share-survey-complete-thank-you.html")
+    return render_template("surveys/surveys-share/share-survey-complete-thank-you.html", session=session)
 
 
 def _is_existing_account(respondent_email):

--- a/frontstage/views/account/accept_transfer_survey.py
+++ b/frontstage/views/account/accept_transfer_survey.py
@@ -1,6 +1,6 @@
 import logging
 
-from flask import flash, render_template, request, url_for
+from flask import flash, request, url_for
 from structlog import wrap_logger
 from werkzeug.utils import redirect
 
@@ -10,6 +10,7 @@ from frontstage.controllers import party_controller, survey_controller
 from frontstage.controllers.party_controller import get_business_by_id
 from frontstage.exceptions.exceptions import ApiError
 from frontstage.views.account import account_bp
+from frontstage.views.template_helper import render_template
 
 logger = wrap_logger(logging.getLogger(__name__))
 
@@ -131,7 +132,7 @@ def accept_transfer_surveys_existing_account(session, batch):
         )
         raise exc
     logger.info("Successfully completed transfer survey for existing account", batch_number=batch)
-    return render_template("surveys/surveys-transfer/transfer-survey-complete-thank-you.html")
+    return render_template("surveys/surveys-transfer/transfer-survey-complete-thank-you.html", session=session)
 
 
 def _is_existing_account(respondent_email):

--- a/frontstage/views/account/account.py
+++ b/frontstage/views/account/account.py
@@ -194,7 +194,7 @@ def something_else_post(session):
     sent_message = _send_new_message(subject, party_id, category="TECHNICAL")
     thread_url = url_for("secure_message_bp.view_conversation", thread_id=sent_message["thread_id"]) + "#latest-message"
     flash(Markup(f"Message sent. <a href={thread_url}>View Message</a>"))
-    return redirect(url_for("surveys_bp.get_survey_list", session=session, tag="todo"))
+    return redirect(url_for("surveys_bp.get_survey_list", tag="todo"))
 
 
 def check_attribute_change(form, attributes_changed, respondent_details, update_required_flag):

--- a/frontstage/views/account/account.py
+++ b/frontstage/views/account/account.py
@@ -1,7 +1,7 @@
 import json
 import logging
 
-from flask import flash, render_template, request, url_for
+from flask import flash, request, url_for
 from markupsafe import Markup
 from structlog import wrap_logger
 from werkzeug.utils import redirect
@@ -22,6 +22,7 @@ from frontstage.models import (
     SecureMessagingForm,
 )
 from frontstage.views.account import account_bp
+from frontstage.views.template_helper import render_template
 
 logger = wrap_logger(logging.getLogger(__name__))
 
@@ -99,7 +100,7 @@ def change_password(session):
     else:
         errors = form.errors
 
-    return render_template("account/account-change-password.html", form=form, errors=errors)
+    return render_template("account/account-change-password.html", session=session, form=form, errors=errors)
 
 
 @account_bp.route("/change-account-email-address", methods=["POST"])
@@ -123,7 +124,7 @@ def change_email_address(session):
         else:
             raise exc
     logger.info("Successfully updated email on account", party_id=party_id)
-    return render_template("account/account-change-email-address-almost-done.html")
+    return render_template("account/account-change-email-address-almost-done.html", session=session)
 
 
 @account_bp.route("/change-account-details", methods=["GET", "POST"])
@@ -161,6 +162,7 @@ def change_account_details(session):
     else:
         return render_template(
             "account/account-contact-detail-change.html",
+            session=session,
             form=form,
             errors=form.errors,
             respondent=respondent_details,
@@ -169,10 +171,11 @@ def change_account_details(session):
 
 @account_bp.route("/something-else", methods=["GET"])
 @jwt_authorization(request)
-def something_else(_):
+def something_else(session):
     """Gets the something else once the option is selected"""
     return render_template(
         "account/account-something-else.html",
+        session=session,
         form=SecureMessagingForm(),
     )
 
@@ -191,7 +194,7 @@ def something_else_post(session):
     sent_message = _send_new_message(subject, party_id, category="TECHNICAL")
     thread_url = url_for("secure_message_bp.view_conversation", thread_id=sent_message["thread_id"]) + "#latest-message"
     flash(Markup(f"Message sent. <a href={thread_url}>View Message</a>"))
-    return redirect(url_for("surveys_bp.get_survey_list", tag="todo"))
+    return redirect(url_for("surveys_bp.get_survey_list", session=session, tag="todo"))
 
 
 def check_attribute_change(form, attributes_changed, respondent_details, update_required_flag):

--- a/frontstage/views/account/account_delete.py
+++ b/frontstage/views/account/account_delete.py
@@ -1,6 +1,6 @@
 import logging
 
-from flask import flash, render_template, request, url_for
+from flask import flash, request, url_for
 from structlog import wrap_logger
 from werkzeug.utils import redirect
 
@@ -8,6 +8,7 @@ from frontstage.common.authorisation import jwt_authorization
 from frontstage.controllers import party_controller
 from frontstage.controllers.auth_controller import delete_account
 from frontstage.views.account import account_bp
+from frontstage.views.template_helper import render_template
 
 logger = wrap_logger(logging.getLogger(__name__))
 
@@ -27,4 +28,4 @@ def delete_user_account(session):
         delete_account(respondent_details["emailAddress"])
         return redirect(url_for("sign_in_bp.logout"))
 
-    return render_template("account/account-delete.html", is_validated=True)
+    return render_template("account/account-delete.html", session=session, is_validated=True)

--- a/frontstage/views/account/account_email_change.py
+++ b/frontstage/views/account/account_email_change.py
@@ -1,6 +1,6 @@
 import logging
 
-from flask import abort, render_template, request
+from flask import abort, request
 from structlog import wrap_logger
 
 from frontstage.common.authorisation import jwt_authorization
@@ -8,6 +8,7 @@ from frontstage.common.session import Session
 from frontstage.controllers import party_controller
 from frontstage.exceptions.exceptions import ApiError
 from frontstage.views.account import account_bp
+from frontstage.views.template_helper import render_template
 
 logger = wrap_logger(logging.getLogger(__name__))
 
@@ -60,4 +61,4 @@ def confirm_account_email_change(token):
 def resend_account_email_change_expired_token(session, token):
     party_controller.resend_account_email_change_expired_token(token)
     logger.info("Re-sent verification email for account email change expired token.", token=token)
-    return render_template("sign-in/sign-in.verification-email-sent.html")
+    return render_template("sign-in/sign-in.verification-email-sent.html", session=session)

--- a/frontstage/views/account/account_survey_share.py
+++ b/frontstage/views/account/account_survey_share.py
@@ -1,7 +1,7 @@
 import json
 import logging
 
-from flask import flash, render_template, request
+from flask import flash, request
 from flask import session as flask_session
 from flask import url_for
 from structlog import wrap_logger
@@ -24,13 +24,14 @@ from frontstage.models import (
     ConfirmEmailChangeForm,
 )
 from frontstage.views.account import account_bp
+from frontstage.views.template_helper import render_template
 
 logger = wrap_logger(logging.getLogger(__name__))
 
 
 @account_bp.route("/share-surveys", methods=["GET"])
 @jwt_authorization(request)
-def share_survey_overview(_):
+def share_survey_overview(session):
     # 'share_survey_data' holds business and surveys selected for share
     flask_session.pop("share_survey_data", None)
     # 'share_survey_recipient_email_address' holds the recipient email address
@@ -40,7 +41,7 @@ def share_survey_overview(_):
     flask_session.pop("validation_failure_share_surveys_list", None)
     # 'share_surveys_selected_list' holds list of surveys selected by user so that its checked in case of any error
     flask_session.pop("share_surveys_selected_list", None)
-    return render_template("surveys/surveys-share/overview.html")
+    return render_template("surveys/surveys-share/overview.html", session=session)
 
 
 @account_bp.route("/share-surveys/business-selection", methods=["GET"])
@@ -52,7 +53,9 @@ def share_survey_business_select(session):
     form = AccountSurveySelectBusinessForm(request.values)
     party_id = session.get_party_id()
     businesses = get_list_of_business_for_party(party_id)
-    return render_template("surveys/surveys-share/business-select.html", businesses=businesses, form=form)
+    return render_template(
+        "surveys/surveys-share/business-select.html", session=session, businesses=businesses, form=form
+    )
 
 
 @account_bp.route("/share-surveys/business-selection", methods=["POST"])
@@ -84,6 +87,7 @@ def share_survey_survey_select(session):
     selected_survey_list = flask_session.get("share_surveys_selected_list")
     return render_template(
         "surveys/surveys-share/survey-select.html",
+        session=session,
         share_dict=share_dict,
         error=error,
         failed_surveys_list=failed_surveys_list if failed_surveys_list is not None else [],

--- a/frontstage/views/account/account_transfer_survey.py
+++ b/frontstage/views/account/account_transfer_survey.py
@@ -1,7 +1,7 @@
 import json
 import logging
 
-from flask import flash, render_template, request
+from flask import flash, request
 from flask import session as flask_session
 from flask import url_for
 from structlog import wrap_logger
@@ -24,13 +24,14 @@ from frontstage.models import (
     ConfirmEmailChangeForm,
 )
 from frontstage.views.account import account_bp
+from frontstage.views.template_helper import render_template
 
 logger = wrap_logger(logging.getLogger(__name__))
 
 
 @account_bp.route("/transfer-surveys", methods=["GET"])
 @jwt_authorization(request)
-def transfer_survey_overview(_):
+def transfer_survey_overview(session):
     # 'transfer_survey_data' holds business and surveys selected for share
     flask_session.pop("transfer_survey_data", None)
     # 'transfer_survey_recipient_email_address' holds the recipient email address
@@ -40,7 +41,7 @@ def transfer_survey_overview(_):
     flask_session.pop("validation_failure_transfer_surveys_list", None)
     # 'transfer_surveys_selected_list' holds list of surveys selected by user so that its checked in case of any error
     flask_session.pop("transfer_surveys_selected_list", None)
-    return render_template("surveys/surveys-transfer/overview.html")
+    return render_template("surveys/surveys-transfer/overview.html", session=session)
 
 
 @account_bp.route("/transfer-surveys/business-selection", methods=["GET"])
@@ -54,6 +55,7 @@ def transfer_survey_business_select(session):
     businesses = get_list_of_business_for_party(party_id)
     return render_template(
         "surveys/surveys-transfer/business-select.html",
+        session=session,
         businesses=businesses,
         form=form,
     )
@@ -61,7 +63,7 @@ def transfer_survey_business_select(session):
 
 @account_bp.route("/transfer-surveys/business-selection", methods=["POST"])
 @jwt_authorization(request)
-def transfer_survey_post_business_select(_):
+def transfer_survey_post_business_select(session):
     flask_session.pop("transfer_survey_data", None)
     transfer_survey_business_selected = request.form.getlist("checkbox-answer")
     if len(transfer_survey_business_selected) == 0:
@@ -88,6 +90,7 @@ def transfer_survey_survey_select(session):
     selected_survey_list = flask_session.get("transfer_surveys_selected_list")
     return render_template(
         "surveys/surveys-transfer/survey-select.html",
+        session=session,
         transfer_dict=transfer_dict,
         error=error,
         failed_surveys_list=failed_surveys_list if failed_surveys_list is not None else [],
@@ -184,7 +187,7 @@ def is_max_transfer_survey_exceeded(selected_businesses, form):
 
 @account_bp.route("/transfer-surveys/survey-selection", methods=["POST"])
 @jwt_authorization(request)
-def transfer_survey_post_survey_select(_):
+def transfer_survey_post_survey_select(session):
     share_dictionary_copy = flask_session["transfer_survey_data"]
     flask_session.pop("validation_failure_transfer_surveys_list", None)
     selected_businesses = get_selected_businesses()
@@ -210,10 +213,12 @@ def transfer_survey_post_survey_select(_):
 
 @account_bp.route("/transfer-surveys/recipient-email-address", methods=["GET"])
 @jwt_authorization(request)
-def transfer_survey_email_entry(_):
+def transfer_survey_email_entry(session):
     form = AccountSurveyShareRecipientEmailForm(request.values)
     flask_session["transfer_survey_recipient_email_address"] = None
-    return render_template("surveys/surveys-transfer/recipient-email-address.html", form=form, errors=form.errors)
+    return render_template(
+        "surveys/surveys-transfer/recipient-email-address.html", session=session, form=form, errors=form.errors
+    )
 
 
 @account_bp.route("/transfer-surveys/recipient-email-address", methods=["POST"])
@@ -224,19 +229,23 @@ def transfer_survey_post_email_entry(session):
     respondent_details = party_controller.get_respondent_party_by_id(party_id)
     if not form.validate():
         errors = form.errors
-        return render_template("surveys/surveys-transfer/recipient-email-address.html", form=form, errors=errors)
+        return render_template(
+            "surveys/surveys-transfer/recipient-email-address.html", session=session, form=form, errors=errors
+        )
 
     if "emailAddress" in respondent_details:
         if respondent_details["emailAddress"].lower() == form.data["email_address"].lower():
             errors = {"email_address": ["You can not transfer surveys to yourself."]}
-            return render_template("surveys/surveys-transfer/recipient-email-address.html", form=form, errors=errors)
+            return render_template(
+                "surveys/surveys-transfer/recipient-email-address.html", session=session, form=form, errors=errors
+            )
     flask_session["transfer_survey_recipient_email_address"] = form.data["email_address"]
     return redirect(url_for("account_bp.send_transfer_instruction_get"))
 
 
 @account_bp.route("/transfer-surveys/send-instruction", methods=["GET"])
 @jwt_authorization(request)
-def send_transfer_instruction_get(_):
+def send_transfer_instruction_get(session):
     email = flask_session["transfer_survey_recipient_email_address"]
     share_dict = {}
     for business_id in flask_session["transfer_survey_data"]:
@@ -250,6 +259,7 @@ def send_transfer_instruction_get(_):
         }
     return render_template(
         "surveys/surveys-transfer/send-instructions.html",
+        session=session,
         email=email,
         share_dict=share_dict,
         form=ConfirmEmailChangeForm(),
@@ -309,14 +319,12 @@ def send_transfer_instruction(session):
             "contact us.",
         )
         return redirect(url_for("account_bp.send_transfer_instruction_get"))
-    return render_template(
-        "surveys/surveys-transfer/almost-done.html",
-    )
+    return render_template("surveys/surveys-transfer/almost-done.html", session=session)
 
 
 @account_bp.route("/transfer-surveys/done", methods=["GET"])
 @jwt_authorization(request)
-def transfer_survey_done(_):
+def transfer_survey_done(session):
     flask_session.pop("share", None)
     flask_session.pop("transfer_survey_recipient_email_address", None)
-    return redirect(url_for("surveys_bp.get_survey_list", tag="todo"))
+    return redirect(url_for("surveys_bp.get_survey_list", session=session, tag="todo"))

--- a/frontstage/views/account/account_transfer_survey.py
+++ b/frontstage/views/account/account_transfer_survey.py
@@ -187,7 +187,7 @@ def is_max_transfer_survey_exceeded(selected_businesses, form):
 
 @account_bp.route("/transfer-surveys/survey-selection", methods=["POST"])
 @jwt_authorization(request)
-def transfer_survey_post_survey_select(session):
+def transfer_survey_post_survey_select(_):
     share_dictionary_copy = flask_session["transfer_survey_data"]
     flask_session.pop("validation_failure_transfer_surveys_list", None)
     selected_businesses = get_selected_businesses()
@@ -327,4 +327,4 @@ def send_transfer_instruction(session):
 def transfer_survey_done(session):
     flask_session.pop("share", None)
     flask_session.pop("transfer_survey_recipient_email_address", None)
-    return redirect(url_for("surveys_bp.get_survey_list", session=session, tag="todo"))
+    return redirect(url_for("surveys_bp.get_survey_list", tag="todo"))

--- a/frontstage/views/contact_us.py
+++ b/frontstage/views/contact_us.py
@@ -1,7 +1,9 @@
 import logging
 
-from flask import Blueprint, render_template
+from flask import Blueprint
 from structlog import wrap_logger
+
+from frontstage.views.template_helper import render_template
 
 logger = wrap_logger(logging.getLogger(__name__))
 

--- a/frontstage/views/cookies.py
+++ b/frontstage/views/cookies.py
@@ -1,7 +1,9 @@
 import logging
 
-from flask import Blueprint, render_template
+from flask import Blueprint
 from structlog import wrap_logger
+
+from frontstage.views.template_helper import render_template
 
 logger = wrap_logger(logging.getLogger(__name__))
 

--- a/frontstage/views/help.py
+++ b/frontstage/views/help.py
@@ -1,10 +1,11 @@
 import logging
 
-from flask import Blueprint, flash, render_template, request, url_for
+from flask import Blueprint, flash, request, url_for
 from structlog import wrap_logger
 from werkzeug.utils import redirect
 
 from frontstage.models import HelpForm, HelpInfoOnsForm, HelpPasswordForm
+from frontstage.views.template_helper import render_template
 
 logger = wrap_logger(logging.getLogger(__name__))
 

--- a/frontstage/views/passwords/forgot_password.py
+++ b/frontstage/views/passwords/forgot_password.py
@@ -1,12 +1,13 @@
 import logging
 
-from flask import abort, redirect, render_template, request, url_for
+from flask import abort, redirect, request, url_for
 from itsdangerous import BadSignature, URLSafeSerializer
 from structlog import wrap_logger
 
 from frontstage import app
 from frontstage.models import ForgotPasswordForm
 from frontstage.views.passwords import passwords_bp, reset_password
+from frontstage.views.template_helper import render_template
 
 logger = wrap_logger(logging.getLogger(__name__))
 

--- a/frontstage/views/passwords/reset_password.py
+++ b/frontstage/views/passwords/reset_password.py
@@ -2,7 +2,7 @@ import logging
 
 from flask import abort
 from flask import current_app as app
-from flask import flash, redirect, render_template, request, url_for
+from flask import flash, redirect, request, url_for
 from itsdangerous import BadData, BadSignature, SignatureExpired
 from structlog import wrap_logger
 from werkzeug.exceptions import NotFound
@@ -13,6 +13,7 @@ from frontstage.controllers.notify_controller import NotifyGateway
 from frontstage.exceptions.exceptions import ApiError, RasNotifyError
 from frontstage.models import ResetPasswordForm
 from frontstage.views.passwords import passwords_bp
+from frontstage.views.template_helper import render_template
 
 logger = wrap_logger(logging.getLogger(__name__))
 

--- a/frontstage/views/privacy.py
+++ b/frontstage/views/privacy.py
@@ -1,7 +1,9 @@
 import logging
 
-from flask import Blueprint, render_template
+from flask import Blueprint
 from structlog import wrap_logger
+
+from frontstage.views.template_helper import render_template
 
 logger = wrap_logger(logging.getLogger(__name__))
 

--- a/frontstage/views/register/activate_account.py
+++ b/frontstage/views/register/activate_account.py
@@ -1,12 +1,13 @@
 import logging
 from os import getenv
 
-from flask import abort, redirect, render_template, url_for
+from flask import abort, redirect, url_for
 from structlog import wrap_logger
 
 from frontstage.controllers import party_controller
 from frontstage.exceptions.exceptions import ApiError
 from frontstage.views.register import register_bp
+from frontstage.views.template_helper import render_template
 
 logger = wrap_logger(logging.getLogger(__name__))
 

--- a/frontstage/views/register/check_email.py
+++ b/frontstage/views/register/check_email.py
@@ -1,6 +1,5 @@
-from flask import render_template
-
 from frontstage.views.register import register_bp
+from frontstage.views.template_helper import render_template
 
 
 @register_bp.route("/create-account/check-email")

--- a/frontstage/views/register/confirm_organisation_survey.py
+++ b/frontstage/views/register/confirm_organisation_survey.py
@@ -1,7 +1,7 @@
 import logging
 
 from flask import current_app as app
-from flask import render_template, request
+from flask import request
 from structlog import wrap_logger
 
 from frontstage.common.cryptographer import Cryptographer
@@ -14,6 +14,7 @@ from frontstage.controllers import (
 )
 from frontstage.exceptions.exceptions import ApiError
 from frontstage.views.register import register_bp
+from frontstage.views.template_helper import render_template
 
 logger = wrap_logger(logging.getLogger(__name__))
 

--- a/frontstage/views/register/create_account.py
+++ b/frontstage/views/register/create_account.py
@@ -1,7 +1,7 @@
 import logging
 import os
 
-from flask import redirect, render_template, request, url_for
+from flask import redirect, request, url_for
 from structlog import wrap_logger
 
 from frontstage.common.cryptographer import Cryptographer
@@ -9,6 +9,7 @@ from frontstage.controllers import case_controller, iac_controller
 from frontstage.exceptions.exceptions import ApiError
 from frontstage.models import EnrolmentCodeForm
 from frontstage.views.register import register_bp
+from frontstage.views.template_helper import render_template
 
 logger = wrap_logger(logging.getLogger(__name__))
 

--- a/frontstage/views/register/enter_account_details.py
+++ b/frontstage/views/register/enter_account_details.py
@@ -1,7 +1,7 @@
 import logging
 from distutils.util import strtobool
 
-from flask import flash, render_template, request
+from flask import flash, request
 from structlog import wrap_logger
 
 from frontstage.common.cryptographer import Cryptographer
@@ -10,6 +10,7 @@ from frontstage.controllers import iac_controller, party_controller
 from frontstage.exceptions.exceptions import ApiError
 from frontstage.models import PendingSurveyRegistrationForm, RegistrationForm
 from frontstage.views.register import register_bp
+from frontstage.views.template_helper import render_template
 
 logger = wrap_logger(logging.getLogger(__name__))
 cryptographer = Cryptographer()

--- a/frontstage/views/secure_messaging/create_message.py
+++ b/frontstage/views/secure_messaging/create_message.py
@@ -1,13 +1,14 @@
 import json
 import logging
 
-from flask import Markup, flash, redirect, render_template, request, url_for
+from flask import Markup, flash, redirect, request, url_for
 from structlog import wrap_logger
 
 from frontstage.common.authorisation import jwt_authorization
 from frontstage.controllers import conversation_controller
 from frontstage.models import SecureMessagingForm
 from frontstage.views.secure_messaging import secure_message_bp
+from frontstage.views.template_helper import render_template
 
 logger = wrap_logger(logging.getLogger(__name__))
 
@@ -33,6 +34,7 @@ def create_message(session):
         unread_message_count = {"unread_message_count": conversation_controller.try_message_count_from_session(session)}
         return render_template(
             "secure-messages/secure-messages-view.html",
+            session=session,
             ru_ref=ru_ref,
             survey_id=survey_id,
             form=form,

--- a/frontstage/views/secure_messaging/message_get.py
+++ b/frontstage/views/secure_messaging/message_get.py
@@ -1,7 +1,7 @@
 import logging
 from distutils.util import strtobool
 
-from flask import Markup, flash, json, redirect, render_template, request, url_for
+from flask import Markup, flash, json, redirect, request, url_for
 from structlog import wrap_logger
 
 from frontstage import app
@@ -19,6 +19,7 @@ from frontstage.controllers.survey_controller import get_survey
 from frontstage.exceptions.exceptions import ApiError
 from frontstage.models import SecureMessagingForm
 from frontstage.views.secure_messaging import secure_message_bp
+from frontstage.views.template_helper import render_template
 
 logger = wrap_logger(logging.getLogger(__name__))
 
@@ -83,6 +84,7 @@ def view_conversation(session, thread_id):
 
     return render_template(
         "secure-messages/conversation-view.html",
+        session=session,
         form=form,
         conversation=refined_conversation,
         conversation_data=conversation,
@@ -112,6 +114,7 @@ def view_conversation_list(session):
     unread_message_count = {"unread_message_count": try_message_count_from_session(session)}
     return render_template(
         "secure-messages/conversation-list.html",
+        session=session,
         messages=refined_conversation,
         is_closed=strtobool(is_closed),
         unread_message_count=unread_message_count,

--- a/frontstage/views/session.py
+++ b/frontstage/views/session.py
@@ -7,11 +7,11 @@ session_bp = Blueprint("session", __name__)
 
 @session_bp.route("/expires-at", methods=["GET"])
 @jwt_authorization(request, refresh_session=False)
-def session_expires_at(expires_at):
-    return jsonify(expires_at=expires_at.get_formatted_expires_in())
+def session_expires_at(session):
+    return jsonify(expires_at=session.get_formatted_expires_in())
 
 
 @session_bp.route("/expires-at", methods=["PATCH"])
 @jwt_authorization(request)
-def session_refresh_expires_at(expires_at):
-    return jsonify(expires_at=expires_at.get_formatted_expires_in())
+def session_refresh_expires_at(session):
+    return jsonify(expires_at=session.get_formatted_expires_in())

--- a/frontstage/views/sign_in/logout.py
+++ b/frontstage/views/sign_in/logout.py
@@ -8,6 +8,8 @@ from frontstage.views.sign_in import sign_in_bp
 
 logger = wrap_logger(logging.getLogger(__name__))
 
+SIGN_OUT_GUIDANCE = "To help protect your information we have signed you out."
+
 
 @sign_in_bp.route("/logout")
 def logout():
@@ -19,8 +21,8 @@ def logout():
     if len(flashed_messages) > 0:
         for category, message in flashed_messages:
             flash(message=message, category=category)
-    if request.args.get("csrf_error"):
-        flash("To help protect your information we have signed you out.", "info")
+    if request.args.get("sign_out_guidance"):
+        flash(SIGN_OUT_GUIDANCE, "info")
     # Delete session cookie
     response = make_response(redirect(url_for("sign_in_bp.login", next=request.args.get("next"))))
     response.delete_cookie("authorization")

--- a/frontstage/views/sign_in/sign_in.py
+++ b/frontstage/views/sign_in/sign_in.py
@@ -1,7 +1,7 @@
 import logging
 from os import getenv
 
-from flask import make_response, redirect, render_template, request, session, url_for
+from flask import make_response, redirect, request, session, url_for
 from structlog import wrap_logger
 
 from frontstage import app
@@ -18,6 +18,7 @@ from frontstage.controllers.party_controller import (
 from frontstage.exceptions.exceptions import AuthError
 from frontstage.models import LoginForm
 from frontstage.views.sign_in import sign_in_bp
+from frontstage.views.template_helper import render_template
 
 logger = wrap_logger(logging.getLogger(__name__))
 

--- a/frontstage/views/surveys/access_survey.py
+++ b/frontstage/views/surveys/access_survey.py
@@ -1,6 +1,6 @@
 import logging
 
-from flask import redirect, render_template, request
+from flask import redirect, request
 from structlog import wrap_logger
 
 from frontstage.common.authorisation import jwt_authorization
@@ -10,6 +10,7 @@ from frontstage.controllers import (
     conversation_controller,
 )
 from frontstage.views.surveys import surveys_bp
+from frontstage.views.template_helper import render_template
 
 logger = wrap_logger(logging.getLogger(__name__))
 
@@ -41,6 +42,7 @@ def access_survey(session):
     unread_message_count = {"unread_message_count": conversation_controller.try_message_count_from_session(session)}
     return render_template(
         "surveys/surveys-access.html",
+        session=session,
         case_id=case_id,
         collection_instrument_id=case_data["collection_instrument"]["id"],
         collection_instrument_size=case_data["collection_instrument"]["len"],

--- a/frontstage/views/surveys/add_survey.py
+++ b/frontstage/views/surveys/add_survey.py
@@ -1,7 +1,7 @@
 import logging
 from os import getenv
 
-from flask import redirect, render_template, request, url_for
+from flask import redirect, request, url_for
 from structlog import wrap_logger
 
 from frontstage.common.authorisation import jwt_authorization
@@ -10,13 +10,14 @@ from frontstage.controllers import iac_controller
 from frontstage.exceptions.exceptions import ApiError
 from frontstage.models import EnrolmentCodeForm
 from frontstage.views.surveys import surveys_bp
+from frontstage.views.template_helper import render_template
 
 logger = wrap_logger(logging.getLogger(__name__))
 
 
 @surveys_bp.route("/add-survey", methods=["GET", "POST"])
 @jwt_authorization(request)
-def add_survey(_):
+def add_survey(session):
     form = EnrolmentCodeForm(request.form)
 
     if request.method == "POST" and form.validate():
@@ -83,6 +84,6 @@ def add_survey(_):
     elif request.method == "POST" and not form.validate():
         logger.info("Invalid character length, must be 12 characters")
         template_data = {"error": {"type": "failed"}}
-        return render_template("surveys/surveys-add.html", form=form, data=template_data)
+        return render_template("surveys/surveys-add.html", session=session, form=form, data=template_data)
 
-    return render_template("surveys/surveys-add.html", form=form, data={"error": {}})
+    return render_template("surveys/surveys-add.html", session=session, form=form, data={"error": {}})

--- a/frontstage/views/surveys/add_survey_confirm_organisation_survey.py
+++ b/frontstage/views/surveys/add_survey_confirm_organisation_survey.py
@@ -1,7 +1,7 @@
 import logging
 
 from flask import current_app as app
-from flask import render_template, request
+from flask import request
 from structlog import wrap_logger
 
 from frontstage.common.authorisation import jwt_authorization
@@ -15,13 +15,14 @@ from frontstage.controllers import (
 )
 from frontstage.exceptions.exceptions import ApiError
 from frontstage.views.surveys import surveys_bp
+from frontstage.views.template_helper import render_template
 
 logger = wrap_logger(logging.getLogger(__name__))
 
 
 @surveys_bp.route("/add-survey/confirm-organisation-survey", methods=["GET"])
 @jwt_authorization(request)
-def survey_confirm_organisation(_):
+def survey_confirm_organisation(session):
     # Get and decrypt enrolment code
     cryptographer = Cryptographer()
     encrypted_enrolment_code = request.args.get("encrypted_enrolment_code", None)
@@ -76,5 +77,6 @@ def survey_confirm_organisation(_):
 
     return render_template(
         "surveys/surveys-confirm-organisation.html",
+        session=session,
         context=business_context,
     )

--- a/frontstage/views/surveys/add_survey_submit.py
+++ b/frontstage/views/surveys/add_survey_submit.py
@@ -89,6 +89,7 @@ def add_survey_submit(session):
     return redirect(
         url_for(
             "surveys_bp.get_survey_list",
+            session=session,
             _external=True,
             business_party_id=business_party_id,
             survey_id=added_survey_id,

--- a/frontstage/views/surveys/help/surveys_help.py
+++ b/frontstage/views/surveys/help/surveys_help.py
@@ -1,7 +1,7 @@
 import json
 import logging
 
-from flask import abort, flash, render_template, request
+from flask import abort, flash, request
 from flask import session as flask_session
 from flask import url_for
 from markupsafe import Markup
@@ -23,6 +23,7 @@ from frontstage.models import (
     SecureMessagingForm,
 )
 from frontstage.views.surveys import surveys_bp
+from frontstage.views.template_helper import render_template
 
 logger = wrap_logger(logging.getLogger(__name__))
 help_completing_this_survey_title = "Help completing this survey"
@@ -117,7 +118,7 @@ breadcrumb_text_mapping = {
 
 @surveys_bp.route("/surveys-help", methods=["GET"])
 @jwt_authorization(request)
-def get_surveys_help_page(_):
+def get_surveys_help_page(session):
     """Gets Survey Help page provided survey_ref and ru_ref and creates flash session for selection"""
     flask_session["help_survey_ref"] = request.args.get("survey_ref", None)
     flask_session["help_ru_ref"] = request.args.get("ru_ref", None)
@@ -131,7 +132,7 @@ def get_surveys_help_page(_):
 
 @surveys_bp.route("/help", methods=["GET", "POST"])
 @jwt_authorization(request)
-def help_page(_):
+def help_page(session):
     """Get survey help page provided survey_ref and ru_ref are in session and post help completing this survey option
     for respective survey"""
     abort_help_if_session_not_set()
@@ -150,6 +151,7 @@ def help_page(_):
 
     return render_template(
         "surveys/help/surveys-help.html",
+        session=session,
         form=HelpOptionsForm(),
         short_name=short_name,
         survey_name=survey["longName"],
@@ -215,6 +217,7 @@ def help_option_select(session, option: str):
 
     return render_template(
         template,
+        session=session,
         short_name=short_name,
         business_id=business_id,
         option=option,
@@ -239,6 +242,7 @@ def get_help_option_sub_option_select(session, option, sub_option):
     else:
         return render_template(
             template,
+            session=session,
             short_name=short_name,
             option=option,
             sub_option=sub_option,
@@ -287,6 +291,7 @@ def send_help_message(session, option, sub_option):
 
     return render_template(
         "secure-messages/help/secure-message-send-messages-view.html",
+        session=session,
         short_name=short_name,
         option=option,
         sub_option=sub_option,

--- a/frontstage/views/surveys/help/technical_help.py
+++ b/frontstage/views/surveys/help/technical_help.py
@@ -1,7 +1,7 @@
 import json
 import logging
 
-from flask import flash, render_template, request, url_for
+from flask import flash, request, url_for
 from markupsafe import Markup
 from structlog import wrap_logger
 from werkzeug.utils import redirect
@@ -10,6 +10,7 @@ from frontstage.common.authorisation import jwt_authorization
 from frontstage.controllers import conversation_controller
 from frontstage.models import SecureMessagingForm
 from frontstage.views.surveys import surveys_bp
+from frontstage.views.template_helper import render_template
 
 logger = wrap_logger(logging.getLogger(__name__))
 
@@ -29,18 +30,19 @@ breadcrumb_text_mapping = {
 @jwt_authorization(request)
 def get_technical_message_page_option(session, option):
     template = option_template_url_mapping.get(option, "Invalid template")
-    return render_template(template, option=option)
+    return render_template(template, session=session, option=option)
 
 
 @surveys_bp.route("/technical/send-message", methods=["GET"])
 @jwt_authorization(request)
-def get_send_help_technical_message_page(_):
+def get_send_help_technical_message_page(session):
     """Gets the send message page"""
     option = request.args.get("option", None)
     subject = subject_text_mapping.get(option, None)
     breadcrumbs = breadcrumb_text_mapping.get(option, None)
     return render_template(
         "secure-messages/help/secure-message-send-technical-messages-view.html",
+        session=session,
         option=option,
         subject=subject,
         breadcrumbs=breadcrumbs,

--- a/frontstage/views/surveys/surveys_list.py
+++ b/frontstage/views/surveys/surveys_list.py
@@ -1,13 +1,14 @@
 import logging
 from datetime import datetime
 
-from flask import make_response, render_template, request
+from flask import make_response, request
 from flask import session as flask_session
 from structlog import wrap_logger
 
 from frontstage.common.authorisation import jwt_authorization
 from frontstage.controllers import conversation_controller, party_controller
 from frontstage.views.surveys import surveys_bp
+from frontstage.views.template_helper import render_template
 
 logger = wrap_logger(logging.getLogger(__name__))
 
@@ -58,6 +59,7 @@ def get_survey_list(session, tag):
         response = make_response(
             render_template(
                 "surveys/surveys-todo.html",
+                session=session,
                 sorted_surveys_list=sorted_survey_list,
                 added_survey=added_survey,
                 already_enrolled=already_enrolled,
@@ -73,6 +75,7 @@ def get_survey_list(session, tag):
     else:
         return render_template(
             "surveys/surveys-history.html",
+            session=session,
             sorted_surveys_list=sorted_survey_list,
             history=True,
             unread_message_count=unread_message_count,

--- a/frontstage/views/surveys/upload_survey.py
+++ b/frontstage/views/surveys/upload_survey.py
@@ -1,6 +1,6 @@
 import logging
 
-from flask import redirect, render_template, request, url_for
+from flask import redirect, request, url_for
 from structlog import wrap_logger
 
 from frontstage import app
@@ -14,6 +14,7 @@ from frontstage.controllers import (
 )
 from frontstage.exceptions.exceptions import CiUploadError, NoSurveyPermission
 from frontstage.views.surveys import surveys_bp
+from frontstage.views.template_helper import render_template
 
 logger = wrap_logger(logging.getLogger(__name__))
 
@@ -89,6 +90,7 @@ def upload_survey(session):
     unread_message_count = {"unread_message_count": conversation_controller.try_message_count_from_session(session)}
     return render_template(
         "surveys/surveys-upload-success.html",
+        session=session,
         upload_filename=upload_file.filename,
         unread_message_count=unread_message_count,
     )

--- a/frontstage/views/surveys/upload_survey_failed.py
+++ b/frontstage/views/surveys/upload_survey_failed.py
@@ -1,11 +1,12 @@
 import logging
 
-from flask import render_template, request
+from flask import request
 from structlog import wrap_logger
 
 from frontstage.common.authorisation import jwt_authorization
 from frontstage.controllers import case_controller, conversation_controller
 from frontstage.views.surveys import surveys_bp
+from frontstage.views.template_helper import render_template
 
 logger = wrap_logger(logging.getLogger(__name__))
 
@@ -47,6 +48,7 @@ def upload_failed(session):
     unread_message_count = {"unread_message_count": conversation_controller.try_message_count_from_session(session)}
     return render_template(
         "surveys/surveys-upload-failure.html",
+        session=session,
         business_info=case_data["business_party"],
         survey_info=case_data["survey"],
         collection_exercise_info=case_data["collection_exercise"],

--- a/frontstage/views/template_helper.py
+++ b/frontstage/views/template_helper.py
@@ -1,6 +1,10 @@
+from typing import Any
+
 from flask import render_template as flask_render_template
 
+from frontstage.common.session import Session
 
-def render_template(template: str, session=None, **kwargs) -> str:
+
+def render_template(template: str, session: Session = None, **kwargs: Any) -> str:
     session_expires_at = session.get_formatted_expires_in() if session else None
     return flask_render_template(template, session_expires_at=session_expires_at, **kwargs)

--- a/frontstage/views/template_helper.py
+++ b/frontstage/views/template_helper.py
@@ -1,0 +1,6 @@
+from flask import render_template as flask_render_template
+
+
+def render_template(template: str, session=None, **kwargs) -> str:
+    session_expires_at = session.get_formatted_expires_in() if session else None
+    return flask_render_template(template, session_expires_at=session_expires_at, **kwargs)

--- a/tests/integration/test_jwt_authorization.py
+++ b/tests/integration/test_jwt_authorization.py
@@ -13,7 +13,7 @@ from frontstage.common.authorisation import (
     jwt_authorization,
 )
 from frontstage.common.session import Session
-from frontstage.exceptions.exceptions import JWTValidationError
+from frontstage.exceptions.exceptions import JWTTimeoutError, JWTValidationError
 
 valid_jwt = (
     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXJ0eV9pZCI6InRlc3QiLCJyb2xlIjoicmVzcG9uZGVudCIsInVucmVhZF9"
@@ -90,9 +90,9 @@ class TestJWTAuthorization(unittest.TestCase):
 
         # When the jwt_authorization decorator is exercised
         # Then the function raises an Unauthorized, JWT_DATE_EXPIRED exception
-        with self.assertRaises(Unauthorized) as e:
+        with self.assertRaises(JWTTimeoutError) as e:
             self.decorator_test(request)
-        self.assertEqual(e.exception.description, f"{JWT_DATE_EXPIRED} {self.party_id}")
+        self.assertEqual(e.exception.message, f"{JWT_DATE_EXPIRED} {self.party_id}")
 
     def test_jwt_authorization_no_expiry_in_payload(self):
         # Given a valid authorization cookie, but invalid JWT where the expiry_in key is missing from the payload

--- a/tests/integration/test_sign_in.py
+++ b/tests/integration/test_sign_in.py
@@ -11,6 +11,7 @@ from frontstage.controllers.party_controller import (
     notify_party_and_respondent_account_locked,
 )
 from frontstage.exceptions.exceptions import ApiError
+from frontstage.views.sign_in.logout import SIGN_OUT_GUIDANCE
 from tests.integration.mocked_services import (
     message_count,
     party,
@@ -166,7 +167,7 @@ class TestSignIn(unittest.TestCase):
 
         response = self.app.get("/surveys/todo", follow_redirects=True)
         self.assertEqual(response.status_code, 200)
-        self.assertTrue("To help protect your information we have signed you out".encode() in response.data)
+        self.assertTrue(SIGN_OUT_GUIDANCE.encode() in response.data)
         self.assertIn(b"Sign in", response.data)
 
     @requests_mock.mock()


### PR DESCRIPTION
# What and why?
This PR adds the timeout modal.
# How to test?
It's best to test this locally, for 2 reasons, csrf is turned off in dev and the timeout is set to 60 minutes, turning on csrf in dev isn't an issue, but the timeout is hardcoded which is a pain.

Now that you have it running locally, go into the code and change this to something sensible https://github.com/ONSdigital/ras-frontstage/blob/main/frontstage/common/session.py#L87 like 65, this means the modal will pop up after 5 seconds making it a lot easier to test. Basically you now what to interact with the app and the modal, recommended tests

1. Navigated around the app clicking with-inside the 5 seconds(if you set it to 65), make sure the timeout doesn't appear
2. Let the modal pop up then press the continue and make sure the session is extended (http://localhost:8082/session/expires-at is useful), repeat however many times you like
3. Let the modal run down and check it logs you out
4. Check the modal works without focus, i.e log in to frontstage then go to another page and make sure it is logged out after you come back after 70 seconds
5. Anything else you can think off


# Jira
