### PR TITLE
Remove timeout modal

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.4.71
+version: 2.4.72
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.4.71
+appVersion: 2.4.72

--- a/frontstage/templates/layouts/_base.html
+++ b/frontstage/templates/layouts/_base.html
@@ -62,26 +62,3 @@
 
 {% block bodyEnd %}
 {% endblock %}
-
-{% block preFooter %}
-    {% if session_expires_at %}
-        {{
-            onsTimeoutModal ({
-                "showModalTimeInSeconds": 60,
-                "redirectUrl": url_for("sign_in_bp.logout", sign_out_guidance=True),
-                "sessionExpiresAt": session_expires_at,
-                "serverSessionExpiryEndpoint": url_for("session.session_expires_at"),
-                "title": "You will be signed out soon",
-                "textFirstLine": "It appears you have been inactive for a while.",
-                "countdownText": "To protect your information, your progress will be saved and you will be signed out in",
-                "countdownExpiredText": "You are being signed out.",
-                "btnText": "Continue survey",
-                "minutesTextSingular": "minute",
-                "minutesTextPlural": "minutes",
-                "secondsTextSingular": "second",
-                "secondsTextPlural": "seconds",
-                "endWithFullStop": true
-            })
-        }}
-    {% endif %}
-{% endblock %}


### PR DESCRIPTION
# What and why?
It looks like there might be a race condition (it could be something else, I haven't fully debugged) with the modal timeout and the authorization cookie, the modal is calling to the expire-at when created and finding there isn't a cookie sometimes and raising a 401. This is not a fix, purely a removal at present, another PR will follow this
# How to test?
Just make sure you can login and navigate around and the modal code has gone from the html
# Jira
