### PR TITLE
Update sdc-cryptography 2.1.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-
       - name: Build
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,8 +59,8 @@ jobs:
       - name: Build
         run: |
           python -m pip install --upgrade pip
-          pip install pipenv
-          pipenv install --dev -c constraints.txt
+          pip install pipenv -c constraints.txt
+          pipenv install --dev
       - name: Load Design System templates
         run: |
           make load-design-system-templates

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pipenv
-          pipenv install --dev
+          pipenv install --dev --no-build-isolation
       - name: Load Design System templates
         run: |
           make load-design-system-templates

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,13 +53,10 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Create constraints.txt
-        run: echo 'setuptools<72' > constraints.txt
-
       - name: Build
         run: |
           python -m pip install --upgrade pip
-          pip install pipenv -c constraints.txt
+          pip install pipenv
           pipenv install --dev
       - name: Load Design System templates
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,11 +52,15 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
+
+      - name: Create constraints.txt
+        run: echo 'setuptools<72' > constraints.txt
+
       - name: Build
         run: |
           python -m pip install --upgrade pip
           pip install pipenv
-          pipenv install --dev --no-build-isolation
+          pipenv install --dev -c constraints.txt
       - name: Load Design System templates
         run: |
           make load-design-system-templates

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1014,11 +1014,11 @@
         },
         "sdc-cryptography": {
             "hashes": [
-                "sha256:1c15e8e412c89c30f129e3b60e2bfc60017a7e9a1e11ef3401e328b154958651",
-                "sha256:b39547b0d80c401e9419e44496430c2e498fd2ff59f76b7b89adf7697d5b23db"
+                "sha256:2b87da178c0d9c6a8add4e2afbe81139bbb056598af0cda61b52f421fb29451f",
+                "sha256:cea2de62e65940efb72bfd3ed677b1e685678521a52eb4c06769ffce506f5847"
             ],
             "index": "pypi",
-            "version": "==1.2.0"
+            "version": "==1.2.1"
         },
         "setuptools": {
             "hashes": [
@@ -1054,11 +1054,11 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475",
-                "sha256:b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb"
+                "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
+                "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==4.10.0"
+            "version": "==4.12.2"
         },
         "uritemplate": {
             "hashes": [

--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.5.18
+version: 2.5.19
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.18
+appVersion: 2.5.19

--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.5.19
+version: 2.5.18
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.19
+appVersion: 2.5.18


### PR DESCRIPTION
# What and why?
Updates the version of sdc-cryptography to address a vulnerability.

# How to test?
Check all works after the version bump.
# Jira
https://jira.ons.gov.uk/secure/RapidBoard.jspa?rapidView=1493&projectKey=RAS&view=detail&selectedIssue=RAS-1237