### PR TITLE
fix ons-icon in html files

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.4.78
+version: 2.4.79
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.4.78
+appVersion: 2.4.79

--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.4.79
+version: 2.4.80
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.4.79
+appVersion: 2.4.80

--- a/frontstage/static/css/theme.css
+++ b/frontstage/static/css/theme.css
@@ -31,3 +31,19 @@
 .ons-tab--row:hover .tab--text {
   text-decoration: underline solid 2px;
 }
+
+.ons-tabs__list {
+    width: 100%;
+}
+
+.ons-tabs__list--row::after {
+    background: var(--ons-color-borders);
+    bottom: 0;
+    -webkit-box-shadow: 0 1px 0 0 var(--ons-color-page-light);
+    box-shadow: 0 1px 0 0 var(--ons-color-page-light);
+    content: "";
+    height: 1px;
+    left: 0;
+    position: absolute;
+    width: 100%;
+}

--- a/frontstage/templates/help/help-info-something-else.html
+++ b/frontstage/templates/help/help-info-something-else.html
@@ -30,7 +30,7 @@
 
 {% block main %}
     <h1 class="ons-u-fs-xl">Information about the Office for National Statistics (ONS)</h1>
-    <p>Find out more <a href="https://www.ons.gov.uk/surveys/informationforbusinesses" class="ons-external-link" target="_blank" rel="noopener">information about the ONS<svg id="external-link" class="ons-svg-icon" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
+    <p>Find out more <a href="https://www.ons.gov.uk/surveys/informationforbusinesses" class="ons-external-link" target="_blank" rel="noopener">information about the ONS<svg id="external-link" class="ons-icon" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
         <path d="M13.5,9H13a.5.5,0,0,0-.5.5v3h-9v-9h3A.5.5,0,0,0,7,3V2.5A.5.5,0,0,0,6.5,2h-4a.5.5,0,0,0-.5.5v11a.5.5,0,0,0,.5.5h11a.5.5,0,0,0,.5-.5v-4A.5.5,0,0,0,13.5,9Z" transform="translate(-2 -1.99)" />
         <path d="M8.83,7.88a.51.51,0,0,0,.71,0l2.31-2.32,1.28,1.28A.51.51,0,0,0,14,6.49v-4a.52.52,0,0,0-.5-.5h-4A.51.51,0,0,0,9,2.52a.58.58,0,0,0,.14.33l1.28,1.28L8.12,6.46a.51.51,0,0,0,0,.71Z" transform="translate(-2 -1.99)" />
       </svg></a></p>

--- a/frontstage/templates/help/help-who-is-ons.html
+++ b/frontstage/templates/help/help-who-is-ons.html
@@ -34,7 +34,7 @@
     <p>We are responsible for collecting and publishing statistics related to the economy, population and society at national, regional and local levels.</p>
     <p>We also conduct the census in England and Wales every 10 years.</p>
 
-    <p>See more <a href="https://www.ons.gov.uk/surveys/informationforbusinesses" class="ons-external-link" target="_blank" rel="noopener">about the ONS<svg id="external-link" class="ons-svg-icon" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
+    <p>See more <a href="https://www.ons.gov.uk/surveys/informationforbusinesses" class="ons-external-link" target="_blank" rel="noopener">about the ONS<svg id="external-link" class="ons-icon" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
         <path d="M13.5,9H13a.5.5,0,0,0-.5.5v3h-9v-9h3A.5.5,0,0,0,7,3V2.5A.5.5,0,0,0,6.5,2h-4a.5.5,0,0,0-.5.5v11a.5.5,0,0,0,.5.5h11a.5.5,0,0,0,.5-.5v-4A.5.5,0,0,0,13.5,9Z" transform="translate(-2 -1.99)" />
         <path d="M8.83,7.88a.51.51,0,0,0,.71,0l2.31-2.32,1.28,1.28A.51.51,0,0,0,14,6.49v-4a.52.52,0,0,0-.5-.5h-4A.51.51,0,0,0,9,2.52a.58.58,0,0,0,.14.33l1.28,1.28L8.12,6.46a.51.51,0,0,0,0,.71Z" transform="translate(-2 -1.99)" />
       </svg></a></p>

