### PR TITLE
Contact us before login

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,12 +5,12 @@ name: Build
 on:
   push:
     branches:
-      - main
+      - survey-respondent-help-journey
     paths-ignore:
       - _infra/spinnaker/**
   pull_request:
     branches:
-      - main
+      - survey-respondent-help-journey
     paths-ignore:
       - _infra/spinnaker/**
 

--- a/README.md
+++ b/README.md
@@ -132,4 +132,3 @@ gpg --armor --export ED1B7A3EADF95687
 current saved exported  public private keys are dev-public-key.asc dev-private-key.asc
 The private key is only supplied for testing decryption
 passphase if needed is PASSWORD1
-

--- a/README.md
+++ b/README.md
@@ -132,3 +132,4 @@ gpg --armor --export ED1B7A3EADF95687
 current saved exported  public private keys are dev-public-key.asc dev-private-key.asc
 The private key is only supplied for testing decryption
 passphase if needed is PASSWORD1
+

--- a/frontstage/templates/contact-us.html
+++ b/frontstage/templates/contact-us.html
@@ -37,8 +37,8 @@
     </h2>
     <div class="ons-u-mb-xs">
         <p> +44 300 1234 931<br/>
-            Monday to Thursday 8:30am – 5pm<br/>
-            Friday 8:30am - 4:30pm</p>
+            Monday to Thursday 8:30am to 5:00pm<br/>
+            Friday 8:30am to 4:00pm</p>
     </div>
     <h2>
         Post

--- a/frontstage/templates/contact-us.html
+++ b/frontstage/templates/contact-us.html
@@ -1,21 +1,42 @@
 
 {% extends "layouts/_block_content.html" %}
 {% from "components/address-output/_macro.njk" import onsAddressOutput %}
+{% from "components/breadcrumbs/_macro.njk" import onsBreadcrumbs %}
 
 {% set page_title = "Contact us" %}
+
+{% set breadcrumbsData = [
+    {
+        "text": "Back",
+        "url": "/sign-in/",
+        "id": "b-item"
+    }
+] %}
+{% block breadcrumbs %}
+    {{
+        onsBreadcrumbs({
+            "ariaLabel": "Breadcrumbs",
+            "id": "breadcrumbs",
+            "itemsList": breadcrumbsData
+        })
+    }}
+{% endblock breadcrumbs %}
 
 {% block main %}
 
     <h1 class="ons-u-fs-xl">Contact us</h1>
 
     <h2>
-        Telephone
+        Email
     </h2>
-    <div class="ons-u-fs-r">
-        <p><a href="tel:+44-300-1234-931">0300 1234 931</a></p>
+    <div class="ons-u-mb-xs">
+        <p><a href="mailto:surveys@ons.gov.uk">surveys@ons.gov.uk</a></p>
     </div>
-    <div class="ons-u-fs-r">
-        <p class="ons-u-mb-l">Opening hours:<br />
+    <h2>
+        Phone
+    </h2>
+    <div class="ons-u-mb-xs">
+        <p> +44 300 1234 931<br/>
             Monday to Thursday 8:30am – 5pm<br/>
             Friday 8:30am - 4:30pm</p>
     </div>

--- a/frontstage/templates/contact-us.html
+++ b/frontstage/templates/contact-us.html
@@ -25,22 +25,22 @@
 {% block main %}
     <h1 class="ons-u-fs-xxl">Contact us</h1>
 
-    <h1>
+    <h2>
         Email
-    </h1>
+    </h2>
         <p><a href="mailto:surveys@ons.gov.uk">surveys@ons.gov.uk</a></p>
 
-    <h1>
+    <h2>
         Phone
-    </h1>
+    </h2>
     <div class="ons-u-mb-xs">
         <p> +44 300 1234 931<br/>
             Monday to Thursday 8:30am to 5:00pm<br/>
             Friday 8:30am to 4:00pm</p>
     </div>
-    <h1>
+    <h2>
         Post
-    </h1>
+    </h2>
     {{
         onsAddressOutput({
             "unit": 'Office for National Statistics',

--- a/frontstage/templates/contact-us.html
+++ b/frontstage/templates/contact-us.html
@@ -23,26 +23,24 @@
 {% endblock breadcrumbs %}
 
 {% block main %}
+    <h1 class="ons-u-fs-xxl">Contact us</h1>
 
-    <h1 class="ons-u-fs-xl">Contact us</h1>
-
-    <h2>
+    <h1>
         Email
-    </h2>
-    <div class="ons-u-mb-xs">
+    </h1>
         <p><a href="mailto:surveys@ons.gov.uk">surveys@ons.gov.uk</a></p>
-    </div>
-    <h2>
+
+    <h1>
         Phone
-    </h2>
+    </h1>
     <div class="ons-u-mb-xs">
         <p> +44 300 1234 931<br/>
             Monday to Thursday 8:30am to 5:00pm<br/>
             Friday 8:30am to 4:00pm</p>
     </div>
-    <h2>
+    <h1>
         Post
-    </h2>
+    </h1>
     {{
         onsAddressOutput({
             "unit": 'Office for National Statistics',

--- a/tests/unit/views/test_cookies_and_contact.py
+++ b/tests/unit/views/test_cookies_and_contact.py
@@ -38,6 +38,4 @@ class TestCookiesContact(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertTrue("Contact us".encode() in response.data)
-        self.assertTrue('aria-label="Breadcrumbs"'.encode() in response.data)
-        self.assertIn(b'href="mailto:surveys@ons.gov.uk"', response.data)
         self.assertIn(b'href="/sign-in/"', response.data)

--- a/tests/unit/views/test_cookies_and_contact.py
+++ b/tests/unit/views/test_cookies_and_contact.py
@@ -38,4 +38,6 @@ class TestCookiesContact(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertTrue("Contact us".encode() in response.data)
-        self.assertTrue("Opening hours:".encode() in response.data)
+        self.assertTrue('aria-label="Breadcrumbs"'.encode() in response.data)
+        self.assertIn(b'href="mailto:surveys@ons.gov.uk"', response.data)
+        self.assertIn(b'href="/sign-in/"', response.data)


### PR DESCRIPTION
# What and why?
As part of the updated user help journey we want to improve the contact us page before a user has logged in to enhance user experience. 
# How to test?
Ensure the implementation matches the Figma documents and the contact us page is working correctly. 
N.B. There is an upcoming card to update the contact us after login, which will contain the functionality to separate the two pages.
# Jira
https://jira.ons.gov.uk/secure/RapidBoard.jspa?rapidView=1493&projectKey=RAS&view=detail&selectedIssue=RAS-1155