### PR TITLE
RAS-1308: Something went wrong message on password reset 

### DIFF
--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.5.85
+version: 2.5.86
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.85
+appVersion: 2.5.86

--- a/frontstage/views/passwords/reset_password.py
+++ b/frontstage/views/passwords/reset_password.py
@@ -111,10 +111,10 @@ def resend_password_email_expired_token(token):
 
 def request_password_change(email):
     respondent = party_controller.get_respondent_by_email(email)
-
+    token = verification.generate_email_token(email)
     if not respondent:
         logger.info("Respondent does not exist")
-        return redirect(url_for("passwords_bp.reset_password_trouble"))
+        return redirect(url_for("passwords_bp.reset_password_check_email", token=token))
 
     party_id = str(respondent["id"])
     password_reset_counter = party_controller.get_password_reset_counter(party_id)["counter"]
@@ -133,8 +133,6 @@ def request_password_change(email):
                 return redirect(url_for("passwords_bp.reset_password_trouble"))
 
     logger.info("Requesting password change", party_id=party_id)
-
-    token = verification.generate_email_token(email)
 
     url_root = request.url_root
     # url_for comes with a leading slash, so strip off the trailing slash in url_root if there is one

--- a/tests/integration/test_passwords.py
+++ b/tests/integration/test_passwords.py
@@ -147,7 +147,6 @@ class TestPasswords(unittest.TestCase):
         response = self.app.post("passwords/forgot-password", data=self.email_form, follow_redirects=True)
 
         self.assertEqual(response.status_code, 200)
-        # mock_notify.assert_called_once()
         self.assertTrue("Check your email".encode() in response.data)
 
     @requests_mock.mock()

--- a/tests/integration/test_passwords.py
+++ b/tests/integration/test_passwords.py
@@ -147,7 +147,8 @@ class TestPasswords(unittest.TestCase):
         response = self.app.post("passwords/forgot-password", data=self.email_form, follow_redirects=True)
 
         self.assertEqual(response.status_code, 200)
-        self.assertTrue("Something went wrong".encode() in response.data)
+        # mock_notify.assert_called_once()
+        self.assertTrue("Check your email".encode() in response.data)
 
     @requests_mock.mock()
     def test_forgot_password_post_api_call_fail(self, mock_request):


### PR DESCRIPTION
# What and why?
A bug was found whereby if a user puts in an password reset request for an unknown/unregistered email account, the user would be redirected and receive the message 'Something went wrong'. This needed to be changed. Based on the comments in the card, it was decided that the person entering the email shouldn't be made aware that the issue was being caused by this unknown email address (for security purposes). Therefore, the user is redirected back to the 'Check your email' page. Help is listed there to support the user if they have not received an email. It creates a better user experience this way without compromising security.  This PR accomplishes this.

# How to test?
- Deploy this PR to your env
- Load Frontstage and click the 'Need help signing in?' link under the password entry field
- Once redirected, put it an email address you know that is not registered and click the 'Send reset link' button
- You should be redirected to the Check your email page
- Run acceptance tests

# Jira
https://officefornationalstatistics.atlassian.net/browse/RAS-1308