--- a/frontstage/templates/surveys/help/surveys-help-exemption-completing-survey.html
+++ b/frontstage/templates/surveys/help/surveys-help-exemption-completing-survey.html
@@ -37,7 +37,7 @@
         <p>While this survey is voluntary, we have selected your company in the same way we select companies for mandatory surveys. This means that any information you share with us will allow us to produce statistics on things that may not be asked as part of mandatory surveys.</p>
     {% endif %}
 
-    <p>See more <a href="https://www.ons.gov.uk/surveys/informationforbusinesses" class="ons-external-link" target="_blank" rel="noopener">information for businesses<svg id="external-link" class="ons-svg-icon" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
+    <p>See more <a href="https://www.ons.gov.uk/surveys/informationforbusinesses" class="ons-external-link" target="_blank" rel="noopener">information for businesses<svg id="external-link" class="ons-icon" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
         <path d="M13.5,9H13a.5.5,0,0,0-.5.5v3h-9v-9h3A.5.5,0,0,0,7,3V2.5A.5.5,0,0,0,6.5,2h-4a.5.5,0,0,0-.5.5v11a.5.5,0,0,0,.5.5h11a.5.5,0,0,0,.5-.5v-4A.5.5,0,0,0,13.5,9Z" transform="translate(-2 -1.99)" />
         <path d="M8.83,7.88a.51.51,0,0,0,.71,0l2.31-2.32,1.28,1.28A.51.51,0,0,0,14,6.49v-4a.52.52,0,0,0-.5-.5h-4A.51.51,0,0,0,9,2.52a.58.58,0,0,0,.14.33l1.28,1.28L8.12,6.46a.51.51,0,0,0,0,.71Z" transform="translate(-2 -1.99)" />
       </svg></a></p>

--- a/frontstage/templates/surveys/help/surveys-help-how-long-selected-for.html
+++ b/frontstage/templates/surveys/help/surveys-help-how-long-selected-for.html
@@ -33,7 +33,7 @@
     <h1 class="ons-u-fs-xl">How long will my business be selected for?</h1>
     <p>We cannot give a definite period of selection for business surveys as this depends on various factors. We choose a specific number of businesses for a survey sample. This can change as businesses start and other businesses stop trading.</p>
     <p>Employment levels within each business may change, which affects the number of businesses in each size-band. This also has an impact on how long a business is selected for.</p>
-    <p>See more <a href="https://www.ons.gov.uk/surveys/informationforbusinesses" class="ons-external-link" target="_blank" rel="noopener">information for businesses<svg id="external-link" class="ons-svg-icon" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
+    <p>See more <a href="https://www.ons.gov.uk/surveys/informationforbusinesses" class="ons-external-link" target="_blank" rel="noopener">information for businesses<svg id="external-link" class="ons-icon" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
         <path d="M13.5,9H13a.5.5,0,0,0-.5.5v3h-9v-9h3A.5.5,0,0,0,7,3V2.5A.5.5,0,0,0,6.5,2h-4a.5.5,0,0,0-.5.5v11a.5.5,0,0,0,.5.5h11a.5.5,0,0,0,.5-.5v-4A.5.5,0,0,0,13.5,9Z" transform="translate(-2 -1.99)" />
         <path d="M8.83,7.88a.51.51,0,0,0,.71,0l2.31-2.32,1.28,1.28A.51.51,0,0,0,14,6.49v-4a.52.52,0,0,0-.5-.5h-4A.51.51,0,0,0,9,2.52a.58.58,0,0,0,.14.33l1.28,1.28L8.12,6.46a.51.51,0,0,0,0,.71Z" transform="translate(-2 -1.99)" />
       </svg></a></p>

