### PR TITLE
update code to render GTM and GA snippet based on if its present in config

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.4.83
+version: 2.4.84
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.4.83
+appVersion: 2.4.84

--- a/frontstage/templates/layouts/_base.html
+++ b/frontstage/templates/layouts/_base.html
@@ -5,16 +5,13 @@
 {% block head %}
     {% set css_theme = "css"~_theme~"/theme.css" %}
     <link href="{{ url_for('static', filename=css_theme) }}" rel="stylesheet" />
-
     {% if config.GOOGLE_TAG_MANAGER_ID %}
         {% include "partials/gtm.html" %}
     {% endif %}
 {% endblock %}
 {% block bodyStart %}
-    {% if config.GOOGLE_TAG_MANAGER_ID %}
-        {% if config.GOOGLE_ANALYTICS_MEASUREMENT_ID %}
-            {% include "partials/ga.html" %}
-        {% endif %}
+    {% if config.GOOGLE_ANALYTICS_MEASUREMENT_ID %}
+        {% include "partials/ga.html" %}
     {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
# What and why?
Due to the potential security risk, we should not currently include the gtm.html snippet in the page to avoid sending any GTM managed metrics to Google Tag Manager in prod and preprod.

# How to test?
This will need to be tested within preprod. 
After the deployment I will use Tag Assistant 
Tag Assistant lets you quickly see which of your site's trackers are working as expected. And if there are issues.

I expect tag assistant to inform me that it was unable to find any data due to the snippet not being present.

# Jira
https://jira.ons.gov.uk/browse/RAS-905
