### PR TITLE
Update deprecated ingress class annotation

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.5.52
+version: 2.5.53
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.52
+appVersion: 2.5.53

--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.5.51
+version: 2.5.52
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.51
+appVersion: 2.5.52

--- a/_infra/helm/frontstage/templates/ingress.yaml
+++ b/_infra/helm/frontstage/templates/ingress.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ .Chart.Name }}-ingress
   annotations:
     kubernetes.io/ingress.global-static-ip-name: frontstage-ip
+    kubernetes.io/ingress.class: gce
     networking.gke.io/managed-certificates: {{ .Values.ingress.certNameSurveys }}
     networking.gke.io/v1beta1.FrontendConfig: {{ .Values.ingress.frontendConfigName }}
 

--- a/_infra/helm/frontstage/templates/ingress.yaml
+++ b/_infra/helm/frontstage/templates/ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     networking.gke.io/v1beta1.FrontendConfig: {{ .Values.ingress.frontendConfigName }}
 
 spec:
+  ingressClassName: gce
   rules:
   - host: {{ .Values.ingress.host | quote }}
     http:


### PR DESCRIPTION
# What and why?
`kubernetes.io/ingress.class: gce` is deprecated as of kubernetes 1.18 in favor of 
```
spec:
  ingressClassName: gce
```
This PR introduces the new ingress class annotation to resolve the deprecation warning however the old annotation is persisted due to compatibility with GKE https://cloud.google.com/kubernetes-engine/docs/concepts/ingress#deprecated_annotation

# How to test?
- Deploy your dev environment
- Uninstall/delete your deployment of frontstage through helm. (you will also need to delete the external secrets, backend config).
- helm install frontstage on latest with ingress.enabled="true", you should see a deprecation warning:
`annotation "kubernetes.io/ingress.class" is deprecated, please use 'spec.ingressClassName' instead`
- Pull this PR, delete and reinstall frontstage with ingress enabled through helm
- You should no longer see the deprecation warning.
- To fully test the ingress still works use fly to set this pipeline after updating it to your namespace and updating the frontstage image to this PR. https://github.com/ONSdigital/ras-rm-concourse/blob/main/infrastructure/dev-share-with-loadbalancers.yml
- Run the Pipeline and check everything deploys correctly and you are able to access frontstage through https://frontstage-dev.rmrasbs.gcp.onsdigital.uk/
- make sure to run the undeploy steps so non of the network groups are left hanging.  

Need to decide if this is the right approach given the incompatibility with GKE.
# Jira
[RAS-1377](https://jira.ons.gov.uk/browse/RAS-1377)