### PR TITLE
RAS-1150 Secure messages going to team mailbox instead of to user on ABS

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -15,8 +15,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 2.5.6
+version: 2.5.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.6
+appVersion: 2.5.7

--- a/frontstage/controllers/conversation_controller.py
+++ b/frontstage/controllers/conversation_controller.py
@@ -94,9 +94,10 @@ def send_message(
     party_id: UUID,
     subject: str,
     category: str,
+    msg_to=["GROUP"],
     survey_id: UUID = None,
     business_id: UUID = None,
-    collection_exercise_id: UUID = None,
+    ce_id: UUID = None,
 ) -> UUID:
     """
     Creates a message in the secure-message service
@@ -108,7 +109,7 @@ def send_message(
 
     message_json = {
         "msg_from": party_id,
-        "msg_to": ["GROUP"],
+        "msg_to": msg_to,
         "subject": subject,
         "category": category,
         "body": secure_message_form["body"].data,
@@ -140,7 +141,7 @@ def send_message(
         category=category,
         survey_id=survey_id,
         business_id=business_id,
-        collection_exercise_id=collection_exercise_id,
+        ce_id=ce_id,
     )
 
     return msg_id

--- a/frontstage/views/surveys/help/surveys_help.py
+++ b/frontstage/views/surveys/help/surveys_help.py
@@ -274,7 +274,9 @@ def send_help_message(session, option: str, sub_option: str):
         category = "TECHNICAL" if option == "info-about-the-ons" else "SURVEY"
         subject = sub_option_dict["subject"]
         try:
-            msg_id = send_message(request.form, party_id, subject, category, survey_id, business_id)
+            msg_id = send_message(
+                request.form, party_id, subject, category, survey_id=survey_id, business_id=business_id, ce_id=ce_id
+            )
 
             thread_url = url_for("secure_message_bp.view_conversation", thread_id=msg_id) + "#latest-message"
             flash(Markup(f"Message sent. <a href={thread_url}>View Message</a>"))

--- a/frontstage/views/surveys/help/technical_help.py
+++ b/frontstage/views/surveys/help/technical_help.py
@@ -59,7 +59,7 @@ def send_help_technical_message(session):
     party_id = session.get_party_id()
 
     try:
-        msg_id = send_message(request.form, party_id, "dd", subject)
+        msg_id = send_message(request.form, party_id, subject, "TECHNICAL")
     except InvalidSecureMessagingForm as e:
         flash(e.errors["body"][0])
         return redirect(url_for("surveys_bp.get_send_help_technical_message_page", option=option))

--- a/tests/integration/controllers/test_conversation_controller.py
+++ b/tests/integration/controllers/test_conversation_controller.py
@@ -138,7 +138,9 @@ class TestConversationController(unittest.TestCase):
         with responses.RequestsMock() as rsps:
             rsps.add(rsps.POST, url_send_message, json={"msg_id": MSG_ID})
             with app.app_context():
-                msg_id = send_message(SM_FORM, PARTY_ID, "subject", "category", SURVEY_ID, BUSINESS_ID, CE_ID)
+                msg_id = send_message(
+                    SM_FORM, PARTY_ID, "subject", "category", survey_id=SURVEY_ID, business_id=BUSINESS_ID, ce_id=CE_ID
+                )
 
         self.assertEqual(msg_id, MSG_ID)
 
@@ -149,7 +151,15 @@ class TestConversationController(unittest.TestCase):
         with app.app_context():
 
             with self.assertRaises(InvalidSecureMessagingForm):
-                send_message(empty_form, PARTY_ID, "subject", "category", SURVEY_ID, BUSINESS_ID, CE_ID)
+                send_message(
+                    empty_form,
+                    PARTY_ID,
+                    "subject",
+                    "category",
+                    survey_id=SURVEY_ID,
+                    business_id=BUSINESS_ID,
+                    ce_id=CE_ID,
+                )
 
     @patch("frontstage.controllers.conversation_controller._create_send_message_headers")
     def test_send_message_api_error(self, headers):
@@ -159,4 +169,12 @@ class TestConversationController(unittest.TestCase):
             with app.app_context():
 
                 with self.assertRaises(ApiError):
-                    send_message(SM_FORM, PARTY_ID, "subject", "category", SURVEY_ID, BUSINESS_ID, CE_ID)
+                    send_message(
+                        SM_FORM,
+                        PARTY_ID,
+                        "subject",
+                        "category",
+                        survey_id=SURVEY_ID,
+                        business_id=BUSINESS_ID,
+                        ce_id=CE_ID,
+                    )

--- a/tests/integration/test_message_get.py
+++ b/tests/integration/test_message_get.py
@@ -6,6 +6,7 @@ import requests_mock
 
 from frontstage import app
 from frontstage.controllers.conversation_controller import InvalidSecureMessagingForm
+from frontstage.views.secure_messaging.message_get import get_msg_to
 from tests.integration.mocked_services import (
     encoded_jwt_token,
     message_json,
@@ -75,3 +76,19 @@ class TestMessageGet(unittest.TestCase):
         response = self.app.post("secure-message/threads/9e3465c0-9172-4974-a7d1-3a01592d1594", follow_redirects=True)
 
         self.assertTrue("Message is required".encode() in response.data)
+
+    def test_get_msg_to_returns_group_if_no_internal_user(self):
+        msg = {"something": "somethings"}
+        conversation = [msg, copy.deepcopy(msg), copy.deepcopy(msg)]
+        to = get_msg_to(conversation)
+
+        self.assertEqual(to, ["GROUP"])
+
+    def test_get_msg_to_returns_newest_internal_user_if_known(self):
+        msg = {"something": "somethings"}
+        first_message_with_user = {"internal_user": "user1", "from_internal": True}
+        second_message_with_user = {"internal_user": "user2", "from_internal": True}
+        conversation = [msg, first_message_with_user, second_message_with_user, copy.deepcopy(msg)]
+        to = get_msg_to(conversation)
+
+        self.assertEqual(to, ["user2"])


### PR DESCRIPTION
# What and why?
The changes in SM recently introduced a bug when answering a thread, the msg_to was not being passed and therefore was always going back to group, this leads to 2 errors
"When an internal user sends a secure message on ABS and the respondent returns a message, this is going to the ABS team and not in the 'my messages' tab of the person who is dealing with the message. "

"Incoming SDCs are showing as Initials and missing the previous message thread, appears to be affecting all survey inboxes"

This PR adds in the msg_to and corrects some other minor issues spotted when going over it. It also restores get_msg_to and the tests that went with it

# How to test?
Create a new collection exercise and make it live (or use acceptance tests) now in ROPs create a user and send a message to an enrolled respondent. Go to frontstage and make sure it arrives, reply to it and confirm it goes back to the user that sent it (i.e your new user) and that the history of the message is there. 

# Jira
