### PR TITLE
RAS-1654: CIR - RASRM and EQ launching

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.5.63
+version: 2.5.64
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.63
+appVersion: 2.5.64

--- a/frontstage/common/eq_payload.py
+++ b/frontstage/common/eq_payload.py
@@ -7,6 +7,7 @@ import iso8601
 from flask import current_app
 from structlog import wrap_logger
 
+from frontstage.common.redis_cache import RedisCache
 from frontstage.controllers import (
     collection_exercise_controller,
     collection_instrument_controller,
@@ -44,13 +45,15 @@ class EqPayload(object):
             raise InvalidEqPayLoad(f"Collection instrument {ci_id} classifiers are incorrect or missing")
 
         form_type = classifiers["form_type"]
-
-        registry_instrument = collection_instrument_controller.get_registry_instrument(
-            exercise_id=ce_id, form_type=form_type
-        )
-
         eq_id = ci["classifiers"]["eq_id"]
-        cir_instrument_id = registry_instrument["guid"] if registry_instrument["guid"] else None
+
+        redis_cache = RedisCache()
+        registry_instrument = redis_cache.get_registry_instrument(exercise_id=ce_id, form_type=form_type)
+
+        if registry_instrument:
+            cir_instrument_id = registry_instrument["guid"]
+        else:
+            cir_instrument_id = None
         party = party_controller.get_party_by_business_id(
             business_party_id,
             current_app.config["PARTY_URL"],

--- a/frontstage/common/redis_cache.py
+++ b/frontstage/common/redis_cache.py
@@ -41,7 +41,7 @@ class RedisCache:
 
         return json.loads(result.decode("utf-8"))
 
-    def get_registry_instrument(self, collection_exercise_id, form_type):
+    def get_registry_instrument(self, exercise_id, form_type):
         """
         Gets the registry-instrument from redis or the collection-instrument service
 
@@ -49,7 +49,7 @@ class RedisCache:
         :param form_type: Key in redis
         :return: Result from either the cache or collection instrument service
         """
-        redis_key = f"frontstage:registry-instrument:{collection_exercise_id}:{form_type})"
+        redis_key = f"frontstage:registry-instrument:{exercise_id}:{form_type})"
         try:
             result = redis.get(redis_key)
         except RedisError:
@@ -58,7 +58,7 @@ class RedisCache:
 
         if not result:
             logger.info("Key not in cache, getting value from collection instrument service", key=redis_key)
-            result = get_registry_instrument(collection_exercise_id, form_type)
+            result = get_registry_instrument(exercise_id, form_type)
             self.save(redis_key, result, self.COLLECTION_INSTRUMENT_CATEGORY_EXPIRY)
             return result
 

--- a/frontstage/common/redis_cache.py
+++ b/frontstage/common/redis_cache.py
@@ -40,7 +40,7 @@ class RedisCache:
 
         return json.loads(result.decode("utf-8"))
 
-    def get_registry_instrument(self, exercise_id, form_type) -> dict:
+    def get_registry_instrument(self, collection_exercise_id: str, form_type: str) -> dict:
         """
         Gets the registry-instrument from redis or the collection-instrument service
 
@@ -48,11 +48,11 @@ class RedisCache:
         :param form_type: Key in redis
         :return: Result from either the cache or collection instrument service
         """
-        redis_key = f"frontstage:registry-instrument:{exercise_id}:{form_type})"
+        redis_key = f"frontstage:registry-instrument:{collection_exercise_id}:{form_type})"
         result = redis.get(redis_key)
         if not result:
             logger.info("Key not in cache, getting value from collection instrument service", key=redis_key)
-            result = get_registry_instrument(exercise_id, form_type)
+            result = get_registry_instrument(collection_exercise_id, form_type)
             self.save(redis_key, result, self.COLLECTION_REGISTRY_EXPIRY_IN_SECONDS)
             return result
 

--- a/frontstage/controllers/collection_instrument_controller.py
+++ b/frontstage/controllers/collection_instrument_controller.py
@@ -84,7 +84,7 @@ def get_collection_instrument(collection_instrument_id, collection_instrument_ur
 
 
 @lru_cache
-def get_registry_instrument(exercise_id, form_type) -> dict or None:
+def get_registry_instrument(exercise_id: str, form_type: str) -> dict | None:
     url = (
         f"{app.config["COLLECTION_INSTRUMENT_URL"]}/collection-instrument-api/1.0.2/registry-instrument/exercise-id/"
         f"{exercise_id}/formtype/{form_type}"

--- a/frontstage/controllers/collection_instrument_controller.py
+++ b/frontstage/controllers/collection_instrument_controller.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from functools import lru_cache
 
 import requests
 from flask import current_app as app
@@ -79,6 +80,37 @@ def get_collection_instrument(collection_instrument_id, collection_instrument_ur
         raise ApiError(logger, response)
 
     logger.info("Successfully retrieved collection instrument", collection_instrument_id=collection_instrument_id)
+    return response.json()
+
+
+@lru_cache
+def get_registry_instrument(exercise_id, form_type):
+    logger.info(
+        "Attempting to retrieve registry instrument by exercise_id and form_type",
+        collection_exercise_id=exercise_id,
+        form_type=form_type,
+    )
+
+    url = (
+        f"{app.config["COLLECTION_INSTRUMENT_URL"]}/collection-instrument-api/1.0.2/registry-instrument/exercise-id/"
+        f"{exercise_id}/formtype/{form_type}"
+    )
+    response = requests.get(url, auth=app.config["BASIC_AUTH"])
+
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError:
+        logger.error(
+            "Failed to retrieve registry instrument by exercise_id and form_type",
+            collection_exercise_id=exercise_id,
+            form_type=form_type,
+        )
+
+    logger.info(
+        "Successfully retrieved registry instrument by exercise_id and form_type",
+        collection_exercise_id=exercise_id,
+        form_type=form_type,
+    )
     return response.json()
 
 

--- a/frontstage/controllers/collection_instrument_controller.py
+++ b/frontstage/controllers/collection_instrument_controller.py
@@ -84,13 +84,7 @@ def get_collection_instrument(collection_instrument_id, collection_instrument_ur
 
 
 @lru_cache
-def get_registry_instrument(exercise_id, form_type):
-    logger.info(
-        "Attempting to retrieve registry instrument by exercise_id and form_type",
-        collection_exercise_id=exercise_id,
-        form_type=form_type,
-    )
-
+def get_registry_instrument(exercise_id, form_type) -> dict or None:
     url = (
         f"{app.config["COLLECTION_INSTRUMENT_URL"]}/collection-instrument-api/1.0.2/registry-instrument/exercise-id/"
         f"{exercise_id}/formtype/{form_type}"

--- a/frontstage/controllers/collection_instrument_controller.py
+++ b/frontstage/controllers/collection_instrument_controller.py
@@ -101,10 +101,11 @@ def get_registry_instrument(exercise_id, form_type):
         response.raise_for_status()
     except requests.exceptions.HTTPError:
         logger.error(
-            "Failed to retrieve registry instrument by exercise_id and form_type",
+            "No registry instrument found for exercise_id and form_type",
             collection_exercise_id=exercise_id,
             form_type=form_type,
         )
+        return None
 
     logger.info(
         "Successfully retrieved registry instrument by exercise_id and form_type",

--- a/tests/integration/mocked_services.py
+++ b/tests/integration/mocked_services.py
@@ -94,6 +94,9 @@ with open("tests/test_data/survey/survey_list_history.json") as fp:
 with open("tests/test_data/party/respondent_enrolments.json") as fp:
     respondent_enrolments = json.load(fp)
 
+with open("tests/test_data/registry_instrument/registry_instrument.json") as fp:
+    registry_instrument = json.load(fp)
+
 encoded_jwt_token = (
     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXJ0eV9pZCI6ImY5NTZlOGFlLTZ"
     "lMGYtNDQxNC1iMGNmLWEwN2MxYWEzZTM3YiIsImV4cGlyZXNfYXQiOiIxMDAxMjM0NTY"
@@ -157,3 +160,8 @@ url_notify_party_and_respondent_account_locked = (
 )
 url_banner_api = f"{app.config['BANNER_SERVICE_URL']}/banner"
 url_auth_delete = f'{app.config["AUTH_URL"]}/api/account/user'
+url_registry_instrument = (
+    f"{app.config['COLLECTION_INSTRUMENT_URL']}/collection-instrument-api/1.0.2/registry"
+    f"-instrument/exercise-id/{registry_instrument['exercise_id']}"
+    f"/formtype/{registry_instrument['classifier_value']}"
+)

--- a/tests/integration/test_generate_eq.py
+++ b/tests/integration/test_generate_eq.py
@@ -92,12 +92,14 @@ class TestGenerateEqURL(unittest.TestCase):
 
     @freeze_time(TIME_TO_FREEZE)
     @requests_mock.mock()
-    def test_create_payload_without_employment_date(self, mock_request):
+    @patch("frontstage.controllers.party_controller.RedisCache.get_registry_instrument")
+    def test_create_payload_without_employment_date(self, mock_request, mock_cache):
         # Given a collection exercise without an employment date event
         mock_request.get(url_get_collection_exercise_events, json=collection_exercise_events)
         mock_request.get(url_get_business_party, json=business_party)
         mock_request.get(url_get_ci, json=collection_instrument_eq)
-        mock_request.get(url_registry_instrument, json=registry_instrument)
+        mock_request.get(url_registry_instrument, json=None)
+        mock_cache.return_value = None
 
         # When a payload is created
         with app.app_context():
@@ -114,7 +116,8 @@ class TestGenerateEqURL(unittest.TestCase):
 
     @freeze_time(TIME_TO_FREEZE)
     @requests_mock.mock()
-    def test_create_payload_with_employment_date(self, mock_request):
+    @patch("frontstage.controllers.party_controller.RedisCache.get_registry_instrument")
+    def test_create_payload_with_employment_date(self, mock_request, mock_cache):
         # Given a collection exercise with an employment date event
         collection_exercise_event_employment_date = {
             "id": "5629d715-ec3e-4ca2-9232-be5c1d56cf32",
@@ -128,6 +131,7 @@ class TestGenerateEqURL(unittest.TestCase):
         mock_request.get(url_get_business_party, json=business_party)
         mock_request.get(url_get_ci, json=collection_instrument_eq)
         mock_request.get(url_registry_instrument, json=registry_instrument)
+        mock_cache.return_value = None
 
         # When a payload is created
         with app.app_context():
@@ -143,7 +147,8 @@ class TestGenerateEqURL(unittest.TestCase):
         self.assertTrue(_is_valid_uuid(payload_created["tx_id"]))
 
     @requests_mock.mock()
-    def test_generate_eq_url_seft(self, mock_request):
+    @patch("frontstage.controllers.party_controller.RedisCache.get_registry_instrument")
+    def test_generate_eq_url_seft(self, mock_request, mock_cache):
         # Given all external services are mocked and we have seft collection instrument
         mock_request.get(url_get_collection_exercise, json=collection_exercise)
         mock_request.get(url_get_collection_exercise_events, json=collection_exercise_events)
@@ -151,6 +156,7 @@ class TestGenerateEqURL(unittest.TestCase):
         mock_request.get(url_get_survey, json=survey)
         mock_request.get(url_get_ci, json=collection_instrument_seft)
         mock_request.get(url_banner_api, status_code=404)
+        mock_cache.return_value = None
 
         # When create_payload is called
         # Then an InvalidEqPayLoad is raised
@@ -168,7 +174,8 @@ class TestGenerateEqURL(unittest.TestCase):
         )
 
     @requests_mock.mock()
-    def test_generate_eq_url_no_eq_id(self, mock_request):
+    @patch("frontstage.controllers.party_controller.RedisCache.get_registry_instrument")
+    def test_generate_eq_url_no_eq_id(self, mock_request, mock_cache):
         # Given all external services are mocked and we have an EQ collection instrument without an EQ ID
         with open("tests/test_data/collection_instrument/collection_instrument_eq_no_eq_id.json") as json_data:
             collection_instrument_eq_no_eq_id = json.load(json_data)
@@ -176,6 +183,7 @@ class TestGenerateEqURL(unittest.TestCase):
         mock_request.get(url_get_ci, json=collection_instrument_eq_no_eq_id)
         mock_request.get(url_banner_api, status_code=404)
         mock_request.get(url_registry_instrument, json=registry_instrument)
+        mock_cache.return_value = None
 
         # When create_payload is called
         # Then an InvalidEqPayLoad is raised
@@ -194,7 +202,8 @@ class TestGenerateEqURL(unittest.TestCase):
         )
 
     @requests_mock.mock()
-    def test_generate_eq_url_contains_response_id(self, mock_request):
+    @patch("frontstage.controllers.party_controller.RedisCache.get_registry_instrument")
+    def test_generate_eq_url_contains_response_id(self, mock_request, mock_cache):
         # Given all external services are mocked and we have an EQ collection instrument without an EQ ID
         mock_request.get(url_get_collection_exercise_events, json=collection_exercise_events)
         mock_request.get(url_get_business_party, json=business_party)
@@ -204,6 +213,7 @@ class TestGenerateEqURL(unittest.TestCase):
         mock_request.get(url_get_ci, json=collection_instrument_eq)
         mock_request.get(url_banner_api, status_code=404)
         mock_request.get(url_registry_instrument, json=registry_instrument)
+        mock_cache.return_value = None
 
         # When create_payload is called
         # Then an InvalidEqPayLoad is raised
@@ -219,7 +229,8 @@ class TestGenerateEqURL(unittest.TestCase):
         self.assertEqual("49900000001F8d990a74-5f07-4765-ac66-df7e1a96505b20001", payload["response_id"])
 
     @requests_mock.mock()
-    def test_generate_eq_url_no_form_type(self, mock_request):
+    @patch("frontstage.controllers.party_controller.RedisCache.get_registry_instrument")
+    def test_generate_eq_url_no_form_type(self, mock_request, mock_cache):
         # Given all external services are mocked and we have an EQ collection instrument without a Form_type
         with open("tests/test_data/collection_instrument/collection_instrument_eq_no_form_type.json") as json_data:
             collection_instrument_eq_no_form_type = json.load(json_data)
@@ -227,6 +238,7 @@ class TestGenerateEqURL(unittest.TestCase):
         mock_request.get(url_get_ci, json=collection_instrument_eq_no_form_type)
         mock_request.get(url_banner_api, status_code=404)
         mock_request.get(url_registry_instrument, json=None)
+        mock_cache.return_value = None
 
         # When create_payload is called
         # Then an InvalidEqPayLoad is raised
@@ -245,10 +257,12 @@ class TestGenerateEqURL(unittest.TestCase):
         )
 
     @requests_mock.mock()
-    def test_access_collection_exercise_events_fail(self, mock_request):
+    @patch("frontstage.controllers.party_controller.RedisCache.get_registry_instrument")
+    def test_access_collection_exercise_events_fail(self, mock_request, mock_cache):
         # Given a failing collection exercise events service
         mock_request.get(url_get_collection_exercise_events, status_code=500)
         mock_request.get(url_banner_api, status_code=404)
+        mock_cache.return_value = None
 
         # When get collection exercise events is called
         # Then an ApiError is raised
@@ -352,13 +366,14 @@ class TestGenerateEqURL(unittest.TestCase):
 
     @freeze_time(TIME_TO_FREEZE)
     @requests_mock.mock()
-    def test_create_payload_with_supplementary_data(self, mock_request):
+    @patch("frontstage.controllers.party_controller.RedisCache.get_registry_instrument")
+    def test_create_payload_with_supplementary_data(self, mock_request, mock_cache):
         # Given a collection exercise contains supplementary data
-        collection_exercise_with_supplementary_dataset
         mock_request.get(url_get_collection_exercise_events, json=collection_exercise_events)
         mock_request.get(url_get_business_party, json=business_party)
         mock_request.get(url_get_ci, json=collection_instrument_eq)
         mock_request.get(url_registry_instrument, json=registry_instrument)
+        mock_cache.return_value = None
         # When a payload is created
         with app.app_context():
             payload_created = EqPayload().create_payload(
@@ -377,7 +392,8 @@ class TestGenerateEqURL(unittest.TestCase):
 
     @freeze_time(TIME_TO_FREEZE)
     @requests_mock.mock()
-    def test_create_payload_with_supplementary_data_but_different_form_type(self, mock_request):
+    @patch("frontstage.controllers.party_controller.RedisCache.get_registry_instrument")
+    def test_create_payload_with_supplementary_data_but_different_form_type(self, mock_request, mock_cache):
         # Given a collection exercise contains supplementary data
         different_form_type = {
             "supplementaryDatasetJson": '{"survey_id":"001","period_id":"220823",'
@@ -407,13 +423,14 @@ class TestGenerateEqURL(unittest.TestCase):
         self.assertNotIn("b9a87999-fcc0-4085-979f-06390fb5dddd", payload_created["survey_metadata"]["data"])
 
     @requests_mock.mock()
-    def test_collection_with_registry_instrument(self, mock_request):
+    @patch("frontstage.controllers.party_controller.RedisCache.get_registry_instrument")
+    def test_collection_with_registry_instrument(self, mock_request, mock_cache):
         # Given a collection exercise is without a registry instrument
         mock_request.get(url_get_collection_exercise_events, json=collection_exercise_events)
         mock_request.get(url_get_business_party, json=business_party)
         mock_request.get(url_get_ci, json=collection_instrument_eq)
         mock_request.get(url_registry_instrument, json=registry_instrument)
-
+        mock_cache.return_value = registry_instrument
         # When a payload is created
         with app.app_context():
             response_mock = MagicMock()
@@ -422,23 +439,21 @@ class TestGenerateEqURL(unittest.TestCase):
                 "frontstage.controllers.collection_instrument_controller.get_registry_instrument",
                 Mock(side_effect=ApiError(logger_mock, response_mock)),
             ):
-                with self.assertRaises(ApiError):
-                    payload_created = EqPayload().create_payload(
-                        case, collection_exercise, respondent_party["id"], business_party["id"], survey_eq
-                    )
-
-                    # Then the payload is as expected and doesn't have a registry version
-                    self.assertTrue(PAYLOAD.items() <= payload_created.items())
-                    self.assertIn("8d990a74-5f07-4765-ac66-df7e1a96505b", payload_created)
-                    self.assertIn("cir_instrument_id", payload_created)
+                payload_created = EqPayload().create_payload(
+                    case, collection_exercise, respondent_party["id"], business_party["id"], survey_eq
+                )
+                # Then the payload is as expected and doesn't have a registry version
+                self.assertIn("8d990a74-5f07-4765-ac66-df7e1a96505b", payload_created["collection_exercise_sid"])
+                self.assertIn("e9b3ddcd-bfdc-4c20-aa1b-397b10b4f9d8", payload_created["cir_instrument_id"])
 
     @requests_mock.mock()
-    def test_collection_without_registry_instrument(self, mock_request):
+    @patch("frontstage.controllers.party_controller.RedisCache.get_registry_instrument")
+    def test_collection_without_registry_instrument(self, mock_request, mock_cache):
         # Given a collection exercise is without a registry instrument
         mock_request.get(url_get_collection_exercise_events, json=collection_exercise_events)
         mock_request.get(url_get_business_party, json=business_party)
         mock_request.get(url_get_ci, json=collection_instrument_eq)
-
+        mock_cache.return_value = None
         # When a payload is created
         with app.app_context():
             response_mock = MagicMock()
@@ -447,15 +462,13 @@ class TestGenerateEqURL(unittest.TestCase):
                 "frontstage.controllers.collection_instrument_controller.get_registry_instrument",
                 Mock(side_effect=ApiError(logger_mock, response_mock)),
             ):
-                with self.assertRaises(ApiError):
-                    payload_created = EqPayload().create_payload(
-                        case, collection_exercise, respondent_party["id"], business_party["id"], survey_eq
-                    )
+                payload_created = EqPayload().create_payload(
+                    case, collection_exercise, respondent_party["id"], business_party["id"], survey_eq
+                )
 
-                    # Then the payload is as expected and doesn't have a registry version
-                    self.assertTrue(PAYLOAD.items() <= payload_created.items())
-                    self.assertIn("8d990a74-5f07-4765-ac66-df7e1a96505b", payload_created)
-                    self.assertNotIn("cir_instrument_id", payload_created)
+                # Then the payload is as expected and doesn't have a registry version
+                self.assertIn("8d990a74-5f07-4765-ac66-df7e1a96505b", payload_created["collection_exercise_sid"])
+                self.assertNotIn("e9b3ddcd-bfdc-4c20-aa1b-397b10b4f9d8", payload_created)
 
 
 def _is_valid_uuid(uuid_string: str) -> bool:

--- a/tests/integration/test_generate_eq.py
+++ b/tests/integration/test_generate_eq.py
@@ -2,7 +2,6 @@ import json
 import unittest
 import uuid
 from datetime import datetime, timezone
-from http import HTTPStatus
 from unittest.mock import MagicMock, Mock, patch
 
 import requests_mock

--- a/tests/integration/views/surveys/test_access_survey.py
+++ b/tests/integration/views/surveys/test_access_survey.py
@@ -194,7 +194,7 @@ class TestAccessSurvey(unittest.TestCase):
 
     @patch("frontstage.controllers.party_controller.is_respondent_enrolled")
     @patch("frontstage.controllers.party_controller.RedisCache.get_registry_instrument")
-    def test_generate_eq_url(self, mock_request, _, mock_cache):
+    def test_generate_eq_url(self, mock_request, mock_cache, _):
         # Given all external services are mocked, and we have an EQ collection instrument
         mock_request.get(url_get_case, json=case)
         mock_request.get(url_get_collection_exercise, json=collection_exercise_v3)
@@ -206,6 +206,7 @@ class TestAccessSurvey(unittest.TestCase):
         mock_request.post(url_post_case_event_uuid, status_code=201)
         mock_request.get(url_get_respondent_party, status_code=200, json=respondent_party)
         mock_request.get(url_banner_api, status_code=404)
+        mock_cache.return_value = None
 
         # When the generate-eq-url is called
         response = self.app.get(

--- a/tests/integration/views/surveys/test_access_survey.py
+++ b/tests/integration/views/surveys/test_access_survey.py
@@ -193,7 +193,8 @@ class TestAccessSurvey(unittest.TestCase):
         self.assertTrue("An error has occurred".encode() in response.data)
 
     @patch("frontstage.controllers.party_controller.is_respondent_enrolled")
-    def test_generate_eq_url(self, mock_request, _):
+    @patch("frontstage.controllers.party_controller.RedisCache.get_registry_instrument")
+    def test_generate_eq_url(self, mock_request, _, mock_cache):
         # Given all external services are mocked, and we have an EQ collection instrument
         mock_request.get(url_get_case, json=case)
         mock_request.get(url_get_collection_exercise, json=collection_exercise_v3)

--- a/tests/test_data/registry_instrument/registry_instrument.json
+++ b/tests/test_data/registry_instrument/registry_instrument.json
@@ -1,0 +1,10 @@
+{
+  "instrument_id": "68ad4018-2ddd-4894-89e7-33f0135887a2",
+  "survey_id": "2e517b4f-2854-4afa-ba8a-e3443034cc98",
+  "exercise_id": "8d990a74-5f07-4765-ac66-df7e1a96505b",
+  "classifier_type": "form_type",
+  "classifier_value": "0001",
+  "ci_version": 1,
+  "guid": "e9b3ddcd-bfdc-4c20-aa1b-397b10b4f9d8",
+  "published_at": "2025-12-29T00:00:00.000000Z"
+}

--- a/tests/unit/test_redis_cache.py
+++ b/tests/unit/test_redis_cache.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 from unittest.mock import patch
 
@@ -7,6 +8,7 @@ from frontstage import app
 from frontstage.common.redis_cache import RedisCache
 
 test_uuid = "5d640989-e20d-4367-b341-f067e5343097"
+test_form_type = "0001"
 
 
 class TestRedisCache(unittest.TestCase):
@@ -37,3 +39,31 @@ class TestRedisCache(unittest.TestCase):
                 cache = RedisCache()
                 result = cache.get_collection_instrument(test_uuid)
                 self.assertEqual(result, {"type": "SEFT"})
+
+    @patch("redis.StrictRedis.get")
+    def test_registry_instrument_in_cache(self, redis_get):
+        redis_return_value = {test_uuid: test_form_type}
+        redis_get.return_value = bytes(json.dumps(redis_return_value), "utf-8")
+        with app.app_context():
+            cache = RedisCache()
+            result = cache.get_registry_instrument(test_uuid, test_form_type)
+            self.assertEqual(result, redis_return_value)
+
+    @patch("redis.StrictRedis.get")
+    def test_registry_instrument_not_in_cache(self, redis_get):
+        redis_get.return_value = None
+        registry_response = json.dumps({"collection_exercise_id": test_uuid, "form_type": test_form_type})
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                rsps.GET,
+                f"{app.config["COLLECTION_INSTRUMENT_URL"]}"
+                f"/collection-instrument-api/1.0.2/registry-instrument/exercise-id/"
+                f"{test_uuid}/formtype/{test_form_type}",
+                json=registry_response,
+                status=200,
+                content_type="application/json",
+            )
+            with app.app_context():
+                cache = RedisCache()
+                result = cache.get_registry_instrument(test_uuid, test_form_type)
+                self.assertEqual(result, registry_response)

--- a/tests/unit/test_redis_cache.py
+++ b/tests/unit/test_redis_cache.py
@@ -26,7 +26,7 @@ class TestRedisCache(unittest.TestCase):
 
     @patch("redis.StrictRedis.get")
     @patch("frontstage.common.redis_cache.RedisCache.save")
-    def test__collection_instrument_not_in_cache(self, redis_save, redis_get):
+    def test_collection_instrument_not_in_cache(self, redis_save, redis_get):
         redis_get.return_value = None
         ci_response = {"type": "SEFT"}
         with responses.RequestsMock() as rsps:
@@ -54,7 +54,7 @@ class TestRedisCache(unittest.TestCase):
 
     @patch("redis.StrictRedis.get")
     @patch("frontstage.common.redis_cache.RedisCache.save")
-    def test_registry_instrument_not_in_cache_test(self, redis_save, redis_get):
+    def test_registry_instrument_not_in_cache(self, redis_save, redis_get):
         redis_get.return_value = None
         registry_response = json.dumps({"collection_exercise_id": test_uuid, "form_type": test_form_type})
         with responses.RequestsMock() as rsps:

--- a/tests/unit/test_redis_cache.py
+++ b/tests/unit/test_redis_cache.py
@@ -1,6 +1,6 @@
 import json
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import responses
 


### PR DESCRIPTION
# What and why?
As part of the ongoing CIR work and integration, Frontstage needs to send the CIR GUID (when present) to EQ. This achieves this.

# How to test?
Run unit and acceptance tests

1. Complete a CE and add a CI with a matching version (you will have to check the DB for one)
2. Set CE as live
3. In Frontstage, register a user to the CE
4. Complete the survey
5. Repeat the above except add a CI that doesn't have a version
6. Both times, mock EQ will be launched

# Jira
https://officefornationalstatistics.atlassian.net/browse/RAS-1654