### PR TITLE
Add Talisman session cookie secure

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.4.88
+version: 2.4.89
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.4.88
+appVersion: 2.4.89

--- a/_infra/helm/frontstage/templates/deployment.yaml
+++ b/_infra/helm/frontstage/templates/deployment.yaml
@@ -209,6 +209,8 @@ spec:
             value: "{{- if .Values.security.csrf.protected -}}True{{- else -}}False{{- end -}}"
           - name: WTF_CSRF_TIME_LIMIT
             value: "{{ .Values.security.csrf.timeLimit }}"
+          - name: SESSION_COOKIE_SECURE
+            value: "{{ .Values.security.sessionCookieSecure }}"
           - name: CANARY_GENERATE_ERRORS
             value: "{{- if .Values.canary.generate_errors -}}True{{- else -}}False{{- end -}}"
           - name: SECRET_KEY

--- a/_infra/helm/frontstage/values.yaml
+++ b/_infra/helm/frontstage/values.yaml
@@ -52,6 +52,7 @@ scheme: http
 
 security:
   enabled: true
+  sessionCookieSecure: true
   csrf:
     protected: true
     timeLimit: 7200

--- a/config.py
+++ b/config.py
@@ -66,6 +66,7 @@ class Config(object):
     # WTF_CSRF_ENABLED is used by the flask_wtf.csrf library to control if CSRF protection is turned on
     WTF_CSRF_ENABLED = bool(strtobool(os.getenv("WTF_CSRF_ENABLED", str(SECURE_APP))))
     WTF_CSRF_TIME_LIMIT = int(os.getenv("WTF_CSRF_TIME_LIMIT", "7200"))
+    SESSION_COOKIE_SECURE = bool(strtobool(os.getenv("SESSION_COOKIE_SECURE", "True")))
 
     GOOGLE_CLOUD_PROJECT = os.getenv("GOOGLE_CLOUD_PROJECT", "ras-rm-sandbox")
     PUBSUB_TOPIC = os.getenv("PUBSUB_TOPIC", "ras-rm-notify-test")

--- a/config.py
+++ b/config.py
@@ -92,6 +92,7 @@ class Config(object):
 class DevelopmentConfig(Config):
     DEVELOPMENT = True
     DEBUG = True
+    SESSION_COOKIE_SECURE = False
     TEMPLATES_AUTO_RELOAD = True
     PREFERRED_URL_SCHEME = "http"
     SECRET_KEY = os.getenv("SECRET_KEY", "ONS_DUMMY_KEY")

--- a/frontstage/__init__.py
+++ b/frontstage/__init__.py
@@ -51,7 +51,7 @@ talisman = Talisman(
     strict_transport_security=True,
     strict_transport_security_max_age=31536000,
     frame_options="DENY",
-    session_cookie_secure=app.config["SESSION_COOKIE_SECURE"]
+    session_cookie_secure=app.config["SESSION_COOKIE_SECURE"],
 )
 
 if not app.config["TESTING"]:

--- a/frontstage/__init__.py
+++ b/frontstage/__init__.py
@@ -51,6 +51,7 @@ talisman = Talisman(
     strict_transport_security=True,
     strict_transport_security_max_age=31536000,
     frame_options="DENY",
+    session_cookie_secure=app.config["SESSION_COOKIE_SECURE"]
 )
 
 if not app.config["TESTING"]:


### PR DESCRIPTION
# What and why?
Talisman by default has session cookie secure to True https://github.com/GoogleCloudPlatform/flask-talisman/blob/master/flask_talisman/talisman.py#L78, however we need to be able to control this for the performance environment and dev where it shouldn't be on. This will allow non https sites to still access the cookie which holds the value for csrf. Normal issues with our set-up and that the yaml will not build out till merge
# How to test?
Run the app with data and make sure you can log in
# Jira
