### PR TITLE
updated cancel button navigation

### DIFF
--- a/frontstage/templates/help/help-info-ons.html
+++ b/frontstage/templates/help/help-info-ons.html
@@ -75,7 +75,7 @@
                         "submitType": "timer"
                     })
                 }}
-                <a href="{{ url_for('help_bp.help_page') }}"
+                <a href="{{ url_for('surveys_bp.get_survey_list', tag='todo') }}"
                     role="button" class="ons-btn ons-btn--link ons-btn--secondary" id="btn-who-ons-option-cancel"><span class="ons-btn__inner">Cancel</span></a>
             </div>
         </div>


### PR DESCRIPTION
# What and why?
This PR updates the cancel button on the info about the ONS page. 
# How to test?
Check that when pressing cancel the button takes you back to the survey todo page.
# Jira
[RAS-1488](https://jira.ons.gov.uk/browse/RAS-1488)