### PR TITLE
Ras 791 removing filter

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.4.72
+version: 2.4.73
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.4.72
+appVersion: 2.4.73

--- a/frontstage/controllers/party_controller.py
+++ b/frontstage/controllers/party_controller.py
@@ -1,9 +1,7 @@
-import datetime
 import json
 import logging
 
 import requests
-from dateutil.parser import parse
 from flask import current_app as app
 from structlog import wrap_logger
 from werkzeug.exceptions import NotFound
@@ -373,7 +371,7 @@ def get_survey_list_details_for_party(respondent: dict, tag: str, business_party
     ones that require action (in the form of an EQ or SEFT submission); Or they will be cases that have been completed
     and are used to see what has been submitted in the past.
 
-    This function uses threads and caching to get data from Case, Party, Collection exercise, Survey and
+    This function uses caching to get data from Case, Party, Collection exercise, Survey and
     Collection Instrument services. Without this, respondents with a large number of cases can experience page timeouts
     as it'll take too long to load due to repeated calls for the same information from the services.
 
@@ -386,7 +384,7 @@ def get_survey_list_details_for_party(respondent: dict, tag: str, business_party
       - Get all survey enrolments for the respondent
       - For each enrolment:
           - Get the business details the enrolment is for
-          - Get the live-but-not-ended collection exercises for the survey the enrolment is for
+          - Get the live collection exercises for the survey the enrolment is for
           - Get the cases the business is part of, from the list of collection exercises. Note, this isn't every case
             against the business; depending on if you're looking at the to-do or history page, you'll get a different
             subset of them.
@@ -424,11 +422,7 @@ def get_survey_list_details_for_party(respondent: dict, tag: str, business_party
         business_party = redis_cache.get_business_party(enrolment["business_id"])
         survey = redis_cache.get_survey(enrolment["survey_id"])
 
-        # Note: If it ever becomes possible to get only live-but-not-ended collection exercises from the
-        # collection exercise service, the filter_ended_collection_exercises function will no longer
-        # be needed as we can request what we want instead of having to filter what we get.
-
-        live_collection_exercises = filter_ended_collection_exercises(collection_exercises[enrolment["survey_id"]])
+        live_collection_exercises = collection_exercises[enrolment["survey_id"]]
 
         collection_exercises_by_id = dict((ce["id"], ce) for ce in live_collection_exercises)
         cases_for_business = cache_data["cases"][business_party["id"]]
@@ -470,22 +464,6 @@ def get_survey_list_details_for_party(respondent: dict, tag: str, business_party
                 "added_survey": added_survey,
                 "display_button": display_access_button,
             }
-
-
-def filter_ended_collection_exercises(collection_exercises: dict) -> list:
-    """
-    Takes the list of collection exercises and returns a list with all the ones that don't have a
-    scheduledEndDateTime that is in the past. If a collection exercise is missing a scheduledEndDateTime
-    attribute then it is also removed from the list.
-
-    :param collection_exercises: A list of dictionaries containing collection exercises
-    """
-    return [
-        ce
-        for ce in collection_exercises
-        if ce.get("scheduledEndDateTime")
-        and parse(ce.get("scheduledEndDateTime")) > datetime.datetime.now(datetime.timezone.utc)
-    ]
 
 
 def get_case(cache_data, business_id, case_url, case_auth, tag):

--- a/tests/unit/controllers/test_party_controller.py
+++ b/tests/unit/controllers/test_party_controller.py
@@ -1,7 +1,5 @@
-import json
 import unittest
 from collections import namedtuple
-from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 import responses
@@ -11,7 +9,6 @@ from frontstage import app
 from frontstage.controllers import party_controller
 from frontstage.controllers.party_controller import (
     display_button,
-    filter_ended_collection_exercises,
     get_respondent_enrolments_for_started_collex,
 )
 from frontstage.exceptions.exceptions import ApiError
@@ -257,7 +254,7 @@ class TestPartyController(unittest.TestCase):
         with responses.RequestsMock() as rsps:
             rsps.add(rsps.GET, url_get_survey, json=survey, status=200)
             rsps.add(rsps.GET, url_get_business_party, json=business_party, status=200)
-            rsps.add(rsps.GET, url_get_collection_exercises_by_survey, json=collection_exercise_by_survey, status=200)
+            rsps.add(rsps.GET, url_get_collction_exercises_by_survey, json=collection_exercise_by_survey, status=200)
 
             survey_list = party_controller.get_survey_list_details_for_party(
                 respondent_party["id"], "todo", business_party["id"], survey["id"]
@@ -292,35 +289,3 @@ class TestPartyController(unittest.TestCase):
         ]
         for combination in combinations:
             self.assertEqual(display_button(combination.status, combination.ci_type), combination.expected)
-
-    def test_filter_ended_collection_exercises(self):
-        """Tests the functionality of the 'filter_ended_collection_exercises' function"""
-        with open("tests/test_data/party/collection_exercises.json") as business_json_data:
-            data = json.load(business_json_data)
-
-        # Enddates set for tomorrow. Millseconds are set up this way because datetime generates 6 digits
-        # where we receive 3 digits.
-        date = datetime.now() + timedelta(days=1)
-        data[0]["scheduledEndDateTime"] = date.strftime("%Y-%m-%dT%H:%M:%S") + ".000Z"
-        data[1]["scheduledEndDateTime"] = date.strftime("%Y-%m-%dT%H:%M:%S") + ".111Z"
-        self.assertEqual(2, len(data))
-        result = filter_ended_collection_exercises(data)
-        self.assertEqual(2, len(result))
-
-        # Change one of the end dates to a past date.  It should successfully filter the collection exercise
-        # out of the list.
-        data[0]["scheduledEndDateTime"] = "2019-01-31T00:00:00.000Z"
-        self.assertEqual(2, len(data))
-        result = filter_ended_collection_exercises(data)
-        self.assertEqual(1, len(result))
-
-    def test_filter_ended_collection_exercises_remove_multiple(self):
-        collection_exercises = [
-            {"missingEndDateTime": "!"},
-            {"scheduledEndDateTime": str(datetime.now(timezone.utc) - timedelta(days=1))},
-            {"scheduledEndDateTime": str(datetime.now(timezone.utc) - timedelta(hours=1))},
-            {"scheduledEndDateTime": str(datetime.now(timezone.utc) + timedelta(hours=1))},
-            {"scheduledEndDateTime": str(datetime.now(timezone.utc) + timedelta(days=1))},
-        ]
-        result = filter_ended_collection_exercises(collection_exercises)
-        self.assertEqual(2, len(result))

--- a/tests/unit/controllers/test_party_controller.py
+++ b/tests/unit/controllers/test_party_controller.py
@@ -1,6 +1,5 @@
 import unittest
 from collections import namedtuple
-from unittest.mock import patch
 
 import responses
 
@@ -15,17 +14,11 @@ from frontstage.exceptions.exceptions import ApiError
 from tests.integration.mocked_services import (
     business_party,
     case,
-    case_list,
     collection_exercise,
-    collection_exercise_by_survey,
-    collection_instrument_seft,
     respondent_party,
-    survey,
     url_get_business_party,
-    url_get_collection_exercises_by_survey,
     url_get_respondent_email,
     url_get_respondent_party,
-    url_get_survey,
     url_notify_party_and_respondent_account_locked,
     url_post_add_survey,
     url_reset_password_request,
@@ -232,44 +225,6 @@ class TestPartyController(unittest.TestCase):
         for enrolment in enrolments:
             self.assertTrue(enrolment["business_id"] is not None)
             self.assertTrue(enrolment["survey_id"] is not None)
-
-    @patch("frontstage.controllers.case_controller.calculate_case_status")
-    @patch("frontstage.controllers.collection_instrument_controller.get_collection_instrument")
-    @patch("frontstage.controllers.case_controller.get_cases_for_list_type_by_party_id")
-    @patch("frontstage.controllers.party_controller.get_respondent_enrolments")
-    def test_get_survey_list_details_for_party(
-        self,
-        get_respondent_enrolments,
-        get_cases,
-        get_collection_instrument,
-        calculate_case_status,
-    ):
-        enrolments = [{"business_id": business_party["id"], "survey_id": survey["id"]}]
-
-        get_respondent_enrolments.return_value = enrolments
-        get_cases.return_value = case_list
-        get_collection_instrument.return_value = collection_instrument_seft
-        calculate_case_status.return_value = "In Progress"
-
-        with responses.RequestsMock() as rsps:
-            rsps.add(rsps.GET, url_get_survey, json=survey, status=200)
-            rsps.add(rsps.GET, url_get_business_party, json=business_party, status=200)
-            rsps.add(rsps.GET, url_get_collction_exercises_by_survey, json=collection_exercise_by_survey, status=200)
-
-            survey_list = party_controller.get_survey_list_details_for_party(
-                respondent_party["id"], "todo", business_party["id"], survey["id"]
-            )
-            with app.app_context():
-                # This test might not do anything as the survey_list might be empty... look into this
-                for survey_details in survey_list:
-                    self.assertTrue(survey_details["case_id"] is not None)
-                    self.assertTrue(survey_details["status"] is not None)
-                    self.assertTrue(survey_details["collection_instrument_type"] is not None)
-                    self.assertTrue(survey_details["survey_id"] is not None)
-                    self.assertTrue(survey_details["survey_long_name"] is not None)
-                    self.assertTrue(survey_details["survey_short_name"] is not None)
-                    self.assertTrue(survey_details["business_party_id"] is not None)
-                    self.assertTrue(survey_details["collection_exercise_ref"] is not None)
 
     def test_display_button(self):
         Combination = namedtuple("Combination", ["status", "ci_type", "expected"])


### PR DESCRIPTION
# What and why?
The filter to get live not ended collection exercises needed to removed from frontstage because we already have the ability to get those from the collection exercise service. Additionally, tests that tested this functionality have been removed since they're no longer necessary.

# How to test?
Deploy, run acceptance tests, and make sure they pass.

# Jira
[Card](https://jira.ons.gov.uk/browse/RAS-791)
