### PR TITLE
Add image appuser

### DIFF
--- a/_infra/docker/Dockerfile
+++ b/_infra/docker/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /app
 COPY . /app
 
 RUN groupadd -r appuser && useradd -r -g appuser -u 9000 appuser && chown -R appuser:appuser .
+RUN mkdir /home/appuser && chown appuser:appuser /home/appuser
 RUN pipenv install --deploy --system
 
 USER appuser

--- a/_infra/docker/Dockerfile
+++ b/_infra/docker/Dockerfile
@@ -7,7 +7,10 @@ RUN pip install pipenv
 WORKDIR /app
 
 COPY . /app
+
+RUN groupadd -r appuser && useradd -r -g appuser -u 9000 appuser && chown -R appuser:appuser .
 RUN pipenv install --deploy --system
 
-CMD ["gunicorn", "-b", "0.0.0.0:9000", "--workers", "4", "--timeout", "300", "frontstage:app"]
+USER appuser
 
+CMD ["gunicorn", "-b", "0.0.0.0:9000", "--workers", "4", "--timeout", "300", "frontstage:app"]

--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.5.27
+version: 2.5.28
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.27
+appVersion: 2.5.28


### PR DESCRIPTION
# What and why?

The current Python app is running as `root`. This adds an `appuser` to run the Python app. The previous attempt to do this caused the error
```
gpg: Fatal: can't create directory '/home/appuser/.gnupg': No such file or directory
```
This was due to the `gnupg` library having OS file system dependencies as detailed in the docs https://gnupg.readthedocs.io/en/latest/#before-you-start

The `useradd`  Linux command does not create a `/home` directory for the user being added and has no option to do so. There is an alternative `adduser` command that accepts a flag to create a home directory, however the approach in this PR to manually create the directory is more explicit.

**NOTE:** The continued use of the `/home` directory within the container OS is NOT good practice. However, this is currently the situation with the app running as root, and this PR doesn't change that. Separately we should look at an alternative to allowing gnupg writing to the container OS `/home/appuser/.gnupg` directory such as mounting a dedicated volume into the pods.

# How to test?

Deploy this to your dev namespace and ensure you can upload a SEFT spreadsheet response successfully.

For a wider understanding, exec into the container and check the gnupg directory for artifacts and appuser ownership

```
kubectl exec --namespace=$NAMESPACE --stdin --tty $POD -- /bin/bash
appuser@frontstage-69f8b85c86-mllkm:/app$ ls -ltra /home/appuser/.gnupg
```

# Jira
 
https://jira.ons.gov.uk/browse/RAS-1305