### PR TITLE
RAS-1400 Extend party enrolment to include business and survey details

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.5.35
+version: 2.5.36
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.35
+appVersion: 2.5.36

--- a/frontstage/common/redis_cache.py
+++ b/frontstage/common/redis_cache.py
@@ -12,39 +12,13 @@ from frontstage.controllers.collection_exercise_controller import (
 from frontstage.controllers.collection_instrument_controller import (
     get_collection_instrument,
 )
-from frontstage.controllers.party_controller import get_party_by_business_id
-from frontstage.controllers.survey_controller import get_survey
 
 logger = wrap_logger(logging.getLogger(__name__))
 
 
 class RedisCache:
-    SURVEY_CATEGORY_EXPIRY = 600  # 10 mins
     COLLECTION_INSTRUMENT_CATEGORY_EXPIRY = 600  # 10 mins
-    BUSINESS_PARTY_CATEGORY_EXPIRY = 600  # 10 mins
     COLLECTION_EXERCISE_CATEGORY_EXPIRY = 600  # 10 mins
-
-    def get_survey(self, key):
-        """
-        Gets the survey from redis or the collection-instrument service
-
-        :param key: Key in redis (for this example will be a frontstage:survey:id)
-        :return: Result from either the cache or survey service
-        """
-        redis_key = f"frontstage:survey:{key}"
-        try:
-            result = redis.get(redis_key)
-        except RedisError:
-            logger.error("Error getting value from cache, please investigate", key=redis_key, exc_info=True)
-            result = None
-
-        if not result:
-            logger.info("Key not in cache, getting value from survey service", key=redis_key)
-            result = get_survey(app.config["SURVEY_URL"], app.config["BASIC_AUTH"], key)
-            self.save(redis_key, result, self.SURVEY_CATEGORY_EXPIRY)
-            return result
-
-        return json.loads(result.decode("utf-8"))
 
     def get_collection_instrument(self, key):
         """
@@ -64,28 +38,6 @@ class RedisCache:
             logger.info("Key not in cache, getting value from collection instrument service", key=redis_key)
             result = get_collection_instrument(key, app.config["COLLECTION_INSTRUMENT_URL"], app.config["BASIC_AUTH"])
             self.save(redis_key, result, self.COLLECTION_INSTRUMENT_CATEGORY_EXPIRY)
-            return result
-
-        return json.loads(result.decode("utf-8"))
-
-    def get_business_party(self, key):
-        """
-        Gets the business party from redis or the party service
-
-        :param key: Key in redis (for this example will be a frontstage:business-party:id)
-        :return: Result from either the cache or party service
-        """
-        redis_key = f"frontstage:business-party:{key}"
-        try:
-            result = redis.get(redis_key)
-        except RedisError:
-            logger.error("Error getting value from cache, please investigate", key=redis_key, exc_info=True)
-            result = None
-
-        if not result:
-            logger.info("Key not in cache, getting value from party service", key=redis_key)
-            result = get_party_by_business_id(key, app.config["PARTY_URL"], app.config["BASIC_AUTH"])
-            self.save(redis_key, result, self.BUSINESS_PARTY_CATEGORY_EXPIRY)
             return result
 
         return json.loads(result.decode("utf-8"))

--- a/frontstage/controllers/case_controller.py
+++ b/frontstage/controllers/case_controller.py
@@ -99,7 +99,7 @@ def get_case_data(case_id, party_id, business_party_id, survey_short_name):
     # Check if respondent has permission to see case data
     case = get_case_by_case_id(case_id)
     survey = survey_controller.get_survey_by_short_name(survey_short_name)
-    if not party_controller.is_respondent_enrolled(party_id, business_party_id, survey):
+    if not party_controller.is_respondent_enrolled(party_id, business_party_id, survey["id"]):
         raise NoSurveyPermission(party_id, case_id)
 
     case_data = {
@@ -152,7 +152,7 @@ def get_eq_url(case, collection_exercise, party_id, business_party_id, survey_sh
         abort(403)
 
     survey = survey_controller.get_survey_by_short_name(survey_short_name)
-    if not party_controller.is_respondent_enrolled(party_id, business_party_id, survey):
+    if not party_controller.is_respondent_enrolled(party_id, business_party_id, survey["id"]):
         raise NoSurveyPermission(party_id, case_id)
 
     payload = EqPayload().create_payload(case, collection_exercise, party_id, business_party_id, survey)

--- a/frontstage/views/surveys/download_survey.py
+++ b/frontstage/views/surveys/download_survey.py
@@ -28,7 +28,7 @@ def download_survey(session):
     # Check if respondent has permission to download for this case
     case = case_controller.get_case_by_case_id(case_id)
     survey = survey_controller.get_survey_by_short_name(survey_short_name)
-    if not party_controller.is_respondent_enrolled(party_id, business_party_id, survey):
+    if not party_controller.is_respondent_enrolled(party_id, business_party_id, survey["id"]):
         raise NoSurveyPermission(party_id, case_id)
 
     collection_instrument, headers = collection_instrument_controller.download_collection_instrument(

--- a/frontstage/views/surveys/upload_survey.py
+++ b/frontstage/views/surveys/upload_survey.py
@@ -42,7 +42,7 @@ def upload_survey(session):
 
     # Check if respondent has permission to upload for this case
     survey = survey_controller.get_survey_by_short_name(survey_short_name)
-    if not party_controller.is_respondent_enrolled(party_id, business_party_id, survey):
+    if not party_controller.is_respondent_enrolled(party_id, business_party_id, survey["id"]):
         raise NoSurveyPermission(party_id, case_id)
 
     case = case_controller.get_case_by_case_id(case_id)

--- a/tests/unit/controllers/test_party_controller.py
+++ b/tests/unit/controllers/test_party_controller.py
@@ -43,8 +43,10 @@ registration_data = {
 RESPONDENT_ID = "f956e8ae-6e0f-4414-b0cf-a07c1aa3e37b"
 BUSINESS_ID = "252ffe73-8c97-4ef5-899e-3df092454d31"
 SURVEY_ID = "f82bf312-d677-484b-be57-c83148446095"
-IS_RESPONDENT_ENROLLED_URL= (f"{app.config['PARTY_URL']}/party-api/v1/enrolments/is_respondent_enrolled/{RESPONDENT_ID}"
-                            f"/business_id/{BUSINESS_ID}/survey_id/{SURVEY_ID}")
+IS_RESPONDENT_ENROLLED_URL = (
+    f"{app.config['PARTY_URL']}/party-api/v1/enrolments/is_respondent_enrolled/{RESPONDENT_ID}"
+    f"/business_id/{BUSINESS_ID}/survey_id/{SURVEY_ID}"
+)
 
 
 class TestPartyController(unittest.TestCase):

--- a/tests/unit/test_redis_cache.py
+++ b/tests/unit/test_redis_cache.py
@@ -15,25 +15,25 @@ class TestRedisCache(unittest.TestCase):
 
     @patch("redis.StrictRedis.get")
     def test_get(self, redis_get):
-        redis_get.return_value = b'{"shortName": "MBS"}'
+        redis_get.return_value = b'{"type": "SEFT"}'
         with app.app_context():
             cache = RedisCache()
-            result = cache.get_survey(test_uuid)
-            self.assertEqual(result, {"shortName": "MBS"})
+            result = cache.get_collection_instrument(test_uuid)
+            self.assertEqual(result, {"type": "SEFT"})
 
     @patch("redis.StrictRedis.get")
     def test_get_not_in_cache(self, redis_get):
         redis_get.return_value = None
-        survey_response = {"shortName": "MBS"}
+        ci_response = {"type": "SEFT"}
         with responses.RequestsMock() as rsps:
             rsps.add(
                 rsps.GET,
-                f"http://localhost:8080/surveys/{test_uuid}",
-                json=survey_response,
+                f"http://localhost:8002/collection-instrument-api/1.0.2/{test_uuid}",
+                json=ci_response,
                 status=200,
                 content_type="application/json",
             )
             with app.app_context():
                 cache = RedisCache()
-                result = cache.get_survey(test_uuid)
-                self.assertEqual(result, {"shortName": "MBS"})
+                result = cache.get_collection_instrument(test_uuid)
+                self.assertEqual(result, {"type": "SEFT"})


### PR DESCRIPTION
# What and why?
This PR updates the survey_list build process, instead of using redis and calling to party/survey multiple times it is provided on the first call. It also adds a call to a new endpoint specially for checking a respondent is enrolled 
# How to test?
Deploy this card as well https://github.com/ONSdigital/ras-party/pull/449. Add some enrolment data to your account, acceptance tests could be used, but you might want to add another IAC as well. If it logs in you are good. Also check you can access a eq, download and upload a seft
# Jira
