### PR TITLE
Ensure EQ payload contains one-of cir_instrument_id or schema_name

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.5.68
+version: 2.5.69
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.68
+appVersion: 2.5.69

--- a/frontstage/common/eq_payload.py
+++ b/frontstage/common/eq_payload.py
@@ -72,7 +72,6 @@ class EqPayload(object):
             "collection_exercise_sid": ce_id,
             "response_id": f"{ru_ref}{ce_id}{eq_id}{form_type}",
             "response_expires_at": self._find_event_date_by_tag("exercise_end", ce_events, ce_id),
-            "schema_name": f"{eq_id}_{form_type}",
             "survey_metadata": {
                 "data": {
                     "case_ref": case["caseRef"],
@@ -92,6 +91,8 @@ class EqPayload(object):
 
         if registry_instrument:
             payload["cir_instrument_id"] = registry_instrument["guid"]
+        else:
+            payload["schema_name"] = f"{eq_id}_{form_type}"
 
         if employment_date := self._find_event_date_by_tag("employment", ce_events, ce_id, False):
             payload["survey_metadata"]["data"]["employment_date"] = employment_date

--- a/tests/integration/test_generate_eq.py
+++ b/tests/integration/test_generate_eq.py
@@ -435,10 +435,12 @@ class TestGenerateEqURL(unittest.TestCase):
             payload_created = EqPayload().create_payload(
                 case, collection_exercise, respondent_party["id"], business_party["id"], survey_eq
             )
-            # Then the payload is as expected and has a registry version
+            # Then the payload is as expected and has a cir_instrument_id
             self.assertIn("8d990a74-5f07-4765-ac66-df7e1a96505b", payload_created["collection_exercise_sid"])
             self.assertIn("cir_instrument_id", payload_created.keys())
             self.assertIn("e9b3ddcd-bfdc-4c20-aa1b-397b10b4f9d8", payload_created["cir_instrument_id"])
+            # and the payload doesn't have a schema_name
+            self.assertNotIn("schema_name", payload_created.keys())
 
     @requests_mock.mock()
     @patch.object(RedisCache, "get_registry_instrument", return_value=None)
@@ -453,8 +455,10 @@ class TestGenerateEqURL(unittest.TestCase):
                 case, collection_exercise, respondent_party["id"], business_party["id"], survey_eq
             )
 
-            # Then the payload is as expected and doesn't have a registry version
+            # Then the payload is as expected and has a schema_name
+            self.assertIn("schema_name", payload_created.keys())
             self.assertIn("8d990a74-5f07-4765-ac66-df7e1a96505b", payload_created["collection_exercise_sid"])
+            # and the payload doesn't have a cir_instrument_id
             self.assertNotIn("cir_instrument_id", payload_created.keys())
 
 


### PR DESCRIPTION
# What and why?

To align with the existing platform [schema documentation for EQ launch](https://github.com/ONSdigital/ons-schema-definitions/blob/main/schemas/launch_v2.json#L74-L83), this PR ensures the payload contains one-of `schema_name` or `cir_instrument_id`

# How to test?

- run the tests
- create a QBS CE with CIR version selected through to go live
- launch an EQ and ensure `schema_name` is NOT present and `cir_instrument_id` is present in the Mock EQ launch claims
- manually delete the registry_instrument from the rasci schema
- clear your redis cache (FLUSHALL in the cli can be used)
- re-launch the EQ and ensure `schema_name` is present and `cir_instrument_id` is NOT present in the Mock EQ launch claims

# Jira

https://officefornationalstatistics.atlassian.net/browse/RAS-1654
