### PR TITLE
Bump setup-gcloud to v2 and spinnaker-action upgrade branch

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -19,10 +19,10 @@ jobs:
         with:
           credentials_json: ${{ secrets.GCR_KEY }}
       - name: Setup Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ secrets.GOOGLE_PROJECT_ID }}
-      - uses: onsdigital/ras-rm-spinnaker-action@main
+      - uses: onsdigital/ras-rm-spinnaker-action@upgrade-packages
         with:
           comment-body: ${{ github.event.comment.body }}
           gcp-project: ${{ secrets.GOOGLE_PROJECT_ID }}


### PR DESCRIPTION
# What and why?

The slash deploy comment.yaml is not working as expected and `google-github-actions/setup-gcloud@v0` is no longer supported