--- a/frontstage/templates/surveys/help/surveys-help-info-something-else.html
+++ b/frontstage/templates/surveys/help/surveys-help-info-something-else.html
@@ -33,7 +33,7 @@
 {% block main %}
     <h1 class="ons-u-fs-xl">Information about the {{ survey_name }}</h1>
 
-    <p>You will find answers to most of your questions in our <a href="https://www.ons.gov.uk/surveys/informationforbusinesses" class="ons-external-link" target="_blank" rel="noopener">information for businesses<svg id="external-link" class="ons-svg-icon" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
+    <p>You will find answers to most of your questions in our <a href="https://www.ons.gov.uk/surveys/informationforbusinesses" class="ons-external-link" target="_blank" rel="noopener">information for businesses<svg id="external-link" class="ons-icon" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
           <path d="M13.5,9H13a.5.5,0,0,0-.5.5v3h-9v-9h3A.5.5,0,0,0,7,3V2.5A.5.5,0,0,0,6.5,2h-4a.5.5,0,0,0-.5.5v11a.5.5,0,0,0,.5.5h11a.5.5,0,0,0,.5-.5v-4A.5.5,0,0,0,13.5,9Z" transform="translate(-2 -1.99)" />
           <path d="M8.83,7.88a.51.51,0,0,0,.71,0l2.31-2.32,1.28,1.28A.51.51,0,0,0,14,6.49v-4a.52.52,0,0,0-.5-.5h-4A.51.51,0,0,0,9,2.52a.58.58,0,0,0,.14.33l1.28,1.28L8.12,6.46a.51.51,0,0,0,0,.71Z" transform="translate(-2 -1.99)" />
         </svg></a>

--- a/frontstage/templates/surveys/help/surveys-help-time-to-complete.html
+++ b/frontstage/templates/surveys/help/surveys-help-time-to-complete.html
@@ -33,7 +33,7 @@
     <h1 class="ons-u-fs-xl">How long will it take to complete?</h1>
     <p>We design each survey to answer a set of statistical requirements. The length and number of questions can vary.</p>
     <p>How long it takes your business to complete a survey will depend on how easily you can get hold of the information we ask for.</p>
-    <p>See more <a href="https://www.ons.gov.uk/surveys/informationforbusinesses" class="ons-external-link" target="_blank" rel="noopener">information for businesses<svg id="external-link" class="ons-svg-icon" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
+    <p>See more <a href="https://www.ons.gov.uk/surveys/informationforbusinesses" class="ons-external-link" target="_blank" rel="noopener">information for businesses<svg id="external-link" class="ons-icon" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
         <path d="M13.5,9H13a.5.5,0,0,0-.5.5v3h-9v-9h3A.5.5,0,0,0,7,3V2.5A.5.5,0,0,0,6.5,2h-4a.5.5,0,0,0-.5.5v11a.5.5,0,0,0,.5.5h11a.5.5,0,0,0,.5-.5v-4A.5.5,0,0,0,13.5,9Z" transform="translate(-2 -1.99)" />
         <path d="M8.83,7.88a.51.51,0,0,0,.71,0l2.31-2.32,1.28,1.28A.51.51,0,0,0,14,6.49v-4a.52.52,0,0,0-.5-.5h-4A.51.51,0,0,0,9,2.52a.58.58,0,0,0,.14.33l1.28,1.28L8.12,6.46a.51.51,0,0,0,0,.71Z" transform="translate(-2 -1.99)" />
       </svg></a></p>

--- a/frontstage/templates/surveys/help/surveys-help-who-is-the-ons.html
+++ b/frontstage/templates/surveys/help/surveys-help-who-is-the-ons.html
@@ -36,7 +36,7 @@
         We are responsible for collecting and publishing statistics related to the economy, population and society at national,
         regional and local levels. We also conduct the census in England and Wales every 10 years.</p>
 
