### PR TITLE
RAS-1519 Secure message - no enrolments

### DIFF
--- a/frontstage/controllers/conversation_controller.py
+++ b/frontstage/controllers/conversation_controller.py
@@ -186,7 +186,7 @@ def send_secure_message(form, msg_to=["GROUP"]) -> UUID:
     return sm_v2_message_json["id"] if current_app.config["SECURE_MESSAGE_VERSION"] == "v2" else sm_v1_msg_id
 
 
-def secure_message_enrolment_options(respondent_enrolments: dict, secure_message_form: SecureMessagingForm) -> dict:
+def secure_message_enrolment_options(respondent_enrolments: list, secure_message_form: SecureMessagingForm) -> dict:
     """returns a dict of secure message options based on a respondent_enrolments"""
 
     survey_options = _create_survey_options(respondent_enrolments)
@@ -200,7 +200,7 @@ def secure_message_enrolment_options(respondent_enrolments: dict, secure_message
         ),
     }
 
-    secure_message_form.business_id = respondent_enrolments["business_id"]
+    secure_message_form.business_id = respondent_enrolments[0]["business_id"] if respondent_enrolments else None
 
     return sm_enrolment_options
 
@@ -256,10 +256,12 @@ def get_message_count_from_api(session) -> int:
         return 0
 
 
-def _create_survey_options(respondent_enrolments: dict) -> list:
+def _create_survey_options(respondent_enrolments: list) -> list:
     survey_options = [Option("Not survey related", "Not survey related")]
-    for survey in respondent_enrolments["survey_details"]:
-        survey_options.append(Option(survey["id"], survey["long_name"]))
+
+    if respondent_enrolments:
+        for survey in respondent_enrolments[0]["survey_details"]:
+            survey_options.append(Option(survey["id"], survey["long_name"]))
     return survey_options
 
 
@@ -272,8 +274,9 @@ def _create_organisation_options(business_details: list) -> list:
 
 def _create_formatted_option_list(options: list, selected: str, disabled_option: dict) -> list:
     formatted_option_list = [disabled_option]
+    sorted_options = sorted(options, key=lambda k: k.text)
 
-    for option in sorted(options, key=lambda k: k.text):
+    for option in sorted_options:
         option_dict = {"value": option.value, "text": option.text}
         if selected == option.value:
             option_dict["selected"] = True

--- a/frontstage/views/contact_us.py
+++ b/frontstage/views/contact_us.py
@@ -72,7 +72,7 @@ def send_message(session) -> str:
     if len(respondent_enrolments) > 1:
         return redirect(url_for("contact_us_bp.select_organisation"))
 
-    enrolment_options = secure_message_enrolment_options(respondent_enrolments[0], secure_message_form)
+    enrolment_options = secure_message_enrolment_options(respondent_enrolments, secure_message_form)
     back_url = (
         url_for("contact_us_bp.select_organisation")
         if url_business_id

--- a/tests/integration/controllers/test_conversation_controller.py
+++ b/tests/integration/controllers/test_conversation_controller.py
@@ -285,12 +285,22 @@ class TestConversationController(unittest.TestCase):
                     send_secure_message(self.sm_form)
 
     def test_secure_message(self):
-        options = secure_message_enrolment_options(self._respondent_enrolments()[0], self.sm_form)
+        options = secure_message_enrolment_options(self._respondent_enrolments(), self.sm_form)
         self.assertEqual(options, self._expected_options())
+
+    def test_secure_message_no_enrolments(self):
+        # Given a respondent has no enrolments
+        # When secure_message_enrolment_options is called
+        options = secure_message_enrolment_options([], self.sm_form)
+        expected_options = self._expected_options()
+        expected_options["survey"].pop(1)
+
+        # Then survey should only be populated with non-survey related options (Choose a survey and Not survey related)
+        self.assertEqual(options, expected_options)
 
     def test_secure_message_subject_not_selected(self):
         self.sm_form.subject.data = ""
-        options = secure_message_enrolment_options(self._respondent_enrolments()[0], self.sm_form)
+        options = secure_message_enrolment_options(self._respondent_enrolments(), self.sm_form)
 
         expected_options = self._expected_options()
         expected_options["subject"][0]["selected"] = True


### PR DESCRIPTION
# What and why?
This PR make sure you can still send a secure message without an enrolment
# How to test?
I find it easiest to run the acceptance tests, then go to the db (party) and remove the enrolment for the respondent. Once the respondent has no enrolments, make sure you can send a secure message
# Jira
