### PR TITLE
RAS-1999 Errors in SDX on requests to SEFT bucket

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -30,7 +30,7 @@ werkzeug = "*"
 fakeredis = "*"
 email-validator = "*"
 pyjwt = "*"
-# Pinned to 3.10.0 due to newer versions of google-cloud-storage make get requests to GCS when posting completed
+# Pinned to 3.10.0 due to newer versions of google-cloud-storage making GET requests to GCS when posting completed
 # SEFT files to SDX bucket which we don't have permission to do
 google-cloud-storage = "==3.10.0"
 

--- a/Pipfile
+++ b/Pipfile
@@ -25,12 +25,14 @@ requestsdefaulter = "*"
 pycryptodome = "*"
 flask-talisman = "*"
 google-cloud-pubsub = "*"
-google-cloud-storage = "*"
 python-gnupg = "*"
 werkzeug = "*"
 fakeredis = "*"
 email-validator = "*"
 pyjwt = "*"
+# Pinned to 3.10.0 due to newer versions of google-cloud-storage make get requests to GCS when posting completed
+# SEFT files to SDX bucket which we don't have permission to do
+google-cloud-storage = "==3.10.0"
 
 [dev-packages]
 black = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7fbc0cce6e839dab6ab4026c08224c292c7d063c4f019a9ec69f723aebcca8a9"
+            "sha256": "3912c457272e0d86bba0ef55a5470c5094215286d1ae11e21fa2462320d9b0ce"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -473,12 +473,12 @@
         },
         "google-cloud-storage": {
             "hashes": [
-                "sha256:498bf37c999028f69a245f586b5e50d89f59df1fafc0e3a93783ac56be2a456b",
-                "sha256:cfcc33aa6b899ec9dd1771286f8e79fbed5c35c1c174718071b079aa827f37c2"
+                "sha256:03ae9847c6babb368f35f054126b8a08cbc0e3266efb990eb17b9926a45cf3be",
+                "sha256:3880773754ddf7c27567b04e2a4d193950b6b99429f37b9097d873686e95b09c"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.10'",
-            "version": "==3.11.0"
+            "version": "==3.12.0"
         },
         "google-crc32c": {
             "hashes": [

--- a/_infra/helm/frontstage/Chart.yaml
+++ b/_infra/helm/frontstage/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.5.99
+version: 2.5.100
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.99
+appVersion: 2.5.100


### PR DESCRIPTION
# What and why?
SDX has raised with us that our kubernetes service account started making get requests to their seft responses bucket on 15/06/2026. This is caused by the google cloud storage client version 3.11.0 and onwards. It is not clear why and the changelogs do not make it obvious what change caused this to happen

This PR pins the google cloud storage client version to 3.10.0
# How to test?
- set up a seft CE or run the seft acceptance tests
- log in to frontstage and submit a SEFT 
- Check the logs for our seft responses bucket in dev by filtering using
```
protoPayload.resourceName="projects/_/buckets/ras-rm-seft-responses-dev"
```
- Make sure that an error log appears for a GET
- Deploy this PR to your namespace
- Submit another seft
- Make sure that no log appears
# Jira
[RAS-1999](https://officefornationalstatistics.atlassian.net/browse/RAS-1999)

[RAS-1999]: https://officefornationalstatistics.atlassian.net/browse/RAS-1999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