### PR TITLE
Update banner Help link to point as help-info-ons page

### DIFF
--- a/frontstage/views/help.py
+++ b/frontstage/views/help.py
@@ -18,7 +18,7 @@ form_render_page_mapper = {
 }
 
 
-@help_bp.route("/info-ons", methods=["GET", "POST"])
+@help_bp.route("/", methods=["GET", "POST"])
 def info_ons_page():
     page_title = "Help info ONS"
     form = HelpInfoOnsForm(request.values)


### PR DESCRIPTION
# What and why?

This survey respondent help journey PR removed handing of /help for unauthenticated users. It suggests it should link directly to the help-info-ons page but a handler route doesn't exist for that. This updates that handler.

https://github.com/ONSdigital/ras-frontstage/pull/1051

# How to test?

Check the "Help" link at the top goes to the page and not a 404

# Jira
