### PR TITLE
Fix issue of sending blank surveyID to SMV2

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.5.37
+version: 2.5.38
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.37
+appVersion: 2.5.38

--- a/frontstage/controllers/conversation_controller.py
+++ b/frontstage/controllers/conversation_controller.py
@@ -150,6 +150,9 @@ def send_message(
         )
 
     if current_app.config["SECURE_MESSAGE_VERSION"] in ("v2", "both"):
+        # This code was added due to an issue between the crossover of SM V1 and SM V2. The problem is outlined below:
+        # SM V1 stores empty survey_ids as empty strings whereas SM V2 uses a 'None' value.
+        # So this will break SM V2 which is implemented to except optional UUIDs.
         if survey_id == "":
             survey_id = None
 

--- a/frontstage/controllers/conversation_controller.py
+++ b/frontstage/controllers/conversation_controller.py
@@ -150,6 +150,9 @@ def send_message(
         )
 
     if current_app.config["SECURE_MESSAGE_VERSION"] in ("v2", "both"):
+        if survey_id == "":
+            survey_id = None
+
         sm_v2_thread = {
             "subject": subject,
             "category": category,


### PR DESCRIPTION
# What and why?
It was was found during the testing of https://jira.ons.gov.uk/browse/RAS-1402 that a message could not be sent from Frontstage when the secure message V2 was switched on. This wasn't noticed until preprod as this was unexpected. It was nothing to do with the code change as part of the reference Jira card it was just a more in depth test was conducted which highlighted the defect. 

The problem being was that SM V1 stores empty survey_ids as empty strings whereas SM V2 uses a 'None' value. So this will break SM V2 which is implemented to except optional UUIDs.

This change should fix the issue. 

# How to test?
- Send a new 'Something else' message in Frontstage via the 'My Account' screen
- Go back to the sent message screen and try to send another message in the same thread
- This should send correctly and you should be sent back to the message screen. 

# Jira
No ticket but related to https://jira.ons.gov.uk/browse/RAS-1402