### PR TITLE
RAS-1101: Bug in secure messaging pre prod - Message sends twice

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -15,8 +15,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 2.5.7
+version: 2.5.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.7
+appVersion: 2.5.8

--- a/frontstage/templates/account/account-something-else.html
+++ b/frontstage/templates/account/account-something-else.html
@@ -90,7 +90,7 @@
                     onsButton({
                         "text": "Send",
                         "id": "send-message-ons-btn",
-                        "submitType": "timer"
+                        "variants": "loader"
                     })
                 }}
                 {{

--- a/frontstage/templates/secure-messages/conversation-view.html
+++ b/frontstage/templates/secure-messages/conversation-view.html
@@ -116,7 +116,7 @@
                                     "type": "submit",
                                     "classes": "ons-u-mt-l ons-u-mb-s",
                                     "id": "send_message_button",
-                                    "submitType": "timer"
+                                    "variants": "loader"
                                 })
                             }}
                         </form>

--- a/frontstage/templates/secure-messages/help/secure-message-send-messages-view.html
+++ b/frontstage/templates/secure-messages/help/secure-message-send-messages-view.html
@@ -106,7 +106,7 @@
                     onsButton({
                         "text": "Send message",
                         "id": "send-message-ons-btn",
-                        "submitType": "timer"
+                        "variants": "loader"
                     })
                 }}
                 {% if breadcrumb_title_two != None %}

--- a/frontstage/templates/secure-messages/help/secure-message-send-technical-messages-view.html
+++ b/frontstage/templates/secure-messages/help/secure-message-send-technical-messages-view.html
@@ -77,7 +77,7 @@
                     onsButton({
                         "text": "Send message",
                         "id": "send-message-ons-btn",
-                        "submitType": "timer"
+                        "variants": "loader"
                     })
                 }}
                 {{


### PR DESCRIPTION
# What and why?
When a message is sent and there is a delay, the submit button remains active. The submit can then be clicked 'X' amount of times leading to an equivalent 'X' amount of duplicates. The 'loader' variant has been added to the submit button. The submit button will no longer be active, a loading wheel will appear on the button and will prevent the button being clicked.

# How to test?
- Run acceptance tests
- Pull this PR
- Add 'time.sleep(30)' to
https://github.com/ONSdigital/ras-frontstage/blob/452e73333c025e0176502c7ea059fe45c1b8bfbf/frontstage/controllers/conversation_controller.py#L135
to cause a delay
- Run this PR locally
- Send a message in frontstage (both technical and non-technical)
- The submit button should look like this
![image](https://github.com/ONSdigital/ras-frontstage/assets/47788084/e897cf49-523c-4366-be56-29ed06cd0392)
-After the delay, you should be redirected to the inbox overview page

Additional testing:
-Deploy this PR to your env
-Run acceptance tests

# Jira
https://jira.ons.gov.uk/browse/RAS-1101