### PR TITLE
Remove EQ version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,14 +20,14 @@ docker-test: REDIS_PORT=6379
 docker-test: test
 
 lint:
-	pipenv check
+	pipenv check --ignore=70612
 	pipenv run isort .
 	pipenv run black --line-length 120 .
 	pipenv run djlint frontstage/ --ignore=H037,H021
 	pipenv run flake8
 
 lint-check: load-design-system-templates
-	pipenv check
+	pipenv check --ignore=70612
 	pipenv run isort . --check-only
 	pipenv run black --line-length 120 --check .
 	pipenv run djlint frontstage/ --ignore=H037,H021

--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.5.13
+version: 2.5.14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.13
+appVersion: 2.5.14

--- a/frontstage/common/eq_payload.py
+++ b/frontstage/common/eq_payload.py
@@ -56,11 +56,13 @@ class EqPayload(object):
         ru_ref = f"{party['sampleUnitRef'] + party['checkletter']}"
         int_time = int(time.time())
 
+        # Note that the version mentioned here is the RM->EQ communication version, not the EQ version
         payload = {
             "exp": int_time + 300,
             "iat": int_time,
             "jti": str(uuid.uuid4()),
             "tx_id": tx_id,
+            "version": "v2",
             "account_service_url": current_app.config["ACCOUNT_SERVICE_URL"],
             "case_id": case["id"],
             "collection_exercise_sid": ce_id,

--- a/frontstage/common/eq_payload.py
+++ b/frontstage/common/eq_payload.py
@@ -61,7 +61,6 @@ class EqPayload(object):
             "iat": int_time,
             "jti": str(uuid.uuid4()),
             "tx_id": tx_id,
-            "version": "v2",
             "account_service_url": current_app.config["ACCOUNT_SERVICE_URL"],
             "case_id": case["id"],
             "collection_exercise_sid": ce_id,

--- a/tests/integration/test_generate_eq.py
+++ b/tests/integration/test_generate_eq.py
@@ -42,9 +42,11 @@ with open("tests/test_data/collection_instrument/collection_instrument_eq.json")
 
 TIME_TO_FREEZE = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
 
+# Note that the version mentioned here is the RM->EQ communication version, not the EQ version
 PAYLOAD = {
     "exp": 1672574700,
     "iat": 1672574400,
+    "version": "v2",
     "account_service_url": "http://frontstage-url/surveys",
     "case_id": "8cdc01f9-656a-4715-a148-ffed0dbe1b04",
     "collection_exercise_sid": "8d990a74-5f07-4765-ac66-df7e1a96505b",

--- a/tests/integration/test_generate_eq.py
+++ b/tests/integration/test_generate_eq.py
@@ -45,7 +45,6 @@ TIME_TO_FREEZE = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
 PAYLOAD = {
     "exp": 1672574700,
     "iat": 1672574400,
-    "version": "v2",
     "account_service_url": "http://frontstage-url/surveys",
     "case_id": "8cdc01f9-656a-4715-a148-ffed0dbe1b04",
     "collection_exercise_sid": "8d990a74-5f07-4765-ac66-df7e1a96505b",

--- a/tests/test_data/collection_exercise/collection_exercise.json
+++ b/tests/test_data/collection_exercise/collection_exercise.json
@@ -1,48 +1,47 @@
 {
-        "id": "8d990a74-5f07-4765-ac66-df7e1a96505b",
-        "surveyId": "cb8accda-6118-4d3b-85a3-149e28960c54",
-        "name": null,
-        "actualExecutionDateTime": "2018-07-12T09:00:27.458Z",
-        "scheduledExecutionDateTime": "2018-07-12T09:00:18.000Z",
-        "scheduledStartDateTime": "2018-07-12T09:00:18.000Z",
-        "actualPublishDateTime": "2018-07-12T09:00:29.051Z",
-        "periodStartDateTime": "2018-07-12T09:00:18.000Z",
-        "periodEndDateTime": "2018-07-23T09:00:13.000Z",
-        "scheduledReturnDateTime": "2018-07-22T09:00:13.000Z",
-        "scheduledEndDateTime": "2018-07-23T09:00:13.000Z",
-        "executedBy": null,
-        "state": "LIVE",
-        "exerciseRef": "204901",
-        "userDescription": "test_exercise",
-        "created": "2018-07-12T09:00:21.568Z",
-        "updated": "2018-07-12T09:01:13.004Z",
-        "deleted": null,
-        "validationErrors": null,
-        "eqVersion": "v2",
-        "events": [
-            {
-                "id": "b3651d8b-bb0b-42f7-a2a3-d05d85822226",
-                "collectionExerciseId": "8d990a74-5f07-4765-ac66-df7e1a96505b",
-                "tag": "mps",
-                "timestamp": "2018-07-12T09:00:18.000Z"
-            },
-            {
-                "id": "052328b1-65ea-4778-a788-ec1ecc846802",
-                "collectionExerciseId": "8d990a74-5f07-4765-ac66-df7e1a96505b",
-                "tag": "go_live",
-                "timestamp": "2018-07-12T09:01:13.000Z"
-            },
-            {
-                "id": "186e1a0f-0a49-4e4a-8e0a-c8db7593117e",
-                "collectionExerciseId": "8d990a74-5f07-4765-ac66-df7e1a96505b",
-                "tag": "return_by",
-                "timestamp": "2018-07-22T09:00:13.000Z"
-            },
-            {
-                "id": "e5c34d4e-e7eb-4e38-a14a-7ca16cca4787",
-                "collectionExerciseId": "8d990a74-5f07-4765-ac66-df7e1a96505b",
-                "tag": "exercise_end",
-                "timestamp": "2018-07-23T09:00:13.000Z"
-            }
-        ]
+    "id": "8d990a74-5f07-4765-ac66-df7e1a96505b",
+    "surveyId": "cb8accda-6118-4d3b-85a3-149e28960c54",
+    "name": null,
+    "actualExecutionDateTime": "2018-07-12T09:00:27.458Z",
+    "scheduledExecutionDateTime": "2018-07-12T09:00:18.000Z",
+    "scheduledStartDateTime": "2018-07-12T09:00:18.000Z",
+    "actualPublishDateTime": "2018-07-12T09:00:29.051Z",
+    "periodStartDateTime": "2018-07-12T09:00:18.000Z",
+    "periodEndDateTime": "2018-07-23T09:00:13.000Z",
+    "scheduledReturnDateTime": "2018-07-22T09:00:13.000Z",
+    "scheduledEndDateTime": "2018-07-23T09:00:13.000Z",
+    "executedBy": null,
+    "state": "LIVE",
+    "exerciseRef": "204901",
+    "userDescription": "test_exercise",
+    "created": "2018-07-12T09:00:21.568Z",
+    "updated": "2018-07-12T09:01:13.004Z",
+    "deleted": null,
+    "validationErrors": null,
+    "events": [
+        {
+            "id": "b3651d8b-bb0b-42f7-a2a3-d05d85822226",
+            "collectionExerciseId": "8d990a74-5f07-4765-ac66-df7e1a96505b",
+            "tag": "mps",
+            "timestamp": "2018-07-12T09:00:18.000Z"
+        },
+        {
+            "id": "052328b1-65ea-4778-a788-ec1ecc846802",
+            "collectionExerciseId": "8d990a74-5f07-4765-ac66-df7e1a96505b",
+            "tag": "go_live",
+            "timestamp": "2018-07-12T09:01:13.000Z"
+        },
+        {
+            "id": "186e1a0f-0a49-4e4a-8e0a-c8db7593117e",
+            "collectionExerciseId": "8d990a74-5f07-4765-ac66-df7e1a96505b",
+            "tag": "return_by",
+            "timestamp": "2018-07-22T09:00:13.000Z"
+        },
+        {
+            "id": "e5c34d4e-e7eb-4e38-a14a-7ca16cca4787",
+            "collectionExerciseId": "8d990a74-5f07-4765-ac66-df7e1a96505b",
+            "tag": "exercise_end",
+            "timestamp": "2018-07-23T09:00:13.000Z"
+        }
+    ]
 }

--- a/tests/test_data/collection_exercise/collection_exercise_v3.json
+++ b/tests/test_data/collection_exercise/collection_exercise_v3.json
@@ -1,48 +1,47 @@
 {
-        "id": "8d990a74-5f07-4765-ac66-df7e1a96505b",
-        "surveyId": "cb8accda-6118-4d3b-85a3-149e28960c54",
-        "name": null,
-        "actualExecutionDateTime": "2018-07-12T09:00:27.458Z",
-        "scheduledExecutionDateTime": "2018-07-12T09:00:18.000Z",
-        "scheduledStartDateTime": "2018-07-12T09:00:18.000Z",
-        "actualPublishDateTime": "2018-07-12T09:00:29.051Z",
-        "periodStartDateTime": "2018-07-12T09:00:18.000Z",
-        "periodEndDateTime": "2018-07-23T09:00:13.000Z",
-        "scheduledReturnDateTime": "2018-07-22T09:00:13.000Z",
-        "scheduledEndDateTime": "2018-07-23T09:00:13.000Z",
-        "executedBy": null,
-        "state": "LIVE",
-        "exerciseRef": "204901",
-        "userDescription": "test_exercise",
-        "created": "2018-07-12T09:00:21.568Z",
-        "updated": "2018-07-12T09:01:13.004Z",
-        "deleted": null,
-        "validationErrors": null,
-        "eqVersion": "v3",
-        "events": [
-            {
-                "id": "b3651d8b-bb0b-42f7-a2a3-d05d85822226",
-                "collectionExerciseId": "8d990a74-5f07-4765-ac66-df7e1a96505b",
-                "tag": "mps",
-                "timestamp": "2018-07-12T09:00:18.000Z"
-            },
-            {
-                "id": "052328b1-65ea-4778-a788-ec1ecc846802",
-                "collectionExerciseId": "8d990a74-5f07-4765-ac66-df7e1a96505b",
-                "tag": "go_live",
-                "timestamp": "2018-07-12T09:01:13.000Z"
-            },
-            {
-                "id": "186e1a0f-0a49-4e4a-8e0a-c8db7593117e",
-                "collectionExerciseId": "8d990a74-5f07-4765-ac66-df7e1a96505b",
-                "tag": "return_by",
-                "timestamp": "2018-07-22T09:00:13.000Z"
-            },
-            {
-                "id": "e5c34d4e-e7eb-4e38-a14a-7ca16cca4787",
-                "collectionExerciseId": "8d990a74-5f07-4765-ac66-df7e1a96505b",
-                "tag": "exercise_end",
-                "timestamp": "2018-07-23T09:00:13.000Z"
-            }
-        ]
+    "id": "8d990a74-5f07-4765-ac66-df7e1a96505b",
+    "surveyId": "cb8accda-6118-4d3b-85a3-149e28960c54",
+    "name": null,
+    "actualExecutionDateTime": "2018-07-12T09:00:27.458Z",
+    "scheduledExecutionDateTime": "2018-07-12T09:00:18.000Z",
+    "scheduledStartDateTime": "2018-07-12T09:00:18.000Z",
+    "actualPublishDateTime": "2018-07-12T09:00:29.051Z",
+    "periodStartDateTime": "2018-07-12T09:00:18.000Z",
+    "periodEndDateTime": "2018-07-23T09:00:13.000Z",
+    "scheduledReturnDateTime": "2018-07-22T09:00:13.000Z",
+    "scheduledEndDateTime": "2018-07-23T09:00:13.000Z",
+    "executedBy": null,
+    "state": "LIVE",
+    "exerciseRef": "204901",
+    "userDescription": "test_exercise",
+    "created": "2018-07-12T09:00:21.568Z",
+    "updated": "2018-07-12T09:01:13.004Z",
+    "deleted": null,
+    "validationErrors": null,
+    "events": [
+        {
+            "id": "b3651d8b-bb0b-42f7-a2a3-d05d85822226",
+            "collectionExerciseId": "8d990a74-5f07-4765-ac66-df7e1a96505b",
+            "tag": "mps",
+            "timestamp": "2018-07-12T09:00:18.000Z"
+        },
+        {
+            "id": "052328b1-65ea-4778-a788-ec1ecc846802",
+            "collectionExerciseId": "8d990a74-5f07-4765-ac66-df7e1a96505b",
+            "tag": "go_live",
+            "timestamp": "2018-07-12T09:01:13.000Z"
+        },
+        {
+            "id": "186e1a0f-0a49-4e4a-8e0a-c8db7593117e",
+            "collectionExerciseId": "8d990a74-5f07-4765-ac66-df7e1a96505b",
+            "tag": "return_by",
+            "timestamp": "2018-07-22T09:00:13.000Z"
+        },
+        {
+            "id": "e5c34d4e-e7eb-4e38-a14a-7ca16cca4787",
+            "collectionExerciseId": "8d990a74-5f07-4765-ac66-df7e1a96505b",
+            "tag": "exercise_end",
+            "timestamp": "2018-07-23T09:00:13.000Z"
+        }
+    ]
 }

--- a/tests/test_data/collection_exercise/collection_exercise_with_supplementary_dataset.json
+++ b/tests/test_data/collection_exercise/collection_exercise_with_supplementary_dataset.json
@@ -1,54 +1,53 @@
 {
-   "id":"8d990a74-5f07-4765-ac66-df7e1a96505b",
-   "surveyId":"cb8accda-6118-4d3b-85a3-149e28960c54",
-   "name":null,
-   "actualExecutionDateTime":"2018-07-12T09:00:27.458Z",
-   "scheduledExecutionDateTime":"2018-07-12T09:00:18.000Z",
-   "scheduledStartDateTime":"2018-07-12T09:00:18.000Z",
-   "actualPublishDateTime":"2018-07-12T09:00:29.051Z",
-   "periodStartDateTime":"2018-07-12T09:00:18.000Z",
-   "periodEndDateTime":"2018-07-23T09:00:13.000Z",
-   "scheduledReturnDateTime":"2018-07-22T09:00:13.000Z",
-   "scheduledEndDateTime":"2018-07-23T09:00:13.000Z",
-   "executedBy":null,
-   "state":"LIVE",
-   "exerciseRef":"204901",
-   "userDescription":"test_exercise",
-   "created":"2018-07-12T09:00:21.568Z",
-   "updated":"2018-07-12T09:01:13.004Z",
-   "deleted":null,
-   "validationErrors":null,
-   "eqVersion":"v3",
-   "events":[
+   "id": "8d990a74-5f07-4765-ac66-df7e1a96505b",
+   "surveyId": "cb8accda-6118-4d3b-85a3-149e28960c54",
+   "name": null,
+   "actualExecutionDateTime": "2018-07-12T09:00:27.458Z",
+   "scheduledExecutionDateTime": "2018-07-12T09:00:18.000Z",
+   "scheduledStartDateTime": "2018-07-12T09:00:18.000Z",
+   "actualPublishDateTime": "2018-07-12T09:00:29.051Z",
+   "periodStartDateTime": "2018-07-12T09:00:18.000Z",
+   "periodEndDateTime": "2018-07-23T09:00:13.000Z",
+   "scheduledReturnDateTime": "2018-07-22T09:00:13.000Z",
+   "scheduledEndDateTime": "2018-07-23T09:00:13.000Z",
+   "executedBy": null,
+   "state": "LIVE",
+   "exerciseRef": "204901",
+   "userDescription": "test_exercise",
+   "created": "2018-07-12T09:00:21.568Z",
+   "updated": "2018-07-12T09:01:13.004Z",
+   "deleted": null,
+   "validationErrors": null,
+   "events": [
       {
-         "id":"b3651d8b-bb0b-42f7-a2a3-d05d85822226",
-         "collectionExerciseId":"8d990a74-5f07-4765-ac66-df7e1a96505b",
-         "tag":"mps",
-         "timestamp":"2018-07-12T09:00:18.000Z"
+         "id": "b3651d8b-bb0b-42f7-a2a3-d05d85822226",
+         "collectionExerciseId": "8d990a74-5f07-4765-ac66-df7e1a96505b",
+         "tag": "mps",
+         "timestamp": "2018-07-12T09:00:18.000Z"
       },
       {
-         "id":"052328b1-65ea-4778-a788-ec1ecc846802",
-         "collectionExerciseId":"8d990a74-5f07-4765-ac66-df7e1a96505b",
-         "tag":"go_live",
-         "timestamp":"2018-07-12T09:01:13.000Z"
+         "id": "052328b1-65ea-4778-a788-ec1ecc846802",
+         "collectionExerciseId": "8d990a74-5f07-4765-ac66-df7e1a96505b",
+         "tag": "go_live",
+         "timestamp": "2018-07-12T09:01:13.000Z"
       },
       {
-         "id":"186e1a0f-0a49-4e4a-8e0a-c8db7593117e",
-         "collectionExerciseId":"8d990a74-5f07-4765-ac66-df7e1a96505b",
-         "tag":"return_by",
-         "timestamp":"2018-07-22T09:00:13.000Z"
+         "id": "186e1a0f-0a49-4e4a-8e0a-c8db7593117e",
+         "collectionExerciseId": "8d990a74-5f07-4765-ac66-df7e1a96505b",
+         "tag": "return_by",
+         "timestamp": "2018-07-22T09:00:13.000Z"
       },
       {
-         "id":"e5c34d4e-e7eb-4e38-a14a-7ca16cca4787",
-         "collectionExerciseId":"8d990a74-5f07-4765-ac66-df7e1a96505b",
-         "tag":"exercise_end",
-         "timestamp":"2018-07-23T09:00:13.000Z"
+         "id": "e5c34d4e-e7eb-4e38-a14a-7ca16cca4787",
+         "collectionExerciseId": "8d990a74-5f07-4765-ac66-df7e1a96505b",
+         "tag": "exercise_end",
+         "timestamp": "2018-07-23T09:00:13.000Z"
       }
    ],
-   "supplementaryDatasetEntity":{
-      "id":1,
-      "exerciseFK":69,
-      "supplementaryDatasetId":"b9a87999-fcc0-4085-979f-06390fb5dddd",
-      "supplementaryDatasetJson":"{\"survey_id\":\"001\",\"period_id\":\"220823\",\"form_types\":[\"0001\",\"1234\"],\"title\":\"Test dataset for survey id 009 period 220823\",\"sds_published_at\":\"2023-08-22T14:46:36Z\",\"total_reporting_units\":2,\"schema_version\":\"v1.0.0\",\"sds_dataset_version\":4,\"filename\":\"373d9a77-2ee5-4c1f-a6dd-8d07b0ea9793.json\",\"dataset_id\":\"b9a87999-fcc0-4085-979f-06390fb5dddd\"}"
+   "supplementaryDatasetEntity": {
+      "id": 1,
+      "exerciseFK": 69,
+      "supplementaryDatasetId": "b9a87999-fcc0-4085-979f-06390fb5dddd",
+      "supplementaryDatasetJson": "{\"survey_id\":\"001\",\"period_id\":\"220823\",\"form_types\":[\"0001\",\"1234\"],\"title\":\"Test dataset for survey id 009 period 220823\",\"sds_published_at\":\"2023-08-22T14:46:36Z\",\"total_reporting_units\":2,\"schema_version\":\"v1.0.0\",\"sds_dataset_version\":4,\"filename\":\"373d9a77-2ee5-4c1f-a6dd-8d07b0ea9793.json\",\"dataset_id\":\"b9a87999-fcc0-4085-979f-06390fb5dddd\"}"
    }
 }


### PR DESCRIPTION
# What and why?
EQ v2 has been dead for some time, this removes the concept of a particular version. It also temporarily mutes the Jinja vulnerability as the fix hasn't yet been released

# How to test?
General smoke test around surveys

# Jira
RAS-1144