### PR TITLE
Add test-html to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,3 +36,5 @@ lint-check: load-design-system-templates
 test: lint-check
 	APP_SETTINGS=TestingConfig pipenv run pytest $(TESTS) --cov frontstage --cov-report term-missing
 
+test-html: lint-check
+	APP_SETTINGS=TestingConfig pipenv run pytest $(TESTS) --cov frontstage --cov-report html

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ lint:
 	pipenv check
 	pipenv run isort .
 	pipenv run black --line-length 120 .
-	pipenv run djlint . --ignore=H037,H021
+	pipenv run djlint frontstage/ --ignore=H037,H021
 	pipenv run flake8
 
 lint-check: load-design-system-templates

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ lint-check: load-design-system-templates
 	pipenv check
 	pipenv run isort . --check-only
 	pipenv run black --line-length 120 --check .
-	pipenv run djlint . --ignore=H037,H021
+	pipenv run djlint frontstage/ --ignore=H037,H021
 	pipenv run flake8
 
 test: lint-check

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -703,11 +703,12 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:7d6d50dd97d52cbc355597bd845fabfbac3f551e1f99619e39a35ce8c370b5fa",
-                "sha256:ac8bd6544d4bb2c9792bf3a159e80bba8fda7f07e81bc3aed565432d5925ba90"
+                "sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369",
+                "sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d"
             ],
+            "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==3.1.3"
+            "version": "==3.1.4"
         },
         "jwcrypto": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1755,11 +1755,12 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:1ee4f8a893eb9bef51c6e35730cebf234d5d0b6bd112b0271e10ed7c24a02bd9",
-                "sha256:6cd52cdf0fef0e0f543299cfc96fec90d7b8a7e88745f411ec33eb44d5ed3531"
+                "sha256:23097a41eba115ba99ecae40d06444c15d1c0c698d527a01c6c8bd1c5d0647e5",
+                "sha256:4f41d54107ff9a223dca80b53efe4fb654c67efaba7f47bada3ee9d50e05bd53"
             ],
+            "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==4.66.2"
+            "version": "==4.66.3"
         },
         "urllib3": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ These can be easily run via the following commands:
 ```bash
 make test
 ```
+or if you wish to generate an HTML report viewable at htmlcov/index.html
+```bash
+make test-html
+```
 or if you are running redis in the docker environment
 ```bash
 make docker-test

--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.5.10
+version: 2.5.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.10
+appVersion: 2.5.11

--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -14,9 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-
-version: 2.5.9
+version: 2.5.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.9
+appVersion: 2.5.10


### PR DESCRIPTION
# What and why?
pytest-html offers a nice way to show test reports when devving locally. This exposes it through a make command

# How to test?
`make test-html`

# Jira
