### PR TITLE
Fix for SEFT upload

### DIFF
--- a/_infra/docker/Dockerfile
+++ b/_infra/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile specifically for kubernetes
-FROM python:3.12-slim
+FROM python:3.12.10-slim
 
 RUN apt update && apt install -y build-essential curl gunicorn
 RUN pip install pipenv

--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.5.64
+version: 2.5.65
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.64
+appVersion: 2.5.65


### PR DESCRIPTION
# What and why?
Latest version of python:3.12-slim has caused GPG to fail. Pegging the imaged to python:3.12.10-slim has solved the issue.