### PR TITLE
RAS-1181 Remove get_business-by-ru-ref from frontstage

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.5.11
+version: 2.5.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.11
+appVersion: 2.5.12

--- a/frontstage/controllers/party_controller.py
+++ b/frontstage/controllers/party_controller.py
@@ -644,29 +644,6 @@ def create_pending_survey_account(registration_data):
     logger.info("Successfully created account")
 
 
-def get_business_by_ru_ref(ru_ref: str):
-    """
-    Gives call to party service to retrieve a business using a ru_ref parameter
-    :param ru_ref: the reporting unit reference
-    :returns: a business
-    :raises ApiError: Raised when party returns api error
-    """
-    logger.info("Attempting to retrieve business by ru_ref", ru_ref=ru_ref)
-
-    url = f"{app.config['PARTY_URL']}/party-api/v1/businesses/ref/{ru_ref}"
-    response = requests.get(url, auth=app.config["BASIC_AUTH"])
-
-    try:
-        response.raise_for_status()
-    except requests.exceptions.HTTPError:
-        logger.error("Failed to retrieve business by ru_ref", ru_ref=ru_ref)
-        raise ApiError(logger, response)
-
-    logger.info("Successfully retrieved business by ru_ref", ru_ref=ru_ref)
-
-    return response.json()
-
-
 def get_verification_token(party_id):
     """
     Gives call to party service to retrieve a verification token for the respondent

--- a/tests/integration/views/surveys/help/test_surveys_help_something_else.py
+++ b/tests/integration/views/surveys/help/test_surveys_help_something_else.py
@@ -5,7 +5,6 @@ import requests_mock
 
 from frontstage import app
 from tests.integration.mocked_services import (
-    business_party,
     encoded_jwt_token,
     respondent_party,
     survey,
@@ -46,12 +45,10 @@ class TestSurveyHelpInfoAboutThisSurvey(unittest.TestCase):
         self.assertIn("Cancel".encode(), response.data)
 
     @requests_mock.mock()
-    @patch("frontstage.controllers.party_controller.get_business_by_ru_ref")
     @patch("frontstage.controllers.survey_controller.get_survey_by_survey_ref")
-    def test_survey_help_info_bricks_with_option_select(self, mock_request, get_survey, get_business):
+    def test_survey_help_info_bricks_with_option_select(self, mock_request, get_survey):
         mock_request.get(url_banner_api, status_code=404)
         get_survey.return_value = survey
-        get_business.return_value = business_party
         form = {"option": "something-else"}
         response = self.app.post("/surveys/help", data=form, follow_redirects=True)
 
@@ -64,14 +61,10 @@ class TestSurveyHelpInfoAboutThisSurvey(unittest.TestCase):
         self.assertIn("Cancel".encode(), response.data)
 
     @requests_mock.mock()
-    @patch("frontstage.controllers.party_controller.get_business_by_ru_ref")
     @patch("frontstage.controllers.survey_controller.get_survey_by_survey_ref")
-    def test_survey_help_info_bricks_with_sub_option_my_survey_is_not_listed(
-        self, mock_request, get_survey, get_business
-    ):
+    def test_survey_help_info_bricks_with_sub_option_my_survey_is_not_listed(self, mock_request, get_survey):
         mock_request.get(url_banner_api, status_code=404)
         get_survey.return_value = survey
-        get_business.return_value = business_party
         form = {"option": "my-survey-is-not-listed"}
         response = self.app.post(
             "/surveys/help/something-else?survey_id=1&business_id=1&ce_id=1&survey_name=4",
@@ -87,12 +80,10 @@ class TestSurveyHelpInfoAboutThisSurvey(unittest.TestCase):
         self.assertIn("No".encode(), response.data)
 
     @requests_mock.mock()
-    @patch("frontstage.controllers.party_controller.get_business_by_ru_ref")
     @patch("frontstage.controllers.survey_controller.get_survey_by_survey_ref")
-    def test_survey_help_info_bricks_with_no_option_select(self, mock_request, get_survey, get_business):
+    def test_survey_help_info_bricks_with_no_option_select(self, mock_request, get_survey):
         mock_request.get(url_banner_api, status_code=404)
         get_survey.return_value = survey
-        get_business.return_value = business_party
         form = {}
         response = self.app.post("/surveys/help/something-else", data=form, follow_redirects=True)
 
@@ -103,12 +94,10 @@ class TestSurveyHelpInfoAboutThisSurvey(unittest.TestCase):
         self.assertIn("You need to choose an option".encode(), response.data)
 
     @requests_mock.mock()
-    @patch("frontstage.controllers.party_controller.get_business_by_ru_ref")
     @patch("frontstage.controllers.survey_controller.get_survey_by_survey_ref")
-    def test_survey_help_info_bricks_with_sub_option_something_else(self, mock_request, get_survey, get_business):
+    def test_survey_help_info_bricks_with_sub_option_something_else(self, mock_request, get_survey):
         mock_request.get(url_banner_api, status_code=404)
         get_survey.return_value = survey
-        get_business.return_value = business_party
         form = {"option": "something-else"}
         response = self.app.post("/surveys/help/something-else", data=form, follow_redirects=True)
 
@@ -121,14 +110,12 @@ class TestSurveyHelpInfoAboutThisSurvey(unittest.TestCase):
         self.assertIn("Cancel".encode(), response.data)
 
     @requests_mock.mock()
-    @patch("frontstage.controllers.party_controller.get_business_by_ru_ref")
     @patch("frontstage.controllers.survey_controller.get_survey_by_survey_ref")
     def test_survey_help_send_message_info_bricks_with_sub_option_my_survey_is_not_listed(
-        self, mock_request, get_survey, get_business
+        self, mock_request, get_survey
     ):
         mock_request.get(url_banner_api, status_code=404)
         get_survey.return_value = survey
-        get_business.return_value = business_party
         response = self.app.get(
             "/surveys/help/something-else/my-survey-is-not-listed/send-message", follow_redirects=True
         )
@@ -145,15 +132,13 @@ class TestSurveyHelpInfoAboutThisSurvey(unittest.TestCase):
     @patch("frontstage.controllers.party_controller.get_respondent_party_by_id")
     @patch("frontstage.controllers.party_controller.get_survey_list_details_for_party")
     @patch("frontstage.views.surveys.help.surveys_help.send_message")
-    @patch("frontstage.controllers.party_controller.get_business_by_ru_ref")
     @patch("frontstage.controllers.survey_controller.get_survey_by_survey_ref")
     def test_create_message_post_success(
-        self, mock_request, get_survey, get_business, send_message, get_survey_list, get_respondent_party_by_id
+        self, mock_request, get_survey, send_message, get_survey_list, get_respondent_party_by_id
     ):
         mock_request.get(url_banner_api, status_code=404)
         get_survey.return_value = survey
         send_message.return_value = "a5e67f8a-0d90-4d60-a15a-7e334c75402b"
-        get_business.return_value = business_party
         get_survey_list.return_value = survey_list_todo
         get_respondent_party_by_id.return_value = respondent_party
         form = {"body": "info-something-else"}
@@ -169,14 +154,10 @@ class TestSurveyHelpInfoAboutThisSurvey(unittest.TestCase):
     @requests_mock.mock()
     @patch("frontstage.controllers.party_controller.get_survey_list_details_for_party")
     @patch("frontstage.controllers.conversation_controller.send_message")
-    @patch("frontstage.controllers.party_controller.get_business_by_ru_ref")
     @patch("frontstage.controllers.survey_controller.get_survey_by_survey_ref")
-    def test_create_message_post_something_else_failure(
-        self, mock_request, get_survey, get_business, send_message, get_survey_list
-    ):
+    def test_create_message_post_something_else_failure(self, mock_request, get_survey, send_message, get_survey_list):
         mock_request.get(url_banner_api, status_code=404)
         get_survey.return_value = survey
-        get_business.return_value = business_party
         form = {"body": ""}
         response = self.app.post(
             "/surveys/help/something-else/something-else/send-message",

--- a/tests/integration/views/surveys/help/test_technical_help_survey_not_listed.py
+++ b/tests/integration/views/surveys/help/test_technical_help_survey_not_listed.py
@@ -5,7 +5,6 @@ import requests_mock
 
 from frontstage import app
 from tests.integration.mocked_services import (
-    business_party,
     encoded_jwt_token,
     survey,
     survey_list_todo,
@@ -87,14 +86,10 @@ class TestTechnicalHelpSurveyNotListed(unittest.TestCase):
     @requests_mock.mock()
     @patch("frontstage.controllers.party_controller.get_survey_list_details_for_party")
     @patch("frontstage.controllers.conversation_controller.send_message")
-    @patch("frontstage.controllers.party_controller.get_business_by_ru_ref")
     @patch("frontstage.controllers.survey_controller.get_survey_by_survey_ref")
-    def test_create_message_page_technical_fail(
-        self, mock_request, get_survey, get_business, send_message, get_survey_list
-    ):
+    def test_create_message_page_technical_fail(self, mock_request, get_survey, send_message, get_survey_list):
         mock_request.get(url_banner_api, status_code=404)
         get_survey.return_value = survey
-        get_business.return_value = business_party
         form = {"body": ""}
         response = self.app.post(
             "/surveys/technical/send-message?option=my-survey-is-not-listed",


### PR DESCRIPTION
# What and why?
get_business_by_ru_ref is not used in frontstage, but is calling an endpoint which is used by rops that need rationalising. There are also unnecessary mocks which can be remove
# How to test?
Make sure the function is not used 
# Jira