-    <p>Read more <a href="https://www.ons.gov.uk/aboutus" class="ons-external-link" target="_blank" rel="noopener">About the ONS<svg id="external-link" class="ons-svg-icon" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
+    <p>Read more <a href="https://www.ons.gov.uk/aboutus" class="ons-external-link" target="_blank" rel="noopener">About the ONS<svg id="external-link" class="ons-icon" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
         <path d="M13.5,9H13a.5.5,0,0,0-.5.5v3h-9v-9h3A.5.5,0,0,0,7,3V2.5A.5.5,0,0,0,6.5,2h-4a.5.5,0,0,0-.5.5v11a.5.5,0,0,0,.5.5h11a.5.5,0,0,0,.5-.5v-4A.5.5,0,0,0,13.5,9Z" transform="translate(-2 -1.99)"/>
         <path d="M8.83,7.88a.51.51,0,0,0,.71,0l2.31-2.32,1.28,1.28A.51.51,0,0,0,14,6.49v-4a.52.52,0,0,0-.5-.5h-4A.51.51,0,0,0,9,2.52a.58.58,0,0,0,.14.33l1.28,1.28L8.12,6.46a.51.51,0,0,0,0,.71Z" transform="translate(-2 -1.99)"/>
         </svg></a>

--- a/frontstage/templates/surveys/help/surveys-help-why-selected.html
+++ b/frontstage/templates/surveys/help/surveys-help-why-selected.html
@@ -36,7 +36,7 @@
     <p>Selection depends on several factors. For example, the number of people employed, how many other businesses are operating in the same industry and the size of those businesses.</p>
     <p>We always include large businesses in the survey sample because the information they provide can be significant.</p>
     <p>Large businesses are usually defined as having more than 100 employees.</p>
-    <p>See more <a href="https://www.ons.gov.uk/surveys/informationforbusinesses" class="ons-external-link" target="_blank" rel="noopener">information for businesses<svg id="external-link" class="ons-svg-icon" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
+    <p>See more <a href="https://www.ons.gov.uk/surveys/informationforbusinesses" class="ons-external-link" target="_blank" rel="noopener">information for businesses<svg id="external-link" class="ons-icon" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
             <path d="M13.5,9H13a.5.5,0,0,0-.5.5v3h-9v-9h3A.5.5,0,0,0,7,3V2.5A.5.5,0,0,0,6.5,2h-4a.5.5,0,0,0-.5.5v11a.5.5,0,0,0,.5.5h11a.5.5,0,0,0,.5-.5v-4A.5.5,0,0,0,13.5,9Z" transform="translate(-2 -1.99)" />
             <path d="M8.83,7.88a.51.51,0,0,0,.71,0l2.31-2.32,1.28,1.28A.51.51,0,0,0,14,6.49v-4a.52.52,0,0,0-.5-.5h-4A.51.51,0,0,0,9,2.52a.58.58,0,0,0,.14.33l1.28,1.28L8.12,6.46a.51.51,0,0,0,0,.71Z" transform="translate(-2 -1.99)" />
         </svg></a></p>


### PR DESCRIPTION
# What and why?
I missed something in the last design system upgrade where the icons that appear near links (such as on the About the ONS info page) appeared enormous. This turned out to be because the design system v65 renamed the `ons-svg-icon` to `ons-icon` (this wasn't mentioned in the breaking changes!).

Also, the design system upgrade messed with the appearance of the tab component due to the fact that the way we use it is not in accordance with the design system's ethos. The way the tabs are currently created is by a hacky HYML code block, which isn't how it's meant to be done, but it allows us to have the appropriate functionality. To continue supporting our implementation of tabs, the .css file has had some additional config in order to maintain its current appearance. Also, make sure that the tab component (seen when looking at surveys to-do/history/messages) appears correctly, with a line going across the page underneath the tabs.

# How to test?
Deploy, run acceptance tests, go to frontstage and navigate to one of the help pages and make sure that the icons near links are not way larger than they should be.

# Jira
[Card](https://jira.ons.gov.uk/browse/RAS-863)
