### PR TITLE
RAS-893 shared survey not appearing in their account

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.4.82
+version: 2.4.83
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.4.82
+appVersion: 2.4.83

--- a/frontstage/error_handlers.py
+++ b/frontstage/error_handlers.py
@@ -49,6 +49,7 @@ def handle_csrf_error(error):
 
 @app.errorhandler(Unauthorized)
 def unauthorized(error):
+    session["next"] = request.url
     logger.info(error.description, url=request.url, status_code=401)
     return redirect(url_for("sign_in_bp.logout", sign_out_guidance=True))
 


### PR DESCRIPTION
# What and why?
At present when a user tries to share/transfer a survey to an existing user it will raise a 401 on the email link click if the user is not logged in, which will be the majority of time and redirect them to the sign-in page. At present if the user then  logs in it takes them to the TODO page missing out the code needed to execute the share/transfer

We shouldn't be raising a 401 in this situation, however that is being fixed in a different card. This is purely an ugly fix that allows the previous url to be passed back in when the user does log in

N.B I am not going to write tests for this one as it really shouldn't behaviour like this. There is a card in tech to discuss it properly, but quick and dirty fix was the decision in stand-up

# How to test?
Start off by getting an environment up and running and seeding some data (acceptance tests will be fine). If you did use the acceptance tests enrol another user by getting an IAC from rops and going through the process on frontstage. Once they are enrolled log them in and go to my account, share the survey with the other user in the system (example@example.com) log the user out and go to notify, grab the link in notify (changing the irritating host from 8080 to 8082) and put it into a browser window. Follow the steps and make the survey appears as expected.

Repeat for transfer survey, if you click share survey the option is there in the guidance to transfer instead

# Jira
