### PR TITLE
RAS-888:RITM1072728 - Enrolment Code not Working

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.4.81
+version: 2.4.82
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.4.81
+appVersion: 2.4.82

--- a/frontstage/views/surveys/add_survey.py
+++ b/frontstage/views/surveys/add_survey.py
@@ -85,7 +85,7 @@ def add_survey(session):
         logger.info(
             "Invalid character length, must be 12 characters",
             enrolment_code=request.form.get("enrolment_code").lower(),
-            character_length=len(request.form.get("enrolment_code")),
+            enrolment_code_length=len(request.form.get("enrolment_code")),
         )
         template_data = {"error": {"type": "failed"}}
         return render_template("surveys/surveys-add.html", session=session, form=form, data=template_data)

--- a/frontstage/views/surveys/add_survey.py
+++ b/frontstage/views/surveys/add_survey.py
@@ -85,6 +85,7 @@ def add_survey(session):
         logger.info(
             "Invalid character length, must be 12 characters",
             enrolment_code=request.form.get("enrolment_code").lower(),
+            character_length=len(request.form.get("enrolment_code")),
         )
         template_data = {"error": {"type": "failed"}}
         return render_template("surveys/surveys-add.html", session=session, form=form, data=template_data)

--- a/frontstage/views/surveys/add_survey.py
+++ b/frontstage/views/surveys/add_survey.py
@@ -82,7 +82,10 @@ def add_survey(session):
         )
 
     elif request.method == "POST" and not form.validate():
-        logger.info("Invalid character length, must be 12 characters")
+        logger.info(
+            "Invalid character length, must be 12 characters",
+            enrolment_code=request.form.get("enrolment_code").lower(),
+        )
         template_data = {"error": {"type": "failed"}}
         return render_template("surveys/surveys-add.html", session=session, form=form, data=template_data)
 


### PR DESCRIPTION
# What and why?
A user us reporting that the IAC they have been supplied with is not working. At the same time the user does this, we have noticed an error in the logs indicating that an IAC does not pass verification. Unfortunately, the IAC itself is not captured. This PR adds the IAC to the error message.

# How to test?
1. Find an active IAC
2. Login to Frontstage and click 'add a new survey to your account](http://localhost:8082/surveys/add-survey'
3. Enter the IAC into the input field but add an additional character or whitespace
4. Click continue
5. An error message should appear on screen
6. Goto the logs and search for the IAC (with the additional character(s)/whitespace)
7. The message should read '{"enrolment_code": "[YOUR_IAC] ", "event": "Invalid character length, must be 12 characters", "severity": "info", "service": "ras-frontstage", "created_at": "[TIME_TRIED"}'
8. Go back to Fronstage and correctly enter the IAC and hit continue
9. The error message should have gone and you should be directed to the next page

# Jira
https://jira.ons.gov.uk/browse/RAS-888